### PR TITLE
Fixes 52: Add EditContent Modal

### DIFF
--- a/src/components/AddContent/helpers.ts
+++ b/src/components/AddContent/helpers.ts
@@ -1,7 +1,18 @@
 import { isEmpty } from 'lodash';
+import * as Yup from 'yup';
 import { FormikErrors } from 'formik';
 import { ValidationResponse } from '../../services/Content/ContentApi';
 import ERROR_CODE from './httpErrorCodes.json';
+
+export interface FormikValues {
+  name: string;
+  url: string;
+  gpgKey: string;
+  arch: string;
+  versions: string[];
+  gpgLoading: boolean;
+  expanded: boolean;
+}
 
 export const REGEX_URL =
   /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
@@ -11,17 +22,7 @@ export const isValidURL = (val: string) => {
   return val.match(regex);
 };
 
-export const mapFormikToAPIValues = (
-  formikValues: {
-    name: string;
-    url: string;
-    gpgKey: string;
-    arch: string;
-    versions: string[];
-    gpgLoading: boolean;
-    expanded: boolean;
-  }[],
-) =>
+export const mapFormikToAPIValues = (formikValues: FormikValues[]) =>
   formikValues.map(({ name, url, arch, versions, gpgKey }) => ({
     name,
     url,
@@ -46,18 +47,7 @@ const mapNoMetaDataError = (validationData: ValidationResponse) =>
 
 export const mapValidationData = (
   validationData: ValidationResponse,
-  formikErrors: FormikErrors<
-    | {
-        name: string;
-        url: string;
-        gpgKey: string;
-        arch: string;
-        versions: never[];
-        gpgLoading: boolean;
-        expanded: boolean;
-      }
-    | undefined
-  >[],
+  formikErrors: FormikErrors<FormikValues | undefined>[],
 ) => {
   const updatedValidationData = mapNoMetaDataError(validationData);
   const errors = updatedValidationData.map(({ name, url }, index: number) => ({
@@ -74,3 +64,76 @@ export const mapValidationData = (
 
   return errors;
 };
+
+export const makeValidationSchema = () => {
+  // This adds the uniqueProperty function to the below schema validation
+  Yup.addMethod(Yup.object, 'uniqueProperty', function (propertyName, message) {
+    return this.test('unique', message, function (value) {
+      if (!value || !value[propertyName]) {
+        return true;
+      }
+      if (
+        this.parent.filter((v) => v !== value).some((v) => v[propertyName] === value[propertyName])
+      ) {
+        throw this.createError({
+          path: `${this.path}.${propertyName}`,
+        });
+      }
+
+      return true;
+    });
+  });
+
+  return Yup.array(
+    Yup.object()
+      .shape({
+        name: Yup.string().min(2, 'Too Short!').max(50, 'Too Long!').required('Required'),
+        url: Yup.string().url('Invalid URL').required('Required'),
+        gpgKey: Yup.string().optional(),
+      })
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore-next-line
+      .uniqueProperty('name', 'Names must be unique')
+      .uniqueProperty('url', 'Url\'s must be unique'),
+  );
+};
+
+export const magicURLList = [
+  'https://www.google.com',
+  'https://apple.com',
+  'https://youtube.com',
+  'https://microsoft.com',
+  'https://play.google.com',
+  'https://linkedin.com',
+  'https://www.blogger.com',
+  'https://cloudflare.com',
+  'https://en.wikipedia.org',
+  'https://mozilla.org',
+  'https://docs.google.com',
+  'https://youtu.be',
+  'https://maps.google.com',
+  'https://wordpress.org',
+  'https://accounts.google.com',
+  'https://europa.eu',
+  'https://drive.google.com',
+  'https://whatsapp.com',
+  'https://adobe.com',
+  'https://sites.google.com',
+  'https://plus.google.com',
+  'https://facebook.com',
+  'https://vk.com',
+  'https://github.com',
+  'https://istockphoto.com',
+  'https://amazon.com',
+  'https://uol.com.br',
+  'https://policies.google.com',
+  'https://vimeo.com',
+  'https://t.me',
+  'https://mail.ru',
+  'https://enable-javascript.com',
+  'https://medium.com',
+  'https://search.google.com',
+  'https://google.de',
+  'https://ok.ru',
+  'https://imdb.com',
+];

--- a/src/components/ContentListTable/ContentListFilters.tsx
+++ b/src/components/ContentListTable/ContentListFilters.tsx
@@ -134,6 +134,7 @@ const ContentListFilters = ({ isLoading, setFilterData, filterData }: Props) => 
             ouiaId='filter_search'
             placeholder='Filter by name/url'
             iconVariant='search'
+            value={searchQuery}
             onChange={(value) => setSearchQuery(value)}
           />
         );

--- a/src/components/EditContentModal/EditContentModal.test.tsx
+++ b/src/components/EditContentModal/EditContentModal.test.tsx
@@ -1,0 +1,83 @@
+import {
+  passingValidationErrorData,
+  ReactQueryTestWrapper,
+  testRepositoryParamsResponse,
+} from '../../testingHelpers';
+import EditContentModal from './EditContentModal';
+import { act, fireEvent, render } from '@testing-library/react';
+import { useEditContentQuery, useValidateContentList } from '../../services/Content/ContentQueries';
+import useDebounce from '../../services/useDebounce';
+import { useQueryClient } from 'react-query';
+
+const singleEditValues = [
+  {
+    uuid: 'a68feaa3-9746-4719-8e33-3ff4688fed85',
+    name: 'google',
+    url: 'https://www.google.com',
+    distribution_versions: ['7'],
+    package_count: 24,
+    distribution_arch: 'x86_64',
+    account_id: '6414238',
+    org_id: '13446804',
+  },
+];
+
+jest.mock('../../services/Content/ContentQueries', () => ({
+  useEditContentQuery: jest.fn(),
+  useValidateContentList: jest.fn(),
+}));
+
+jest.mock('react-query', () => ({
+  ...jest.requireActual('react-query'),
+  useQueryClient: jest.fn(),
+}));
+
+jest.mock('../../services/useDebounce', () => jest.fn());
+
+it('Open, confirming values, edit an item, enabling Save button', async () => {
+  (useEditContentQuery as jest.Mock).mockImplementation(() => ({ isLoading: false }));
+  (useValidateContentList as jest.Mock).mockImplementation(() => ({
+    isLoading: false,
+    mutateAsync: async () => passingValidationErrorData,
+  }));
+  (useDebounce as jest.Mock).mockImplementation((value) => value);
+  (useQueryClient as jest.Mock).mockImplementation(() => ({
+    getQueryData: () => testRepositoryParamsResponse,
+  }));
+
+  const { queryByText, queryByPlaceholderText, queryAllByLabelText } = render(
+    <ReactQueryTestWrapper>
+      <EditContentModal open values={singleEditValues} setClosed={() => undefined} />
+    </ReactQueryTestWrapper>,
+  );
+
+  expect(
+    queryByText('Edit by completing the form. Default values may be provided automatically.'),
+  ).toBeInTheDocument();
+  const NameTextfield = queryByPlaceholderText('Enter name');
+  expect(NameTextfield).toBeInTheDocument();
+  expect(NameTextfield).toHaveAttribute('value', singleEditValues[0].name);
+
+  const UrlTextfield = queryByPlaceholderText('https://');
+  expect(UrlTextfield).toBeInTheDocument();
+  expect(UrlTextfield).toHaveAttribute('value', singleEditValues[0].url);
+  expect(queryByText(singleEditValues[0].distribution_arch)).toBeInTheDocument();
+  expect(queryByText('el7')).toBeInTheDocument();
+  expect(queryByText('No changes')).toBeInTheDocument();
+  const optionsMenuButton = queryAllByLabelText('Options menu')[1];
+  expect(optionsMenuButton).toBeInTheDocument();
+  if (optionsMenuButton) {
+    await act(async () => {
+      fireEvent.click(optionsMenuButton);
+    });
+  }
+  expect(optionsMenuButton).toHaveAttribute('aria-expanded', 'true');
+  const el8MenuSelect = queryByText('el8');
+  if (el8MenuSelect) {
+    await act(async () => {
+      fireEvent.click(el8MenuSelect);
+    });
+  }
+  expect(queryByText('No changes')).not.toBeInTheDocument();
+  expect(queryByText('Save changes')).toBeInTheDocument();
+});

--- a/src/components/EditContentModal/EditContentModal.tsx
+++ b/src/components/EditContentModal/EditContentModal.tsx
@@ -1,0 +1,445 @@
+import {
+  Button,
+  FileUpload,
+  Form,
+  FormGroup,
+  Modal,
+  ModalVariant,
+  Popover,
+  SelectVariant,
+  Stack,
+  StackItem,
+  TextInput,
+  Tooltip,
+} from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { TableComposable, Tbody, Td, Tr } from '@patternfly/react-table';
+import { global_Color_200, global_link_Color } from '@patternfly/react-tokens';
+import { useFormik } from 'formik';
+import { useEffect, useMemo } from 'react';
+import { createUseStyles } from 'react-jss';
+import Hide from '../Hide/Hide';
+import useDebounce from '../../services/useDebounce';
+import {
+  REPOSITORY_PARAMS_KEY,
+  useEditContentQuery,
+  useValidateContentList,
+} from '../../services/Content/ContentQueries';
+import { RepositoryParamsResponse } from '../../services/Content/ContentApi';
+import DropdownSelect from '../DropdownSelect/DropdownSelect';
+import { useQueryClient } from 'react-query';
+import { isValidURL, makeValidationSchema, mapValidationData } from '../AddContent/helpers';
+import ContentValidity from '../AddContent/components/ContentValidity';
+import {
+  EditContentProps,
+  FormikEditValues,
+  mapFormikToEditAPIValues,
+  mapToDefaultFormikValues,
+} from './helpers';
+import { isEqual } from 'lodash';
+
+const useStyles = createUseStyles({
+  description: {
+    color: global_Color_200.value,
+  },
+  removeSideBorder: {
+    '&:after': {
+      borderLeft: 'none!important',
+    },
+  },
+  toggleAllRow: {
+    composes: ['$removeSideBorder'],
+    cursor: 'pointer',
+    borderBottom: 'none!important',
+    '& td': {
+      color: global_link_Color.value + '!important',
+      padding: '12px 0!important',
+    },
+    '& svg': {
+      fill: global_link_Color.value + '!important',
+      padding: '',
+    },
+  },
+  colHeader: {
+    '& td': {
+      '&:not(:last-child)': { cursor: 'pointer' },
+      padding: '12px 0!important',
+    },
+  },
+  mainContentCol: {
+    composes: ['$removeSideBorder'],
+    padding: '16px 0px 16px 36px!important',
+  },
+  toggleAction: {
+    composes: ['$removeSideBorder'],
+    '& button': {
+      padding: '8px',
+    },
+  },
+  saveButton: {
+    marginRight: '36px',
+    transition: 'unset!important',
+  },
+});
+
+const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
+  if (!open) return <></>;
+  const initialValues = mapToDefaultFormikValues(values);
+  const classes = useStyles();
+  const queryClient = useQueryClient();
+  const formik = useFormik({
+    initialValues: initialValues,
+    validateOnBlur: false,
+    validateOnChange: false,
+    validationSchema: makeValidationSchema(),
+    initialTouched: values.map(() => ({ name: true, url: true })),
+    onSubmit: () => undefined,
+  });
+
+  const valuesHaveChanged = useMemo(
+    () => !isEqual(initialValues, formik.values),
+    [initialValues, formik.values],
+  );
+  const { distribution_arches: distArches = [], distribution_versions: distVersions = [] } =
+    queryClient.getQueryData<RepositoryParamsResponse>(REPOSITORY_PARAMS_KEY) || {};
+
+  const { distributionArches, distributionVersions } = useMemo(() => {
+    const distributionArches = { 'Any architecture': '' };
+    const distributionVersions = {};
+    distArches.forEach(({ name, label }) => (distributionArches[name] = label));
+    distVersions.forEach(({ name, label }) => (distributionVersions[name] = label));
+    return { distributionArches, distributionVersions };
+  }, [distArches, distVersions]);
+
+  const closeModal = () => {
+    setClosed();
+    formik.resetForm();
+  };
+
+  const { mutateAsync: editContent, isLoading: isEditing } = useEditContentQuery(
+    queryClient,
+    mapFormikToEditAPIValues(formik.values),
+  );
+
+  const createDataLengthOf1 = formik.values.length === 1;
+
+  const allExpanded = !formik.values.some(({ expanded }) => !expanded);
+
+  const expandAllToggle = () => {
+    formik.setValues([...formik.values.map((vals) => ({ ...vals, expanded: !allExpanded }))]);
+  };
+
+  const updateVariable = (index: number, newValue) => {
+    const updatedData = [...formik.values];
+    updatedData[index] = { ...updatedData[index], ...newValue };
+    formik.setValues(updatedData);
+  };
+
+  const getFieldValidation = (
+    index: number,
+    field: keyof FormikEditValues,
+  ): 'default' | 'success' | 'error' => {
+    const hasNotChanged = isEqual(initialValues[index]?.[field], formik.values[index]?.[field]);
+    const errors = !!formik.errors[index]?.[field];
+    switch (true) {
+      case errors:
+        return 'error';
+      case hasNotChanged:
+        return 'default';
+      case !hasNotChanged:
+        return 'success';
+      default:
+        return 'default';
+    }
+  };
+
+  const debouncedValues = useDebounce(formik.values);
+
+  const { mutateAsync: validateContentList } = useValidateContentList();
+
+  useEffect(() => {
+    if (open)
+      validateContentList(debouncedValues.map(({ name, url, uuid }) => ({ name, url, uuid }))).then(
+        async (validationData) => {
+          const formikErrors = await formik.validateForm(debouncedValues);
+          const mappedErrorData = mapValidationData(validationData, formikErrors);
+          formik.setErrors(mappedErrorData);
+        },
+      );
+  }, [debouncedValues, values, open]);
+
+  const onToggle = (index: number) => {
+    if (formik.values[index]?.expanded) {
+      updateVariable(index, { ...formik.values[index], expanded: false });
+    } else updateVariable(index, { ...formik.values[index], expanded: true });
+  };
+
+  const updateArchAndVersion = (index: number) => {
+    const url = formik.values[index]?.url;
+    if (isValidURL(url)) {
+      const arch =
+        formik.values[index]?.arch ||
+        distArches.find(({ name, label }) => url.includes(name) || url.includes(label))?.label ||
+        '';
+
+      let versions: Array<string> = [];
+      if (formik.values[index]?.versions?.length) {
+        versions = formik.values[index]?.versions;
+      } else {
+        const newVersion = distVersions.find(
+          ({ name, label }) => url.includes(name) || url.includes(label),
+        )?.label;
+        if (newVersion) versions = [newVersion];
+      }
+      updateVariable(index, { arch, versions });
+    }
+  };
+
+  const urlOnBlur = (index: number) => {
+    updateArchAndVersion(index);
+  };
+
+  return (
+    <Modal
+      variant={ModalVariant.medium}
+      title='Edit Content Source'
+      help={
+        <Popover
+          headerContent={<div>Help Popover</div>}
+          bodyContent={
+            <div>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec
+              fringilla turpis.
+            </div>
+          }
+          footerContent='Popover Footer'
+        >
+          <Button variant='plain' aria-label='Help'>
+            <OutlinedQuestionCircleIcon />
+          </Button>
+        </Popover>
+      }
+      description={
+        <p className={classes.description}>
+          Edit by completing the form. Default values may be provided automatically.
+        </p>
+      }
+      isOpen={open}
+      onClose={closeModal}
+      footer={
+        <Stack>
+          <StackItem>
+            <Button
+              className={classes.saveButton}
+              key='confirm'
+              variant='primary'
+              isLoading={isEditing}
+              isDisabled={
+                !formik.isValid ||
+                isEditing ||
+                !valuesHaveChanged ||
+                !isEqual(formik.values, debouncedValues)
+              }
+              onClick={() => {
+                editContent().then(closeModal);
+              }}
+            >
+              {valuesHaveChanged ? 'Save changes' : 'No changes'}
+            </Button>
+            <Button key='cancel' variant='link' onClick={closeModal}>
+              Cancel
+            </Button>
+          </StackItem>
+        </Stack>
+      }
+    >
+      <TableComposable aria-label='Expandable table'>
+        <Hide hide={createDataLengthOf1}>
+          <Tbody isExpanded={allExpanded}>
+            <Tr onClick={expandAllToggle} className={classes.toggleAllRow}>
+              <Td
+                className={classes.toggleAction}
+                isActionCell
+                expand={{
+                  rowIndex: 0,
+                  isExpanded: allExpanded,
+                }}
+              />
+              <Td dataLabel='expand-collapse'>{allExpanded ? 'Collapse all' : 'Expand all'}</Td>
+            </Tr>
+          </Tbody>
+        </Hide>
+        {formik.values.map(({ expanded, name, url, arch, gpgKey, versions, gpgLoading }, index) => (
+          <Tbody key={index} isExpanded={createDataLengthOf1 ? undefined : expanded}>
+            <Hide hide={createDataLengthOf1}>
+              <Tr className={classes.colHeader}>
+                <Td
+                  onClick={() => onToggle(index)}
+                  className={classes.toggleAction}
+                  isActionCell
+                  expand={{
+                    rowIndex: index,
+                    isExpanded: expanded,
+                  }}
+                />
+                <Td width={35} onClick={() => onToggle(index)} dataLabel={name}>
+                  {name || 'New content'}
+                </Td>
+                <Td onClick={() => onToggle(index)} dataLabel='validity'>
+                  <ContentValidity touched={formik.touched[index]} errors={formik.errors[index]} />
+                </Td>
+              </Tr>
+            </Hide>
+            <Tr isExpanded={createDataLengthOf1 ? undefined : expanded}>
+              <Td colSpan={4} className={createDataLengthOf1 ? '' : classes.mainContentCol}>
+                <Form>
+                  <FormGroup
+                    label='Name'
+                    isRequired
+                    fieldId='namegroup'
+                    validated={getFieldValidation(index, 'name')}
+                    helperTextInvalid={formik.errors[index]?.name}
+                  >
+                    <TextInput
+                      isRequired
+                      id='name'
+                      name='name'
+                      label='Name'
+                      type='text'
+                      validated={getFieldValidation(index, 'name')}
+                      onChange={(value) => {
+                        updateVariable(index, { name: value });
+                      }}
+                      value={name || ''}
+                      placeholder='Enter name'
+                    />
+                  </FormGroup>
+                  <FormGroup
+                    label='URL'
+                    isRequired
+                    fieldId='url'
+                    validated={getFieldValidation(index, 'url')}
+                    helperTextInvalid={formik.errors[index]?.url}
+                  >
+                    <TextInput
+                      isRequired
+                      type='url'
+                      validated={getFieldValidation(index, 'url')}
+                      onBlur={() => urlOnBlur(index)}
+                      onChange={(value) => updateVariable(index, { url: value })}
+                      value={url || ''}
+                      placeholder='https://'
+                      id='url'
+                      name='url'
+                      label='Url'
+                    />
+                  </FormGroup>
+                  <FormGroup
+                    label='Restrict architecture'
+                    labelIcon={
+                      <Tooltip content='Something super important and stuff'>
+                        <OutlinedQuestionCircleIcon
+                          className='pf-u-ml-xs'
+                          color={global_Color_200.value}
+                        />
+                      </Tooltip>
+                    }
+                    fieldId='arch'
+                  >
+                    <DropdownSelect
+                      validated={getFieldValidation(index, 'arch')}
+                      menuAppendTo={document.body}
+                      toggleId={'archSelection' + index}
+                      options={Object.keys(distributionArches)}
+                      variant={SelectVariant.single}
+                      selectedProp={arch}
+                      setSelected={(value) =>
+                        updateVariable(index, { arch: distributionArches[value] })
+                      }
+                    />
+                  </FormGroup>
+                  <FormGroup
+                    label='Restrict OS version'
+                    labelIcon={
+                      <Tooltip content='Something super important and stuff'>
+                        <OutlinedQuestionCircleIcon
+                          className='pf-u-ml-xs'
+                          color={global_Color_200.value}
+                        />
+                      </Tooltip>
+                    }
+                    fieldId='version'
+                  >
+                    <DropdownSelect
+                      validated={getFieldValidation(index, 'versions')}
+                      menuAppendTo={document.body}
+                      toggleId={'versionSelection' + index}
+                      options={Object.keys(distributionVersions)}
+                      variant={SelectVariant.typeaheadMulti}
+                      selectedProp={Object.keys(distributionVersions).filter((key: string) =>
+                        versions?.includes(distributionVersions[key]),
+                      )}
+                      placeholderText={versions?.length ? '' : 'Any version'}
+                      setSelected={(value) =>
+                        updateVariable(index, {
+                          versions: value.map((val) => distributionVersions[val]),
+                        })
+                      }
+                    />
+                  </FormGroup>
+                  <Hide hide>
+                    <FormGroup
+                      label='GPG key'
+                      labelIcon={
+                        <Tooltip content='Something super important and stuff'>
+                          <OutlinedQuestionCircleIcon
+                            className='pf-u-ml-xs'
+                            color={global_Color_200.value}
+                          />
+                        </Tooltip>
+                      }
+                      fieldId='gpgKey'
+                    >
+                      <FileUpload
+                        id='gpgKey-uploader'
+                        type='text'
+                        filenamePlaceholder='Drag a file here or upload one'
+                        textAreaPlaceholder='Paste GPG key or URL here'
+                        value={gpgKey}
+                        isLoading={gpgLoading}
+                        // filename={filename}
+                        // onFileInputChange={(e, { name }) => console.log(name)}
+                        onDataChange={(value) => updateVariable(index, { gpgKey: value })}
+                        onTextChange={(value) => {
+                          if (isValidURL(value)) {
+                            updateVariable(index, { gpgLoading: true });
+                            // TODO: add call to GPGkey api
+                            return setTimeout(
+                              () => updateVariable(index, { gpgLoading: false }),
+                              1500,
+                            );
+                          }
+                          updateVariable(index, { gpgKey: value });
+                        }}
+                        onClearClick={() => updateVariable(index, { gpgKey: '' })}
+                        dropzoneProps={{
+                          accept: '.txt',
+                          maxSize: 4096,
+                          onDropRejected: (e) => console.log('onDropRejected', e),
+                        }}
+                        allowEditingUploadedText
+                        browseButtonText='Upload'
+                      />
+                    </FormGroup>
+                  </Hide>
+                </Form>
+              </Td>
+            </Tr>
+          </Tbody>
+        ))}
+      </TableComposable>
+    </Modal>
+  );
+};
+
+export default EditContentModal;

--- a/src/components/EditContentModal/helpers.test.ts
+++ b/src/components/EditContentModal/helpers.test.ts
@@ -1,0 +1,60 @@
+import { ContentItem } from '../../services/Content/ContentApi';
+import { mapFormikToEditAPIValues, mapToDefaultFormikValues } from './helpers';
+
+it('mapFormikToEditAPIValues', () => {
+  const values = [
+    {
+      name: 'AwesomeNamewtmsgnum0',
+      url: 'https://google.ca/wtmsgnum0/x86_64/el7',
+      gpgKey: '',
+      arch: 'x86_64',
+      versions: ['el7'],
+      gpgLoading: false,
+      expanded: false,
+      uuid: 'stuff',
+    },
+  ];
+
+  const mappedValues = [
+    {
+      name: 'AwesomeNamewtmsgnum0',
+      url: 'https://google.ca/wtmsgnum0/x86_64/el7',
+      distribution_arch: 'x86_64',
+      distribution_versions: ['el7'],
+      gpgKey: '',
+      uuid: 'stuff',
+    },
+  ];
+
+  expect(mapFormikToEditAPIValues(values)).toEqual(mappedValues);
+});
+
+it('mapToDefaultFormikValues', () => {
+  const validationData: ContentItem[] = [
+    {
+      uuid: 'stuffAndThings',
+      name: 'stuffAndThings',
+      url: 'stuffAndThings',
+      package_count: 25,
+      distribution_versions: ['version1', 'etc'],
+      distribution_arch: 'stuffAndThings',
+      account_id: 'stuffAndThings',
+      org_id: 'stuffAndThings',
+    },
+  ];
+  const mapped = [
+    {
+      name: 'stuffAndThings',
+      url: 'stuffAndThings',
+      arch: 'stuffAndThings',
+      versions: ['version1', 'etc'],
+      gpgKey: '',
+      gpgLoading: false,
+      expanded: true,
+      uuid: 'stuffAndThings',
+    },
+  ];
+
+  expect(mapToDefaultFormikValues([])).toEqual([]);
+  expect(mapToDefaultFormikValues(validationData)).toEqual(mapped);
+});

--- a/src/components/EditContentModal/helpers.ts
+++ b/src/components/EditContentModal/helpers.ts
@@ -1,0 +1,41 @@
+import { ContentItem, EditContentRequest } from './../../services/Content/ContentApi';
+export interface EditContentProps {
+  setClosed: () => void;
+  open: boolean;
+  values: ContentItem[];
+}
+
+export interface FormikEditValues {
+  name: string;
+  url: string;
+  gpgKey: string;
+  arch: string;
+  versions: string[];
+  gpgLoading: boolean;
+  expanded: boolean;
+  uuid: string;
+}
+
+export const mapFormikToEditAPIValues = (formikValues: FormikEditValues[]): EditContentRequest =>
+  formikValues.map(({ name, url, arch, versions, gpgKey, uuid }) => ({
+    uuid,
+    name,
+    url,
+    distribution_arch: arch,
+    distribution_versions: versions,
+    gpgKey,
+  }));
+
+export const mapToDefaultFormikValues = (values: EditContentProps['values']): FormikEditValues[] =>
+  values.map(
+    ({ name, url, distribution_arch: arch, distribution_versions: versions, uuid }, index) => ({
+      name,
+      url,
+      arch,
+      versions,
+      gpgKey: '',
+      gpgLoading: false,
+      expanded: index + 1 === values.length,
+      uuid,
+    }),
+  );

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -21,6 +21,17 @@ export interface CreateContentRequestItem {
 
 export type CreateContentRequest = Array<CreateContentRequestItem>;
 
+export interface EditContentRequestItem {
+  uuid: string;
+  name: string;
+  url: string;
+  distribution_arch: string;
+  distribution_versions: string[];
+  gpgKey: string;
+}
+
+export type EditContentRequest = Array<EditContentRequestItem>;
+
 export type ContentList = Array<ContentItem>;
 
 export type Links = {
@@ -101,6 +112,16 @@ export const AddContentListItems: (request: CreateContentRequest) => Promise<voi
   request,
 ) => {
   const { data } = await axios.post('/api/content-sources/v1.0/repositories/bulk_create/', request);
+  return data;
+};
+
+export const EditContentListItem: (request: EditContentRequestItem) => Promise<void> = async (
+  request,
+) => {
+  const { data } = await axios.patch(
+    `/api/content-sources/v1.0/repositories/${request.uuid}`,
+    request,
+  );
   return data;
 };
 

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -12,6 +12,8 @@ import {
   CreateContentRequest,
   FilterData,
   validateContentListItems,
+  EditContentListItem,
+  EditContentRequest,
 } from './ContentApi';
 
 export const CONTENT_LIST_KEY = 'CONTENT_LIST_KEY';
@@ -62,6 +64,45 @@ export const useAddContentQuery = (queryClient: QueryClient, request: CreateCont
       notify({
         variant: AlertVariant.danger,
         title: 'Error adding items to content list',
+        description,
+      });
+    },
+  });
+};
+
+export const useEditContentQuery = (queryClient: QueryClient, request: EditContentRequest) => {
+  const { notify } = useNotification();
+  return useMutation(() => EditContentListItem(request[0]), {
+    onSuccess: () => {
+      notify({
+        variant: AlertVariant.success,
+        title: `Successfully edited ${request.length} ${request.length > 1 ? 'items' : 'item'}.`,
+      });
+      queryClient.invalidateQueries(CONTENT_LIST_KEY);
+    },
+    onError: (err: { response?: { data: string | Array<{ error: string | null }> } }) => {
+      let description = 'An error occurred.';
+
+      switch (typeof err?.response?.data) {
+        case 'string':
+          description = err?.response?.data;
+          break;
+        case 'object':
+          // Only show the first error
+          err?.response?.data.find(({ error }) => {
+            if (error) {
+              description = error;
+              return true;
+            }
+          })?.error;
+          break;
+        default:
+          break;
+      }
+
+      notify({
+        variant: AlertVariant.danger,
+        title: 'Error editing items on content list',
         description,
       });
     },


### PR DESCRIPTION
This PR adds the ability to Edit repositories within a list. 

Bulk edit functionality is also complete within the modal should we need it.
We would just need the multi-select boxes/Bulk Edit button/BulkEditAPI, to see that unrequested "feature" complete. 😜 

Additional Changes: 
- Introduced new "single item" UI for both AddContent and EditContent (more streamlined).
- Fixed a bug associated with the textfield on the "name/url" field on filters not being cleared properly
- Fixed a bug associated with the versions not displaying/being stored correctly.
- Fixed a bug associated with AddContent Modal validity after removing items.
