### PR TITLE
Fixes 208: Add api validation for gpg-keys

### DIFF
--- a/src/components/AddContent/helpers.test.ts
+++ b/src/components/AddContent/helpers.test.ts
@@ -57,6 +57,7 @@ it('mapValidationData', () => {
           'Error fetching YUM metadata: Head "https://bobjull.co": dial tcp: lookup bobjull.co: no such host',
         http_code: 0,
         metadata_present: false,
+        metadata_signature_present: false,
       },
     },
   ];

--- a/src/components/AddContent/helpers.ts
+++ b/src/components/AddContent/helpers.ts
@@ -52,10 +52,11 @@ export const mapValidationData = (
   formikErrors: FormikErrors<FormikValues | undefined>[],
 ) => {
   const updatedValidationData = mapNoMetaDataError(validationData);
-  const errors = updatedValidationData.map(({ name, url }, index: number) => ({
+  const errors = updatedValidationData.map(({ name, url, gpg_key: gpgKey }, index: number) => ({
     // First apply the errors found in the ValidationAPI
     ...(name?.error ? { name: name?.error } : {}),
     ...(url?.error ? { url: url?.error } : {}),
+    ...(gpgKey?.error ? { gpgKey: gpgKey?.error } : {}),
     // Overwrite any errors with errors found within the UI itself
     ...formikErrors[index],
   }));
@@ -91,7 +92,6 @@ export const makeValidationSchema = () => {
       .shape({
         name: Yup.string().min(2, 'Too Short!').max(50, 'Too Long!').required('Required'),
         url: Yup.string().url('Invalid URL').required('Required'),
-        gpgKey: Yup.string().optional(),
       })
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore-next-line

--- a/src/components/EditContentModal/EditContentModal.test.tsx
+++ b/src/components/EditContentModal/EditContentModal.test.tsx
@@ -84,7 +84,7 @@ it('Open, confirming values, edit an item, enabling Save button', async () => {
   }
   expect(queryByText('test gpg key')).toBeInTheDocument();
   expect(queryByText('Package verification only')).toBeInTheDocument();
-  expect(queryByText('Package and repository verification')).toBeInTheDocument();
+  expect(queryByText('Package and metadata verification')).toBeInTheDocument();
   expect(queryByText('No changes')).not.toBeInTheDocument();
   expect(queryByText('Save changes')).toBeInTheDocument();
 });

--- a/src/components/Error/ErrorPage.test.tsx
+++ b/src/components/Error/ErrorPage.test.tsx
@@ -10,7 +10,7 @@ const WillError = () => {
 const WontErrorText = 'Oh Yeah!';
 const WontError = () => <h1>{WontErrorText}</h1>;
 
-it('Catch the child\'s error and show it on the dom', () => {
+it("Catch the child's error and show it on the dom", () => {
   const { queryByText } = render(
     <div>
       <ErrorPage>

--- a/src/components/OptionalTooltip/OptionalTooltip.test.tsx
+++ b/src/components/OptionalTooltip/OptionalTooltip.test.tsx
@@ -1,0 +1,48 @@
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import OptionalTooltip from './OptionalTooltip';
+
+const text = 'Hello';
+const content = <h1>{text}</h1>;
+
+it('Render content when show is true', async () => {
+  const { queryByText } = render(
+    <div>
+      <OptionalTooltip content={content} show={true}>
+        <div>Test</div>
+      </OptionalTooltip>
+    </div>,
+  );
+
+  const divElement = queryByText('Test');
+  expect(divElement).toBeInTheDocument();
+
+  if (divElement) {
+    userEvent.hover(divElement);
+  }
+
+  await waitFor(() => {
+    expect(queryByText(text)).toBeInTheDocument();
+  });
+});
+
+it('Hide content when show is false', async () => {
+  const { queryByText } = render(
+    <div>
+      <OptionalTooltip content={content} show={false}>
+        <div>Test</div>
+      </OptionalTooltip>
+    </div>,
+  );
+
+  const divElement = queryByText('Test');
+  expect(divElement).toBeInTheDocument();
+
+  if (divElement) {
+    userEvent.hover(divElement);
+  }
+
+  await waitFor(() => {
+    expect(queryByText(text)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/OptionalTooltip/OptionalTooltip.tsx
+++ b/src/components/OptionalTooltip/OptionalTooltip.tsx
@@ -1,0 +1,10 @@
+import { Tooltip, TooltipProps } from '@patternfly/react-core';
+
+interface Props extends TooltipProps {
+  show: boolean;
+}
+
+const OptionalTooltip = ({ show, children, ...rest }: Props) =>
+  show ? <Tooltip {...rest}>{children}</Tooltip> : <>{children}</>;
+
+export default OptionalTooltip;

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -90,6 +90,7 @@ export type ValidateItem = {
 export interface ValidationUrl extends ValidateItem {
   http_code: number;
   metadata_present: boolean;
+  metadata_signature_present: boolean;
 }
 
 export type ValidationResponse = {
@@ -97,7 +98,7 @@ export type ValidationResponse = {
   url?: ValidationUrl;
   distribution_versions?: ValidateItem;
   distribution_arch?: ValidateItem;
-  gpgKey?: ValidateItem;
+  gpg_key?: ValidateItem;
 }[];
 
 export const getContentList: (

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { RepositoryParamsResponse } from './services/Content/ContentApi';
+import { RepositoryParamsResponse, ValidationResponse } from './services/Content/ContentApi';
 
 const queryClient = new QueryClient({
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -66,7 +66,7 @@ export const testRepositoryParamsResponse: RepositoryParamsResponse = {
   ],
 };
 
-export const defaultValidationErrorData = [
+export const defaultValidationErrorData: ValidationResponse = [
   {
     name: {
       skipped: false,
@@ -79,13 +79,19 @@ export const defaultValidationErrorData = [
       error: 'URL cannot be blank',
       http_code: 0,
       metadata_present: false,
+      metadata_signature_present: false,
     },
   },
 ];
 
-export const passingValidationErrorData = [
+export const passingValidationErrorData: ValidationResponse = [
   {
     name: {
+      skipped: false,
+      valid: true,
+      error: '',
+    },
+    gpg_key: {
       skipped: false,
       valid: true,
       error: '',
@@ -94,8 +100,9 @@ export const passingValidationErrorData = [
       skipped: false,
       valid: true,
       error: '',
-      http_code: 0,
+      http_code: 200,
       metadata_present: true,
+      metadata_signature_present: true,
     },
   },
 ];


### PR DESCRIPTION
This adds validation functionality to be paired with [this backend API ticket](https://github.com/content-services/content-sources-backend/pull/116), allowing the gpg_keys to: 

- Show errors when gpg_key is invalid
- Show errors when Package and metadata verification is set but gpg_key signature does not match.
- Auto-selection of Package and metadata verification option (based on url metadata_verification set to true)
- Auto-selection/disabling of metadata verification option (in case where url metadata_verification set to false).

- [x] Needs tests