### PR TITLE
Fixes 244: Hide package verification

### DIFF
--- a/src/components/ContentListTable/components/AddContent/AddContent.test.tsx
+++ b/src/components/ContentListTable/components/AddContent/AddContent.test.tsx
@@ -20,12 +20,12 @@ jest.mock('../../../../services/Content/ContentQueries', () => ({
 
 jest.mock('../../../../services/useDebounce', () => jest.fn());
 
-const passingValidationMetaDataSigNotPresent = [
-  {
-    ...passingValidationErrorData[0],
-    url: { ...passingValidationErrorData[0], metadata_signature_present: false },
-  },
-];
+// const passingValidationMetaDataSigNotPresent = [
+//   {
+//     ...passingValidationErrorData[0],
+//     url: { ...passingValidationErrorData[0], metadata_signature_present: false },
+//   },
+// ];
 
 it('expect AddContent button to render and be disabled', () => {
   (useAddContentQuery as jest.Mock).mockImplementation(() => ({ isLoading: false }));
@@ -135,90 +135,90 @@ it('expect "url" input to show a validation error', async () => {
   expect(queryByText('Invalid URL')).toBeInTheDocument();
 });
 
-it('expect "Package and metadata verification" to be pre-selected', async () => {
-  (useAddContentQuery as jest.Mock).mockImplementation(() => ({ isLoading: false }));
-  (useValidateContentList as jest.Mock).mockImplementation(() => ({
-    isLoading: false,
-    mutateAsync: async () => passingValidationErrorData,
-    data: passingValidationErrorData,
-  }));
-  (useDebounce as jest.Mock).mockImplementation((value) => value);
+// it('expect "Package and metadata verification" to be pre-selected', async () => {
+//   (useAddContentQuery as jest.Mock).mockImplementation(() => ({ isLoading: false }));
+//   (useValidateContentList as jest.Mock).mockImplementation(() => ({
+//     isLoading: false,
+//     mutateAsync: async () => passingValidationErrorData,
+//     data: passingValidationErrorData,
+//   }));
+//   (useDebounce as jest.Mock).mockImplementation((value) => value);
 
-  const { queryByText, queryByPlaceholderText, queryByLabelText } = render(
-    <ReactQueryTestWrapper>
-      <AddContent />
-    </ReactQueryTestWrapper>,
-  );
+//   const { queryByText, queryByPlaceholderText, queryByLabelText } = render(
+//     <ReactQueryTestWrapper>
+//       <AddContent />
+//     </ReactQueryTestWrapper>,
+//   );
 
-  const button = queryByText('Add repositories');
-  expect(button).toBeInTheDocument();
-  await act(async () => {
-    button?.click();
-  });
-  const urlInput = queryByPlaceholderText('https://');
-  expect(urlInput).toBeInTheDocument();
-  if (urlInput) {
-    await act(async () => {
-      fireEvent.change(urlInput, { target: { value: 'https://bobTheBuilder.com' } });
-      fireEvent.blur(urlInput);
-    });
-  }
-  expect(queryByText('Invalid URL')).not.toBeInTheDocument();
-  const gpgKeyInput = queryByPlaceholderText('Paste GPG key or URL here');
-  expect(gpgKeyInput).toBeInTheDocument();
-  if (gpgKeyInput) {
-    await act(async () => {
-      fireEvent.change(gpgKeyInput, { target: { value: 'aRealGPGKey' } });
-    });
-  }
+//   const button = queryByText('Add repositories');
+//   expect(button).toBeInTheDocument();
+//   await act(async () => {
+//     button?.click();
+//   });
+//   const urlInput = queryByPlaceholderText('https://');
+//   expect(urlInput).toBeInTheDocument();
+//   if (urlInput) {
+//     await act(async () => {
+//       fireEvent.change(urlInput, { target: { value: 'https://bobTheBuilder.com' } });
+//       fireEvent.blur(urlInput);
+//     });
+//   }
+//   expect(queryByText('Invalid URL')).not.toBeInTheDocument();
+//   const gpgKeyInput = queryByPlaceholderText('Paste GPG key or URL here');
+//   expect(gpgKeyInput).toBeInTheDocument();
+//   if (gpgKeyInput) {
+//     await act(async () => {
+//       fireEvent.change(gpgKeyInput, { target: { value: 'aRealGPGKey' } });
+//     });
+//   }
 
-  expect(queryByText('Package and metadata verification')).toBeInTheDocument();
-  const packageMetaDataInput = queryByLabelText('Package and metadata verification');
+//   expect(queryByText('Package and metadata verification')).toBeInTheDocument();
+//   const packageMetaDataInput = queryByLabelText('Package and metadata verification');
 
-  expect(packageMetaDataInput).toHaveAttribute('checked');
-});
+//   expect(packageMetaDataInput).toHaveAttribute('checked');
+// });
 
-it('expect "Package verification only" to be pre-selected', async () => {
-  (useAddContentQuery as jest.Mock).mockImplementation(() => ({ isLoading: false }));
+// it('expect "Package verification only" to be pre-selected', async () => {
+//   (useAddContentQuery as jest.Mock).mockImplementation(() => ({ isLoading: false }));
 
-  (useValidateContentList as jest.Mock).mockImplementation(() => ({
-    isLoading: false,
-    mutateAsync: async () => passingValidationMetaDataSigNotPresent,
-    data: passingValidationMetaDataSigNotPresent,
-  }));
-  (useDebounce as jest.Mock).mockImplementation((value) => value);
+//   (useValidateContentList as jest.Mock).mockImplementation(() => ({
+//     isLoading: false,
+//     mutateAsync: async () => passingValidationMetaDataSigNotPresent,
+//     data: passingValidationMetaDataSigNotPresent,
+//   }));
+//   (useDebounce as jest.Mock).mockImplementation((value) => value);
 
-  const { queryByText, queryByPlaceholderText, queryByLabelText } = render(
-    <ReactQueryTestWrapper>
-      <AddContent />
-    </ReactQueryTestWrapper>,
-  );
+//   const { queryByText, queryByPlaceholderText, queryByLabelText } = render(
+//     <ReactQueryTestWrapper>
+//       <AddContent />
+//     </ReactQueryTestWrapper>,
+//   );
 
-  const button = queryByText('Add repositories');
-  expect(button).toBeInTheDocument();
-  await act(async () => {
-    button?.click();
-  });
-  const urlInput = queryByPlaceholderText('https://');
-  expect(urlInput).toBeInTheDocument();
-  if (urlInput) {
-    await act(async () => {
-      fireEvent.change(urlInput, { target: { value: 'https://bobTheBuilder.com' } });
-    });
-  }
-  expect(queryByText('Invalid URL')).not.toBeInTheDocument();
-  const gpgKeyInput = queryByPlaceholderText('Paste GPG key or URL here');
-  expect(gpgKeyInput).toBeInTheDocument();
-  if (gpgKeyInput) {
-    await act(async () => {
-      fireEvent.change(gpgKeyInput, { target: { value: 'aRealGPGKey' } });
-      fireEvent.blur(gpgKeyInput);
-    });
-  }
-  expect(queryByText('Package verification only')).toBeInTheDocument();
-  const packageVerificationOnly = queryByLabelText('Package verification only');
-  expect(packageVerificationOnly).toHaveAttribute('checked');
-});
+//   const button = queryByText('Add repositories');
+//   expect(button).toBeInTheDocument();
+//   await act(async () => {
+//     button?.click();
+//   });
+//   const urlInput = queryByPlaceholderText('https://');
+//   expect(urlInput).toBeInTheDocument();
+//   if (urlInput) {
+//     await act(async () => {
+//       fireEvent.change(urlInput, { target: { value: 'https://bobTheBuilder.com' } });
+//     });
+//   }
+//   expect(queryByText('Invalid URL')).not.toBeInTheDocument();
+//   const gpgKeyInput = queryByPlaceholderText('Paste GPG key or URL here');
+//   expect(gpgKeyInput).toBeInTheDocument();
+//   if (gpgKeyInput) {
+//     await act(async () => {
+//       fireEvent.change(gpgKeyInput, { target: { value: 'aRealGPGKey' } });
+//       fireEvent.blur(gpgKeyInput);
+//     });
+//   }
+//   expect(queryByText('Package verification only')).toBeInTheDocument();
+//   const packageVerificationOnly = queryByLabelText('Package verification only');
+//   expect(packageVerificationOnly).toHaveAttribute('checked');
+// });
 
 it('Add content', async () => {
   (useAddContentQuery as jest.Mock).mockImplementation(() => ({
@@ -271,7 +271,7 @@ it('Add content', async () => {
     });
   }
 
-  expect(queryByText('Use GPG key for')).toBeInTheDocument();
+  //   expect(queryByText('Use GPG key for')).toBeInTheDocument();
   expect(queryByText('test GPG key')).toBeInTheDocument();
 
   expect(queryByText('Invalid URL')).not.toBeInTheDocument();

--- a/src/components/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/components/ContentListTable/components/AddContent/AddContent.tsx
@@ -582,25 +582,25 @@ const AddContent = ({ isLoading }: Props) => {
                                 updateVariable(index, {
                                   gpgKey: gpgData,
                                   gpgLoading: false,
-                                  ...(gpgKey === '' && !!value
-                                    ? {
-                                        metadataVerification:
-                                          !!validationList?.[index]?.url
-                                            ?.metadata_signature_present,
-                                      }
-                                    : {}),
+                                  //   ...(gpgKey === '' && !!value
+                                  //     ? {
+                                  //         metadataVerification:
+                                  //           !!validationList?.[index]?.url
+                                  //             ?.metadata_signature_present,
+                                  //       }
+                                  //     : {}),
                                 });
                               }
                             }}
                             onTextChange={(value) =>
                               updateVariable(index, {
                                 gpgKey: value,
-                                ...(gpgKey === '' && !!value
-                                  ? {
-                                      metadataVerification:
-                                        !!validationList?.[index]?.url?.metadata_signature_present,
-                                    }
-                                  : {}),
+                                // ...(gpgKey === '' && !!value
+                                //   ? {
+                                //       metadataVerification:
+                                //         !!validationList?.[index]?.url?.metadata_signature_present,
+                                //     }
+                                //   : {}),
                               })
                             }
                             onClearClick={() => updateVariable(index, { gpgKey: '' })}
@@ -613,7 +613,8 @@ const AddContent = ({ isLoading }: Props) => {
                             browseButtonText='Upload'
                           />
                         </FormGroup>
-                        <Hide hide={!gpgKey}>
+                        <Hide hide>
+                          {/* <Hide hide={!gpgKey}> */}
                           <FormGroup
                             fieldId='metadataVerification'
                             label='Use GPG key for'

--- a/src/components/ContentListTable/components/EditContentModal/EditContentModal.test.tsx
+++ b/src/components/ContentListTable/components/EditContentModal/EditContentModal.test.tsx
@@ -89,8 +89,8 @@ it('Open, confirming values, edit an item, enabling Save button', async () => {
     });
   }
   expect(queryByText('test GPG key')).toBeInTheDocument();
-  expect(queryByText('Package verification only')).toBeInTheDocument();
-  expect(queryByText('Package and metadata verification')).toBeInTheDocument();
+  //   expect(queryByText('Package verification only')).toBeInTheDocument();
+  //   expect(queryByText('Package and metadata verification')).toBeInTheDocument();
   expect(queryByText('No changes')).not.toBeInTheDocument();
   expect(queryByText('Save changes')).toBeInTheDocument();
 });

--- a/src/components/ContentListTable/components/EditContentModal/EditContentModal.tsx
+++ b/src/components/ContentListTable/components/EditContentModal/EditContentModal.tsx
@@ -464,24 +464,24 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
                             updateVariable(index, {
                               gpgKey: gpgData,
                               gpgLoading: false,
-                              ...(gpgKey === '' && !!value
-                                ? {
-                                    metadataVerification:
-                                      !!validationList?.[index]?.url?.metadata_signature_present,
-                                  }
-                                : {}),
+                              //   ...(gpgKey === '' && !!value
+                              //     ? {
+                              //         metadataVerification:
+                              //           !!validationList?.[index]?.url?.metadata_signature_present,
+                              //       }
+                              //     : {}),
                             });
                           }
                         }}
                         onTextChange={(value) =>
                           updateVariable(index, {
                             gpgKey: value,
-                            ...(gpgKey === '' && !!value
-                              ? {
-                                  metadataVerification:
-                                    !!validationList?.[index]?.url?.metadata_signature_present,
-                                }
-                              : {}),
+                            // ...(gpgKey === '' && !!value
+                            //   ? {
+                            //       metadataVerification:
+                            //         !!validationList?.[index]?.url?.metadata_signature_present,
+                            //     }
+                            //   : {}),
                           })
                         }
                         onClearClick={() => updateVariable(index, { gpgKey: '' })}
@@ -494,7 +494,8 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
                         browseButtonText='Upload'
                       />
                     </FormGroup>
-                    <Hide hide={!gpgKey}>
+                    <Hide hide>
+                      {/* <Hide hide={!gpgKey}> */}
                       <FormGroup fieldId='metadataVerification' label='Use GPG key for' isInline>
                         <Radio
                           isDisabled={


### PR DESCRIPTION
It may be a while before image builder supports metadata verification.  This disables the option in the UI.