### PR TITLE
Fixes 263: show N/A for Invalid repositories

### DIFF
--- a/src/components/ContentListTable/components/PackageCount.test.tsx
+++ b/src/components/ContentListTable/components/PackageCount.test.tsx
@@ -1,46 +1,29 @@
 import { render } from '@testing-library/react';
-import { ReactQueryTestWrapper } from '../../../testingHelpers';
 import PackageCount from './PackageCount';
 
-jest.mock('../../../services/Notifications/Notifications', () => ({
-  useNotification: () => ({ notify: () => null }),
-}));
+it('Render PackageCount for Invalid state', async () => {
+  const data = {uuid: '', name: '', package_count: 100, url: '', status: 'Invalid', account_id: '', distribution_arch: '', gpg_key: '', distribution_versions: [''], last_introspection_error: '', metadata_verification: false, org_id: 'acme'}
+  const {queryByText} = render(
+    <PackageCount rowData={data} />
+  );
 
-jest.mock('../../../middleware/AppContext', () => ({
-  useAppContext: () => ({}),
-}));
+  expect(queryByText('N/A')).toBeInTheDocument();
+});
 
-describe('PackageCount component', () => {
-  it('Render PackageCount for Invalid state', () => {
-    const data = {uuid: '', name: '', package_count: 100, url: '', status: 'Invalid', account_id: '', distribution_arch: '', gpg_key: '', distribution_versions: [''], last_introspection_error: '', metadata_verification: false, org_id: 'acme'}
-    const result = render(
-      <ReactQueryTestWrapper>
-        <PackageCount rowData={data}  />
-      </ReactQueryTestWrapper>,
-    );
+it('Render PackageCount for Pending state', () => {
+  const data = {uuid: '', name: '', package_count: 0, url: '', status: 'Pending', account_id: '', distribution_arch: '', gpg_key: '', distribution_versions: [''], last_introspection_error: '', metadata_verification: false, org_id: 'acme'};
+  const {queryByText} = render(
+    <PackageCount rowData={data} />
+  );
 
-    expect(result.baseElement.textContent).toEqual('N/A');
-  });
+  expect(queryByText('N/A')).toBeInTheDocument();
+});
 
-  it('Render PackageCount for Pending state', () => {
-    const data = {uuid: '', name: '', package_count: 0, url: '', status: 'Pending', account_id: '', distribution_arch: '', gpg_key: '', distribution_versions: [''], last_introspection_error: '', metadata_verification: false, org_id: 'acme'};
-    const result = render(
-      <ReactQueryTestWrapper>
-        <PackageCount rowData={data} />
-      </ReactQueryTestWrapper>,
-    );
+it('Render PackageCount normally', () => {
+  const data = {uuid: '88a8417e-65ab-11ed-b54c-482ae3863d30', name: 'My test repository', package_count: 100, url: 'https://www.example.test/my-repository', status: 'Valid', account_id: '', distribution_arch: 'x86_64', gpg_key: '', distribution_versions: ['el8'], last_introspection_error: '', metadata_verification: false, org_id: 'acme'};
+  const {queryByText} = render(
+    <PackageCount rowData={data} />
+  );
 
-    expect(result.baseElement.textContent).toEqual('N/A');
-  });
-
-  it('Render PackageCount normally', () => {
-    const data = {uuid: '88a8417e-65ab-11ed-b54c-482ae3863d30', name: 'My test repository', package_count: 100, url: 'https://www.example.test/my-repository', status: 'Valid', account_id: '', distribution_arch: 'x86_64', gpg_key: '', distribution_versions: ['el8'], last_introspection_error: '', metadata_verification: false, org_id: 'acme'};
-    const result = render(
-      <ReactQueryTestWrapper>
-        <PackageCount rowData={data} />
-      </ReactQueryTestWrapper>,
-    );
-
-    expect(result.baseElement.textContent).toEqual('100');
-  });
-})
+  expect(queryByText('100')).toBeInTheDocument();
+});

--- a/src/components/ContentListTable/components/PackageCount.test.tsx
+++ b/src/components/ContentListTable/components/PackageCount.test.tsx
@@ -1,0 +1,46 @@
+import { render } from '@testing-library/react';
+import { ReactQueryTestWrapper } from '../../../testingHelpers';
+import PackageCount from './PackageCount';
+
+jest.mock('../../../services/Notifications/Notifications', () => ({
+  useNotification: () => ({ notify: () => null }),
+}));
+
+jest.mock('../../../middleware/AppContext', () => ({
+  useAppContext: () => ({}),
+}));
+
+describe('PackageCount component', () => {
+  it('Render PackageCount for Invalid state', () => {
+    const data = {uuid: '', name: '', package_count: 100, url: '', status: 'Invalid', account_id: '', distribution_arch: '', gpg_key: '', distribution_versions: [''], last_introspection_error: '', metadata_verification: false, org_id: 'acme'}
+    const result = render(
+      <ReactQueryTestWrapper>
+        <PackageCount rowData={data}  />
+      </ReactQueryTestWrapper>,
+    );
+
+    expect(result.baseElement.textContent).toEqual('N/A');
+  });
+
+  it('Render PackageCount for Pending state', () => {
+    const data = {uuid: '', name: '', package_count: 0, url: '', status: 'Pending', account_id: '', distribution_arch: '', gpg_key: '', distribution_versions: [''], last_introspection_error: '', metadata_verification: false, org_id: 'acme'};
+    const result = render(
+      <ReactQueryTestWrapper>
+        <PackageCount rowData={data} />
+      </ReactQueryTestWrapper>,
+    );
+
+    expect(result.baseElement.textContent).toEqual('N/A');
+  });
+
+  it('Render PackageCount normally', () => {
+    const data = {uuid: '88a8417e-65ab-11ed-b54c-482ae3863d30', name: 'My test repository', package_count: 100, url: 'https://www.example.test/my-repository', status: 'Valid', account_id: '', distribution_arch: 'x86_64', gpg_key: '', distribution_versions: ['el8'], last_introspection_error: '', metadata_verification: false, org_id: 'acme'};
+    const result = render(
+      <ReactQueryTestWrapper>
+        <PackageCount rowData={data} />
+      </ReactQueryTestWrapper>,
+    );
+
+    expect(result.baseElement.textContent).toEqual('100');
+  });
+})

--- a/src/components/ContentListTable/components/PackageCount.tsx
+++ b/src/components/ContentListTable/components/PackageCount.tsx
@@ -32,6 +32,14 @@ const PackageCount = ({ rowData }: Props) => {
     );
   }
 
+  if (rowData.status === 'Invalid') {
+    return (
+      <Tooltip isContentLeftAligned content='Repository is invalid please review it'>
+        <Text className={classes.text}>N/A</Text>
+      </Tooltip>
+    )
+  }
+
   return (
     <>
       <Hide hide={!modalOpen}>

--- a/src/components/ContentListTable/components/PackageCount.tsx
+++ b/src/components/ContentListTable/components/PackageCount.tsx
@@ -34,7 +34,7 @@ const PackageCount = ({ rowData }: Props) => {
 
   if (rowData.status === 'Invalid') {
     return (
-      <Tooltip isContentLeftAligned content='Repository is invalid please review it'>
+      <Tooltip isContentLeftAligned content='Repository is invalid.'>
         <Text className={classes.text}>N/A</Text>
       </Tooltip>
     )


### PR DESCRIPTION
- Update component to display N/A into the Packages column when the repository state is Invalid.
- Add unit tests for the component.
