### PR TITLE
Fixes 182: change api errors to error objects

### DIFF
--- a/src/components/ContentListTable/components/AddContent/helpers.ts
+++ b/src/components/ContentListTable/components/AddContent/helpers.ts
@@ -96,7 +96,7 @@ export const makeValidationSchema = () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore-next-line
       .uniqueProperty('name', 'Names must be unique')
-      .uniqueProperty('url', 'Url\'s must be unique'),
+      .uniqueProperty('url', "Url's must be unique"),
   );
 };
 

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -24,12 +24,17 @@ export interface CreateContentRequestItem {
   metadata_verification?: boolean;
 }
 
-export interface CreateContentResponseItem {
-  error: string;
-  repository: ContentItem;
+export interface ErrorItem {
+  status: number;
+  title?: string;
+  detail?: string;
 }
 
-export type CreateContentRequestResponse = CreateContentResponseItem[];
+export interface ErrorResponse {
+  errors: ErrorItem[];
+}
+
+export type CreateContentRequestResponse = ContentItem[] | ErrorResponse;
 
 export type CreateContentRequest = Array<CreateContentRequestItem>;
 

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -17,6 +17,7 @@ import {
   getGpgKey,
   PackagesResponse,
   getPackages,
+  ErrorResponse,
 } from './ContentApi';
 
 export const CONTENT_LIST_KEY = 'CONTENT_LIST_KEY';
@@ -55,7 +56,7 @@ export const useAddContentQuery = (queryClient: QueryClient, request: CreateCont
       });
       queryClient.invalidateQueries(CONTENT_LIST_KEY);
     },
-    onError: (err: { response?: { data: string | Array<{ error: string | null }> } }) => {
+    onError: (err: { response?: { data: ErrorResponse } }) => {
       let description = 'An error occurred';
 
       switch (typeof err?.response?.data) {
@@ -64,12 +65,12 @@ export const useAddContentQuery = (queryClient: QueryClient, request: CreateCont
           break;
         case 'object':
           // Only show the first error
-          err?.response?.data.find(({ error }) => {
-            if (error) {
-              description = error;
+          err?.response?.data.errors?.find(({ detail }) => {
+            if (detail) {
+              description = detail;
               return true;
             }
-          })?.error;
+          })?.detail;
           break;
         default:
           break;
@@ -94,7 +95,7 @@ export const useEditContentQuery = (queryClient: QueryClient, request: EditConte
       });
       queryClient.invalidateQueries(CONTENT_LIST_KEY);
     },
-    onError: (err: { response?: { data: string | Array<{ error: string | null }> } }) => {
+    onError: (err: { response?: { data: ErrorResponse } }) => {
       let description = 'An error occurred';
 
       switch (typeof err?.response?.data) {
@@ -103,12 +104,12 @@ export const useEditContentQuery = (queryClient: QueryClient, request: EditConte
           break;
         case 'object':
           // Only show the first error
-          err?.response?.data.find(({ error }) => {
-            if (error) {
-              description = error;
+          err?.response?.data.errors?.find(({ detail }) => {
+            if (detail) {
+              description = detail;
               return true;
             }
-          })?.error;
+          })?.detail;
           break;
         default:
           break;


### PR DESCRIPTION
Accompanies this PR: https://github.com/content-services/content-sources-backend/pull/126

Updates the error handling here to work with the error structure defined in said PR.