### PR TITLE
Fixes 77: add gpg key and verification option

### DIFF
--- a/src/components/AddContent/AddContent.test.tsx
+++ b/src/components/AddContent/AddContent.test.tsx
@@ -146,7 +146,7 @@ it('Add content', async () => {
   expect(nameInput).toBeInTheDocument();
   const urlInput = queryByPlaceholderText('https://');
   expect(urlInput).toBeInTheDocument();
-  const gpgKeyInput = queryByPlaceholderText('Paste GPG key or URL here')
+  const gpgKeyInput = queryByPlaceholderText('Paste GPG key or URL here');
   if (urlInput && nameInput && gpgKeyInput) {
     await act(async () => {
       fireEvent.change(urlInput, { target: { value: 'https://google.com/' } });

--- a/src/components/AddContent/AddContent.test.tsx
+++ b/src/components/AddContent/AddContent.test.tsx
@@ -146,7 +146,8 @@ it('Add content', async () => {
   expect(nameInput).toBeInTheDocument();
   const urlInput = queryByPlaceholderText('https://');
   expect(urlInput).toBeInTheDocument();
-  if (urlInput && nameInput) {
+  const gpgKeyInput = queryByPlaceholderText('Paste GPG key or URL here')
+  if (urlInput && nameInput && gpgKeyInput) {
     await act(async () => {
       fireEvent.change(urlInput, { target: { value: 'https://google.com/' } });
     });
@@ -154,12 +155,21 @@ it('Add content', async () => {
       fireEvent.change(nameInput, { target: { value: 'superCoolName' } });
     });
     await act(async () => {
+      fireEvent.change(gpgKeyInput, { target: { value: 'test gpg key' } });
+    });
+    await act(async () => {
       fireEvent.blur(urlInput);
     });
     await act(async () => {
       fireEvent.blur(nameInput);
     });
+    await act(async () => {
+      fireEvent.blur(gpgKeyInput);
+    });
   }
+
+  expect(queryByText('Use GPG key for')).toBeInTheDocument();
+  expect(queryByText('test gpg key')).toBeInTheDocument();
 
   expect(queryByText('Invalid URL')).not.toBeInTheDocument();
   const addAnotherButton = queryByText('Add another repository');

--- a/src/components/AddContent/AddContent.tsx
+++ b/src/components/AddContent/AddContent.tsx
@@ -5,12 +5,12 @@ import {
   FormGroup,
   Modal,
   ModalVariant,
-  Popover,
+  Popover, Radio,
   SelectVariant,
   Stack,
   StackItem,
   TextInput,
-  Tooltip,
+  Tooltip
 } from '@patternfly/react-core';
 import {
   OutlinedQuestionCircleIcon,
@@ -105,6 +105,7 @@ const defaultValues: FormikValues = {
   versions: ['any'],
   gpgLoading: false,
   expanded: true,
+  metadataVerification: false,
 };
 
 const AddContent = ({ isLoading }: Props) => {
@@ -279,6 +280,7 @@ const AddContent = ({ isLoading }: Props) => {
       versions: !(index % 2) ? ['7'] : ['any'],
       gpgLoading: false,
       expanded: false,
+      metadataVerification: false,
     }));
     formik.setValues(newValues);
   };
@@ -397,7 +399,7 @@ const AddContent = ({ isLoading }: Props) => {
               </Tbody>
             </Hide>
             {formik.values.map(
-              ({ expanded, name, url, arch, gpgKey, versions, gpgLoading }, index) => (
+              ({ expanded, name, url, arch, gpgKey, versions, gpgLoading, metadataVerification }, index) => (
                 <Tbody key={index} isExpanded={createDataLengthOf1 ? undefined : expanded}>
                   <Hide hide={createDataLengthOf1}>
                     <Tr className={classes.colHeader}>
@@ -526,7 +528,6 @@ const AddContent = ({ isLoading }: Props) => {
                             setSelected={(value) => setVersionSelected(value, index)}
                           />
                         </FormGroup>
-                        <Hide hide>
                           <FormGroup
                             label='GPG key'
                             labelIcon={
@@ -570,7 +571,22 @@ const AddContent = ({ isLoading }: Props) => {
                               browseButtonText='Upload'
                             />
                           </FormGroup>
-                        </Hide>
+                        <FormGroup fieldId="metadataVerification" label="Use GPG key for" isInline>
+                          <Radio
+                            id="package verification only"
+                            name="package-verification-only"
+                            label="Package verification only"
+                            isChecked={!metadataVerification}
+                            onChange={() => updateVariable(index, {metadataVerification: false})}
+                          />
+                          <Radio
+                            id="package and repository verification"
+                            name="package-and-repository-verification"
+                            label="Package and repository verification"
+                            isChecked={metadataVerification}
+                            onChange={() => updateVariable(index, {metadataVerification: true})}
+                          />
+                        </FormGroup>
                       </Form>
                     </Td>
                   </Tr>

--- a/src/components/AddContent/AddContent.tsx
+++ b/src/components/AddContent/AddContent.tsx
@@ -5,12 +5,13 @@ import {
   FormGroup,
   Modal,
   ModalVariant,
-  Popover, Radio,
+  Popover,
+  Radio,
   SelectVariant,
   Stack,
   StackItem,
   TextInput,
-  Tooltip
+  Tooltip,
 } from '@patternfly/react-core';
 import {
   OutlinedQuestionCircleIcon,
@@ -399,7 +400,10 @@ const AddContent = ({ isLoading }: Props) => {
               </Tbody>
             </Hide>
             {formik.values.map(
-              ({ expanded, name, url, arch, gpgKey, versions, gpgLoading, metadataVerification }, index) => (
+              (
+                { expanded, name, url, arch, gpgKey, versions, gpgLoading, metadataVerification },
+                index,
+              ) => (
                 <Tbody key={index} isExpanded={createDataLengthOf1 ? undefined : expanded}>
                   <Hide hide={createDataLengthOf1}>
                     <Tr className={classes.colHeader}>
@@ -528,63 +532,63 @@ const AddContent = ({ isLoading }: Props) => {
                             setSelected={(value) => setVersionSelected(value, index)}
                           />
                         </FormGroup>
-                          <FormGroup
-                            label='GPG key'
-                            labelIcon={
-                              <Tooltip content='Something super important and stuff'>
-                                <OutlinedQuestionCircleIcon
-                                  className='pf-u-ml-xs'
-                                  color={global_Color_200.value}
-                                />
-                              </Tooltip>
-                            }
-                            fieldId='gpgKey'
-                          >
-                            <FileUpload
-                              id='gpgKey-uploader'
-                              type='text'
-                              filenamePlaceholder='Drag a file here or upload one'
-                              textAreaPlaceholder='Paste GPG key or URL here'
-                              value={gpgKey}
-                              isLoading={gpgLoading}
-                              // filename={filename}
-                              // onFileInputChange={(e, { name }) => console.log(name)}
-                              onDataChange={(value) => updateVariable(index, { gpgKey: value })}
-                              onTextChange={(value) => {
-                                if (isValidURL(value)) {
-                                  updateVariable(index, { gpgLoading: true });
-                                  // TODO: add call to GPGkey api
-                                  return setTimeout(
-                                    () => updateVariable(index, { gpgLoading: false }),
-                                    1500,
-                                  );
-                                }
-                                updateVariable(index, { gpgKey: value });
-                              }}
-                              onClearClick={() => updateVariable(index, { gpgKey: '' })}
-                              dropzoneProps={{
-                                accept: '.txt',
-                                maxSize: 4096,
-                                onDropRejected: (e) => console.log('onDropRejected', e),
-                              }}
-                              allowEditingUploadedText
-                              browseButtonText='Upload'
-                            />
-                          </FormGroup>
-                        <FormGroup fieldId="metadataVerification" label="Use GPG key for" isInline>
+                        <FormGroup
+                          label='GPG key'
+                          labelIcon={
+                            <Tooltip content='Something super important and stuff'>
+                              <OutlinedQuestionCircleIcon
+                                className='pf-u-ml-xs'
+                                color={global_Color_200.value}
+                              />
+                            </Tooltip>
+                          }
+                          fieldId='gpgKey'
+                        >
+                          <FileUpload
+                            id='gpgKey-uploader'
+                            type='text'
+                            filenamePlaceholder='Drag a file here or upload one'
+                            textAreaPlaceholder='Paste GPG key or URL here'
+                            value={gpgKey}
+                            isLoading={gpgLoading}
+                            // filename={filename}
+                            // onFileInputChange={(e, { name }) => console.log(name)}
+                            onDataChange={(value) => updateVariable(index, { gpgKey: value })}
+                            onTextChange={(value) => {
+                              if (isValidURL(value)) {
+                                updateVariable(index, { gpgLoading: true });
+                                // TODO: add call to GPGkey api
+                                return setTimeout(
+                                  () => updateVariable(index, { gpgLoading: false }),
+                                  1500,
+                                );
+                              }
+                              updateVariable(index, { gpgKey: value });
+                            }}
+                            onClearClick={() => updateVariable(index, { gpgKey: '' })}
+                            dropzoneProps={{
+                              accept: '.txt',
+                              maxSize: 4096,
+                              onDropRejected: (e) => console.log('onDropRejected', e),
+                            }}
+                            allowEditingUploadedText
+                            browseButtonText='Upload'
+                          />
+                        </FormGroup>
+                        <FormGroup fieldId='metadataVerification' label='Use GPG key for' isInline>
                           <Radio
-                            id="package verification only"
-                            name="package-verification-only"
-                            label="Package verification only"
+                            id='package verification only'
+                            name='package-verification-only'
+                            label='Package verification only'
                             isChecked={!metadataVerification}
-                            onChange={() => updateVariable(index, {metadataVerification: false})}
+                            onChange={() => updateVariable(index, { metadataVerification: false })}
                           />
                           <Radio
-                            id="package and repository verification"
-                            name="package-and-repository-verification"
-                            label="Package and repository verification"
+                            id='package and repository verification'
+                            name='package-and-repository-verification'
+                            label='Package and repository verification'
                             isChecked={metadataVerification}
-                            onChange={() => updateVariable(index, {metadataVerification: true})}
+                            onChange={() => updateVariable(index, { metadataVerification: true })}
                           />
                         </FormGroup>
                       </Form>

--- a/src/components/AddContent/helpers.test.ts
+++ b/src/components/AddContent/helpers.test.ts
@@ -24,6 +24,7 @@ it('mapFormikToAPIValues', () => {
       versions: ['el7'],
       gpgLoading: false,
       expanded: false,
+      metadataVerification: false,
     },
   ];
 
@@ -33,7 +34,8 @@ it('mapFormikToAPIValues', () => {
       url: 'https://google.ca/wtmsgnum0/x86_64/el7',
       distribution_arch: 'x86_64',
       distribution_versions: ['el7'],
-      gpgKey: '',
+      gpg_key: '',
+      metadata_verification: false,
     },
   ];
 

--- a/src/components/AddContent/helpers.ts
+++ b/src/components/AddContent/helpers.ts
@@ -30,7 +30,7 @@ export const mapFormikToAPIValues = (formikValues: FormikValues[]) =>
     distribution_arch: arch,
     distribution_versions: versions,
     gpg_key: gpgKey,
-    metadata_verification: metadataVerification
+    metadata_verification: metadataVerification,
   }));
 
 const mapNoMetaDataError = (validationData: ValidationResponse) =>

--- a/src/components/AddContent/helpers.ts
+++ b/src/components/AddContent/helpers.ts
@@ -11,6 +11,7 @@ export interface FormikValues {
   arch: string;
   versions: string[];
   gpgLoading: boolean;
+  metadataVerification: boolean;
   expanded: boolean;
 }
 
@@ -23,12 +24,13 @@ export const isValidURL = (val: string) => {
 };
 
 export const mapFormikToAPIValues = (formikValues: FormikValues[]) =>
-  formikValues.map(({ name, url, arch, versions, gpgKey }) => ({
+  formikValues.map(({ name, url, arch, versions, gpgKey, metadataVerification }) => ({
     name,
     url,
     distribution_arch: arch,
     distribution_versions: versions,
-    gpgKey,
+    gpg_key: gpgKey,
+    metadata_verification: metadataVerification
   }));
 
 const mapNoMetaDataError = (validationData: ValidationResponse) =>

--- a/src/components/ContentListTable/ContentListTable.tsx
+++ b/src/components/ContentListTable/ContentListTable.tsx
@@ -284,10 +284,10 @@ const ContentListTable = () => {
                     <Td>{url}</Td>
                     <Td>{archesDisplay(distribution_arch)}</Td>
                     <Td>{versionDisplay(distribution_versions)}</Td>
+                    <Td>{package_count}</Td>
                     <Td>
                       <StatusIcon status={status} error={last_introspection_error} />
                     </Td>
-                    <Td>{package_count}</Td>
                     <Td isActionCell>
                       {hasActionPermissions ? <ActionsColumn items={rowActions(rowData)} /> : ''}
                     </Td>

--- a/src/components/ContentListTable/components/StatusIcon.test.tsx
+++ b/src/components/ContentListTable/components/StatusIcon.test.tsx
@@ -2,42 +2,26 @@ import { render } from '@testing-library/react';
 import StatusIcon from './StatusIcon';
 
 it('Render with Pending status', () => {
-  const { queryByText } = render(
-    <StatusIcon
-      status='Pending'
-    />,
-  );
+  const { queryByText } = render(<StatusIcon status='Pending' />);
 
   const SelectComponent = queryByText('Pending');
   expect(SelectComponent).toBeInTheDocument();
 });
 
 it('Render with Valid status', () => {
-  const { queryByText } = render(
-    <StatusIcon
-      status='Valid'
-    />,
-  );
+  const { queryByText } = render(<StatusIcon status='Valid' />);
   const SelectComponent = queryByText('Valid');
   expect(SelectComponent).toBeInTheDocument();
 });
 
 it('Render with Invalid status', () => {
-  const { queryByText } = render(
-    <StatusIcon
-      status='Invalid'
-    />,
-  );
+  const { queryByText } = render(<StatusIcon status='Invalid' />);
   const SelectComponent = queryByText('Invalid');
   expect(SelectComponent).toBeInTheDocument();
 });
 
 it('Render with Unavailable status', () => {
-  const { queryByText } = render(
-    <StatusIcon
-      status='Unavailable'
-    />,
-  );
+  const { queryByText } = render(<StatusIcon status='Unavailable' />);
   const SelectComponent = queryByText('Unavailable');
   expect(SelectComponent).toBeInTheDocument();
 });

--- a/src/components/ContentListTable/components/StatusIcon.tsx
+++ b/src/components/ContentListTable/components/StatusIcon.tsx
@@ -1,7 +1,17 @@
-import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon, InfoCircleIcon } from '@patternfly/react-icons';
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InfoCircleIcon,
+} from '@patternfly/react-icons';
 import { Flex, FlexItem, Tooltip } from '@patternfly/react-core';
 import StatusText from './StatusText';
-import { global_danger_color_100, global_success_color_100, global_warning_color_100, global_info_color_100 } from '@patternfly/react-tokens';
+import {
+  global_danger_color_100,
+  global_success_color_100,
+  global_warning_color_100,
+  global_info_color_100,
+} from '@patternfly/react-tokens';
 
 const red = global_danger_color_100.value;
 const green = global_success_color_100.value;
@@ -9,12 +19,12 @@ const gold = global_warning_color_100.value;
 const blue = global_info_color_100.value;
 
 interface Props {
-  status?: string,
-  error?: string,
+  status?: string;
+  error?: string;
 }
 
 const StatusIcon = ({ status, error }: Props) => {
-  switch(status) {
+  switch (status) {
     case 'Valid':
       return (
         <Flex alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'row' }}>
@@ -22,52 +32,52 @@ const StatusIcon = ({ status, error }: Props) => {
             <CheckCircleIcon color={green} />
           </FlexItem>
           <FlexItem>
-           <StatusText color='green'>Valid</StatusText>
+            <StatusText color='green'>Valid</StatusText>
           </FlexItem>
         </Flex>
-      )
+      );
     case 'Invalid':
-      return(
+      return (
         <Tooltip position='top-start' content={error}>
           <Flex alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'row' }}>
             <FlexItem spacer={{ default: 'spacerSm' }}>
-              <ExclamationCircleIcon color={red}/>
+              <ExclamationCircleIcon color={red} />
             </FlexItem>
             <FlexItem>
               <StatusText color='red'>Invalid</StatusText>
             </FlexItem>
           </Flex>
         </Tooltip>
-      )
+      );
     case 'Unavailable':
-      return(
+      return (
         <Tooltip position='top-start' content={error}>
           <Flex alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'row' }}>
             <FlexItem spacer={{ default: 'spacerSm' }}>
-              <ExclamationTriangleIcon color={gold}/>
+              <ExclamationTriangleIcon color={gold} />
             </FlexItem>
             <FlexItem>
               <StatusText color='gold'>Unavailable</StatusText>
             </FlexItem>
           </Flex>
         </Tooltip>
-      )
+      );
     case 'Pending':
-      return(
+      return (
         <Tooltip position='top-start' content='Repository has not been introspected yet'>
           <Flex alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'row' }}>
             <FlexItem spacer={{ default: 'spacerSm' }}>
-              <InfoCircleIcon title='blue' color={blue}/>
+              <InfoCircleIcon title='blue' color={blue} />
             </FlexItem>
             <FlexItem>
               <StatusText color='blue'>Pending</StatusText>
             </FlexItem>
           </Flex>
         </Tooltip>
-      )
+      );
     default:
-      return <></>
+      return <></>;
   }
-}
+};
 
-export default StatusIcon
+export default StatusIcon;

--- a/src/components/ContentListTable/components/StatusText.tsx
+++ b/src/components/ContentListTable/components/StatusText.tsx
@@ -1,5 +1,10 @@
 import { createUseStyles } from 'react-jss';
-import { global_danger_color_200, global_info_color_200, global_success_color_200, global_warning_color_200 } from '@patternfly/react-tokens';
+import {
+  global_danger_color_200,
+  global_info_color_200,
+  global_success_color_200,
+  global_warning_color_200,
+} from '@patternfly/react-tokens';
 
 const red = global_danger_color_200.value;
 const green = global_success_color_200.value;
@@ -14,16 +19,14 @@ const useStyles = createUseStyles({
 });
 
 interface Props {
-  color: 'red' | 'green' | 'gold' | 'blue'
-  children?: React.ReactNode
+  color: 'red' | 'green' | 'gold' | 'blue';
+  children?: React.ReactNode;
 }
 
 const StatusText = ({ color, children }: Props) => {
   const classes = useStyles();
 
-  return (
-    <span className={classes[color]}>{children}</span>
-  )
+  return <span className={classes[color]}>{children}</span>;
 };
 
 export default StatusText;

--- a/src/components/EditContentModal/EditContentModal.test.tsx
+++ b/src/components/EditContentModal/EditContentModal.test.tsx
@@ -22,7 +22,7 @@ const singleEditValues = [
     account_id: '6414238',
     org_id: '13446804',
     gpg_key: 'test gpg key',
-    metadata_verification: false
+    metadata_verification: false,
   },
 ];
 

--- a/src/components/EditContentModal/EditContentModal.test.tsx
+++ b/src/components/EditContentModal/EditContentModal.test.tsx
@@ -21,6 +21,8 @@ const singleEditValues = [
     last_introspection_error: '',
     account_id: '6414238',
     org_id: '13446804',
+    gpg_key: 'test gpg key',
+    metadata_verification: false
   },
 ];
 
@@ -80,6 +82,9 @@ it('Open, confirming values, edit an item, enabling Save button', async () => {
       fireEvent.click(el8MenuSelect);
     });
   }
+  expect(queryByText('test gpg key')).toBeInTheDocument();
+  expect(queryByText('Package verification only')).toBeInTheDocument();
+  expect(queryByText('Package and repository verification')).toBeInTheDocument();
   expect(queryByText('No changes')).not.toBeInTheDocument();
   expect(queryByText('Save changes')).toBeInTheDocument();
 });

--- a/src/components/EditContentModal/EditContentModal.tsx
+++ b/src/components/EditContentModal/EditContentModal.tsx
@@ -5,12 +5,13 @@ import {
   FormGroup,
   Modal,
   ModalVariant,
-  Popover, Radio,
+  Popover,
+  Radio,
   SelectVariant,
   Stack,
   StackItem,
   TextInput,
-  Tooltip
+  Tooltip,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { TableComposable, Tbody, Td, Tr } from '@patternfly/react-table';
@@ -283,122 +284,129 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
             </Tr>
           </Tbody>
         </Hide>
-        {formik.values.map(({ expanded, name, url, arch, gpgKey, versions, gpgLoading , metadataVerification}, index) => (
-          <Tbody key={index} isExpanded={createDataLengthOf1 ? undefined : expanded}>
-            <Hide hide={createDataLengthOf1}>
-              <Tr className={classes.colHeader}>
-                <Td
-                  onClick={() => onToggle(index)}
-                  className={classes.toggleAction}
-                  isActionCell
-                  expand={{
-                    rowIndex: index,
-                    isExpanded: expanded,
-                  }}
-                />
-                <Td width={35} onClick={() => onToggle(index)} dataLabel={name}>
-                  {name || 'New content'}
-                </Td>
-                <Td onClick={() => onToggle(index)} dataLabel='validity'>
-                  <ContentValidity touched={formik.touched[index]} errors={formik.errors[index]} />
-                </Td>
-              </Tr>
-            </Hide>
-            <Tr isExpanded={createDataLengthOf1 ? undefined : expanded}>
-              <Td colSpan={4} className={createDataLengthOf1 ? '' : classes.mainContentCol}>
-                <Form>
-                  <FormGroup
-                    label='Name'
-                    isRequired
-                    fieldId='namegroup'
-                    validated={getFieldValidation(index, 'name')}
-                    helperTextInvalid={formik.errors[index]?.name}
-                  >
-                    <TextInput
-                      isRequired
-                      id='name'
-                      name='name'
+        {formik.values.map(
+          (
+            { expanded, name, url, arch, gpgKey, versions, gpgLoading, metadataVerification },
+            index,
+          ) => (
+            <Tbody key={index} isExpanded={createDataLengthOf1 ? undefined : expanded}>
+              <Hide hide={createDataLengthOf1}>
+                <Tr className={classes.colHeader}>
+                  <Td
+                    onClick={() => onToggle(index)}
+                    className={classes.toggleAction}
+                    isActionCell
+                    expand={{
+                      rowIndex: index,
+                      isExpanded: expanded,
+                    }}
+                  />
+                  <Td width={35} onClick={() => onToggle(index)} dataLabel={name}>
+                    {name || 'New content'}
+                  </Td>
+                  <Td onClick={() => onToggle(index)} dataLabel='validity'>
+                    <ContentValidity
+                      touched={formik.touched[index]}
+                      errors={formik.errors[index]}
+                    />
+                  </Td>
+                </Tr>
+              </Hide>
+              <Tr isExpanded={createDataLengthOf1 ? undefined : expanded}>
+                <Td colSpan={4} className={createDataLengthOf1 ? '' : classes.mainContentCol}>
+                  <Form>
+                    <FormGroup
                       label='Name'
-                      type='text'
-                      validated={getFieldValidation(index, 'name')}
-                      onChange={(value) => {
-                        updateVariable(index, { name: value });
-                      }}
-                      value={name || ''}
-                      placeholder='Enter name'
-                    />
-                  </FormGroup>
-                  <FormGroup
-                    label='URL'
-                    isRequired
-                    fieldId='url'
-                    validated={getFieldValidation(index, 'url')}
-                    helperTextInvalid={formik.errors[index]?.url}
-                  >
-                    <TextInput
                       isRequired
-                      type='url'
+                      fieldId='namegroup'
+                      validated={getFieldValidation(index, 'name')}
+                      helperTextInvalid={formik.errors[index]?.name}
+                    >
+                      <TextInput
+                        isRequired
+                        id='name'
+                        name='name'
+                        label='Name'
+                        type='text'
+                        validated={getFieldValidation(index, 'name')}
+                        onChange={(value) => {
+                          updateVariable(index, { name: value });
+                        }}
+                        value={name || ''}
+                        placeholder='Enter name'
+                      />
+                    </FormGroup>
+                    <FormGroup
+                      label='URL'
+                      isRequired
+                      fieldId='url'
                       validated={getFieldValidation(index, 'url')}
-                      onBlur={() => urlOnBlur(index)}
-                      onChange={(value) => updateVariable(index, { url: value })}
-                      value={url || ''}
-                      placeholder='https://'
-                      id='url'
-                      name='url'
-                      label='Url'
-                    />
-                  </FormGroup>
-                  <FormGroup
-                    label='Restrict architecture'
-                    labelIcon={
-                      <Tooltip content='Something super important and stuff'>
-                        <OutlinedQuestionCircleIcon
-                          className='pf-u-ml-xs'
-                          color={global_Color_200.value}
-                        />
-                      </Tooltip>
-                    }
-                    fieldId='arch'
-                  >
-                    <DropdownSelect
-                      validated={getFieldValidation(index, 'arch')}
-                      menuAppendTo={document.body}
-                      toggleId={'archSelection' + index}
-                      options={Object.keys(distributionArches)}
-                      variant={SelectVariant.single}
-                      selectedProp={Object.keys(distributionArches).find(
-                        (key: string) => arch === distributionArches[key],
-                      )}
-                      setSelected={(value) =>
-                        updateVariable(index, { arch: distributionArches[value] })
+                      helperTextInvalid={formik.errors[index]?.url}
+                    >
+                      <TextInput
+                        isRequired
+                        type='url'
+                        validated={getFieldValidation(index, 'url')}
+                        onBlur={() => urlOnBlur(index)}
+                        onChange={(value) => updateVariable(index, { url: value })}
+                        value={url || ''}
+                        placeholder='https://'
+                        id='url'
+                        name='url'
+                        label='Url'
+                      />
+                    </FormGroup>
+                    <FormGroup
+                      label='Restrict architecture'
+                      labelIcon={
+                        <Tooltip content='Something super important and stuff'>
+                          <OutlinedQuestionCircleIcon
+                            className='pf-u-ml-xs'
+                            color={global_Color_200.value}
+                          />
+                        </Tooltip>
                       }
-                    />
-                  </FormGroup>
-                  <FormGroup
-                    label='Restrict OS version'
-                    labelIcon={
-                      <Tooltip content='Something super important and stuff'>
-                        <OutlinedQuestionCircleIcon
-                          className='pf-u-ml-xs'
-                          color={global_Color_200.value}
-                        />
-                      </Tooltip>
-                    }
-                    fieldId='version'
-                  >
-                    <DropdownSelect
-                      validated={getFieldValidation(index, 'versions')}
-                      menuAppendTo={document.body}
-                      toggleId={'versionSelection' + index}
-                      options={Object.keys(distributionVersions)}
-                      variant={SelectVariant.typeaheadMulti}
-                      selectedProp={Object.keys(distributionVersions).filter((key: string) =>
-                        versions?.includes(distributionVersions[key]),
-                      )}
-                      placeholderText={versions?.length ? '' : 'Any version'}
-                      setSelected={(value) => setVersionSelected(value, index)}
-                    />
-                  </FormGroup>
+                      fieldId='arch'
+                    >
+                      <DropdownSelect
+                        validated={getFieldValidation(index, 'arch')}
+                        menuAppendTo={document.body}
+                        toggleId={'archSelection' + index}
+                        options={Object.keys(distributionArches)}
+                        variant={SelectVariant.single}
+                        selectedProp={Object.keys(distributionArches).find(
+                          (key: string) => arch === distributionArches[key],
+                        )}
+                        setSelected={(value) =>
+                          updateVariable(index, { arch: distributionArches[value] })
+                        }
+                      />
+                    </FormGroup>
+                    <FormGroup
+                      label='Restrict OS version'
+                      labelIcon={
+                        <Tooltip content='Something super important and stuff'>
+                          <OutlinedQuestionCircleIcon
+                            className='pf-u-ml-xs'
+                            color={global_Color_200.value}
+                          />
+                        </Tooltip>
+                      }
+                      fieldId='version'
+                    >
+                      <DropdownSelect
+                        validated={getFieldValidation(index, 'versions')}
+                        menuAppendTo={document.body}
+                        toggleId={'versionSelection' + index}
+                        options={Object.keys(distributionVersions)}
+                        variant={SelectVariant.typeaheadMulti}
+                        selectedProp={Object.keys(distributionVersions).filter((key: string) =>
+                          versions?.includes(distributionVersions[key]),
+                        )}
+                        placeholderText={versions?.length ? '' : 'Any version'}
+                        setSelected={(value) => setVersionSelected(value, index)}
+                      />
+                    </FormGroup>
                     <FormGroup
                       label='GPG key'
                       labelIcon={
@@ -442,28 +450,34 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
                         browseButtonText='Upload'
                       />
                     </FormGroup>
-                    <FormGroup fieldId="metadataVerification" label="Use GPG key for" isInline validated={getFieldValidation(index, 'metadataVerification')}>
+                    <FormGroup
+                      fieldId='metadataVerification'
+                      label='Use GPG key for'
+                      isInline
+                      validated={getFieldValidation(index, 'metadataVerification')}
+                    >
                       <Radio
-                        id="package verification only"
-                        name="package-verification-only"
-                        label="Package verification only"
+                        id='package verification only'
+                        name='package-verification-only'
+                        label='Package verification only'
                         isValid={false}
                         isChecked={!metadataVerification}
-                        onChange={() => updateVariable(index, {metadataVerification: false})}
+                        onChange={() => updateVariable(index, { metadataVerification: false })}
                       />
                       <Radio
-                        id="package and repository verification"
-                        name="package-and-repository-verification"
-                        label="Package and repository verification"
+                        id='package and repository verification'
+                        name='package-and-repository-verification'
+                        label='Package and repository verification'
                         isChecked={metadataVerification}
-                        onChange={() => updateVariable(index, {metadataVerification: true})}
+                        onChange={() => updateVariable(index, { metadataVerification: true })}
                       />
                     </FormGroup>
-                </Form>
-              </Td>
-            </Tr>
-          </Tbody>
-        ))}
+                  </Form>
+                </Td>
+              </Tr>
+            </Tbody>
+          ),
+        )}
       </TableComposable>
     </Modal>
   );

--- a/src/components/EditContentModal/EditContentModal.tsx
+++ b/src/components/EditContentModal/EditContentModal.tsx
@@ -5,12 +5,12 @@ import {
   FormGroup,
   Modal,
   ModalVariant,
-  Popover,
+  Popover, Radio,
   SelectVariant,
   Stack,
   StackItem,
   TextInput,
-  Tooltip,
+  Tooltip
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { TableComposable, Tbody, Td, Tr } from '@patternfly/react-table';
@@ -283,7 +283,7 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
             </Tr>
           </Tbody>
         </Hide>
-        {formik.values.map(({ expanded, name, url, arch, gpgKey, versions, gpgLoading }, index) => (
+        {formik.values.map(({ expanded, name, url, arch, gpgKey, versions, gpgLoading , metadataVerification}, index) => (
           <Tbody key={index} isExpanded={createDataLengthOf1 ? undefined : expanded}>
             <Hide hide={createDataLengthOf1}>
               <Tr className={classes.colHeader}>
@@ -399,7 +399,6 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
                       setSelected={(value) => setVersionSelected(value, index)}
                     />
                   </FormGroup>
-                  <Hide hide>
                     <FormGroup
                       label='GPG key'
                       labelIcon={
@@ -411,6 +410,7 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
                         </Tooltip>
                       }
                       fieldId='gpgKey'
+                      validated={getFieldValidation(index, 'gpgKey')}
                     >
                       <FileUpload
                         id='gpgKey-uploader'
@@ -419,8 +419,7 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
                         textAreaPlaceholder='Paste GPG key or URL here'
                         value={gpgKey}
                         isLoading={gpgLoading}
-                        // filename={filename}
-                        // onFileInputChange={(e, { name }) => console.log(name)}
+                        validated={getFieldValidation(index, 'gpgKey')}
                         onDataChange={(value) => updateVariable(index, { gpgKey: value })}
                         onTextChange={(value) => {
                           if (isValidURL(value)) {
@@ -443,7 +442,23 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
                         browseButtonText='Upload'
                       />
                     </FormGroup>
-                  </Hide>
+                    <FormGroup fieldId="metadataVerification" label="Use GPG key for" isInline validated={getFieldValidation(index, 'metadataVerification')}>
+                      <Radio
+                        id="package verification only"
+                        name="package-verification-only"
+                        label="Package verification only"
+                        isValid={false}
+                        isChecked={!metadataVerification}
+                        onChange={() => updateVariable(index, {metadataVerification: false})}
+                      />
+                      <Radio
+                        id="package and repository verification"
+                        name="package-and-repository-verification"
+                        label="Package and repository verification"
+                        isChecked={metadataVerification}
+                        onChange={() => updateVariable(index, {metadataVerification: true})}
+                      />
+                    </FormGroup>
                 </Form>
               </Td>
             </Tr>

--- a/src/components/EditContentModal/helpers.test.ts
+++ b/src/components/EditContentModal/helpers.test.ts
@@ -12,6 +12,7 @@ it('mapFormikToEditAPIValues', () => {
       gpgLoading: false,
       expanded: false,
       uuid: 'stuff',
+      metadataVerification: false
     },
   ];
 
@@ -21,8 +22,9 @@ it('mapFormikToEditAPIValues', () => {
       url: 'https://google.ca/wtmsgnum0/x86_64/el7',
       distribution_arch: 'x86_64',
       distribution_versions: ['el7'],
-      gpgKey: '',
+      gpg_key: '',
       uuid: 'stuff',
+      metadata_verification: false,
     },
   ];
 
@@ -42,6 +44,8 @@ it('mapToDefaultFormikValues', () => {
       last_introspection_error: 'stuffAndThings',
       account_id: 'stuffAndThings',
       org_id: 'stuffAndThings',
+      gpg_key: 'stuffAndThings',
+      metadata_verification: false,
     },
   ];
   const mapped = [
@@ -50,8 +54,9 @@ it('mapToDefaultFormikValues', () => {
       url: 'stuffAndThings',
       arch: 'stuffAndThings',
       versions: ['version1', 'etc'],
-      gpgKey: '',
+      gpgKey: 'stuffAndThings',
       gpgLoading: false,
+      metadataVerification: false,
       expanded: true,
       uuid: 'stuffAndThings',
     },

--- a/src/components/EditContentModal/helpers.test.ts
+++ b/src/components/EditContentModal/helpers.test.ts
@@ -12,7 +12,7 @@ it('mapFormikToEditAPIValues', () => {
       gpgLoading: false,
       expanded: false,
       uuid: 'stuff',
-      metadataVerification: false
+      metadataVerification: false,
     },
   ];
 

--- a/src/components/EditContentModal/helpers.ts
+++ b/src/components/EditContentModal/helpers.ts
@@ -30,21 +30,26 @@ export const mapFormikToEditAPIValues = (formikValues: FormikEditValues[]): Edit
 
 export const mapToDefaultFormikValues = (values: EditContentProps['values']): FormikEditValues[] =>
   values.map(
-    ({ name,
-      url,
-      distribution_arch: arch,
-      distribution_versions: versions,
-      uuid, gpg_key: gpgKey,
-      metadata_verification: metadataVerification },
-      index) => ({
+    (
+      {
         name,
         url,
-        arch,
-        versions,
-        gpgKey,
-        gpgLoading: false,
-        metadataVerification,
-        expanded: index + 1 === values.length,
+        distribution_arch: arch,
+        distribution_versions: versions,
         uuid,
+        gpg_key: gpgKey,
+        metadata_verification: metadataVerification,
+      },
+      index,
+    ) => ({
+      name,
+      url,
+      arch,
+      versions,
+      gpgKey,
+      gpgLoading: false,
+      metadataVerification,
+      expanded: index + 1 === values.length,
+      uuid,
     }),
   );

--- a/src/components/EditContentModal/helpers.ts
+++ b/src/components/EditContentModal/helpers.ts
@@ -9,6 +9,7 @@ export interface FormikEditValues {
   name: string;
   url: string;
   gpgKey: string;
+  metadataVerification: boolean;
   arch: string;
   versions: string[];
   gpgLoading: boolean;
@@ -17,25 +18,33 @@ export interface FormikEditValues {
 }
 
 export const mapFormikToEditAPIValues = (formikValues: FormikEditValues[]): EditContentRequest =>
-  formikValues.map(({ name, url, arch, versions, gpgKey, uuid }) => ({
+  formikValues.map(({ name, url, arch, versions, gpgKey, metadataVerification, uuid }) => ({
     uuid,
     name,
     url,
     distribution_arch: arch,
     distribution_versions: versions,
-    gpgKey,
+    gpg_key: gpgKey,
+    metadata_verification: metadataVerification,
   }));
 
 export const mapToDefaultFormikValues = (values: EditContentProps['values']): FormikEditValues[] =>
   values.map(
-    ({ name, url, distribution_arch: arch, distribution_versions: versions, uuid }, index) => ({
-      name,
+    ({ name,
       url,
-      arch,
-      versions,
-      gpgKey: '',
-      gpgLoading: false,
-      expanded: index + 1 === values.length,
-      uuid,
+      distribution_arch: arch,
+      distribution_versions: versions,
+      uuid, gpg_key: gpgKey,
+      metadata_verification: metadataVerification },
+      index) => ({
+        name,
+        url,
+        arch,
+        versions,
+        gpgKey,
+        gpgLoading: false,
+        metadataVerification,
+        expanded: index + 1 === values.length,
+        uuid,
     }),
   );

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -11,6 +11,8 @@ export interface ContentItem {
   org_id: string;
   status: string;
   last_introspection_error: string;
+  gpg_key: string;
+  metadata_verification: boolean;
 }
 
 export interface CreateContentRequestItem {
@@ -18,7 +20,8 @@ export interface CreateContentRequestItem {
   url: string;
   distribution_versions?: Array<string>;
   distribution_arch?: string;
-  gpgKey?: string;
+  gpg_key?: string;
+  metadata_verification?: boolean;
 }
 
 export type CreateContentRequest = Array<CreateContentRequestItem>;
@@ -29,7 +32,8 @@ export interface EditContentRequestItem {
   url: string;
   distribution_arch: string;
   distribution_versions: string[];
-  gpgKey: string;
+  gpg_key: string;
+  metadata_verification: boolean;
 }
 
 export type EditContentRequest = Array<EditContentRequestItem>;


### PR DESCRIPTION
- Unhides the GPG key form in the Edit and Add modals. 
- Adds a radio button for the metadata verification option.

I was thinking GPG Key and the verification option should be their own components, but it seems like that would be more than a little disruptive to the current formik stuff. I welcome suggestions there (and anywhere).