### PR TITLE
Fixes 287: Fix for null store error when navigating

### DIFF
--- a/src/AppEntry.tsx
+++ b/src/AppEntry.tsx
@@ -24,9 +24,8 @@ export default function AppEntry({ logger }: AppEntryProps) {
     resetStore();
     if (logger) {
       return createStore(logger).store;
-    } else {
-      return createStore().store;
     }
+    return createStore().store;
   }, [logger]);
 
   useEffect(() => {

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,9 +1,8 @@
 import { FunctionComponent, ReactElement, useMemo } from 'react';
-import { Tab, Tabs, TabTitleText, Text } from '@patternfly/react-core';
+import { Grid, Tab, Tabs, TabTitleText, Text } from '@patternfly/react-core';
 import { Routes, Route, Navigate, useLocation, Link } from 'react-router-dom';
 import { global_Color_100, global_BackgroundColor_100 } from '@patternfly/react-tokens';
 import {
-  Main,
   PageHeader as _PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components';
@@ -39,6 +38,9 @@ const useStyles = createUseStyles({
     '&:focus-visible': {
       outlineOffset: '-6px',
     },
+  },
+  containerMargin: {
+    margin: '24px',
   },
 });
 
@@ -95,9 +97,9 @@ export default function MainRoutes() {
             path={route}
             element={
               <ErrorPage>
-                <Main>
+                <Grid className={classes.containerMargin}>
                   <Element />
-                </Main>
+                </Grid>
               </ErrorPage>
             }
           />

--- a/src/components/NoPermissionsPage/NoPermissionsPage.tsx
+++ b/src/components/NoPermissionsPage/NoPermissionsPage.tsx
@@ -3,11 +3,11 @@ import {
   EmptyStateBody,
   EmptyStateIcon,
   EmptyStateVariant,
+  Grid,
   Title,
 } from '@patternfly/react-core';
 import { LockIcon } from '@patternfly/react-icons';
 import {
-  Main,
   PageHeader as _PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components';
@@ -22,7 +22,7 @@ export const NoPermissionsPage: React.FunctionComponent = () => (
     <PageHeader>
       <PageHeaderTitle title='Repositories' />
     </PageHeader>
-    <Main>
+    <Grid style={{ margin: '24px' }}>
       <EmptyState variant={EmptyStateVariant.full}>
         <EmptyStateIcon icon={LockIcon} />
         <Title headingLevel='h5' size='lg'>
@@ -32,6 +32,6 @@ export const NoPermissionsPage: React.FunctionComponent = () => (
           Contact your organization administrator(s) for more information.
         </EmptyStateBody>
       </EmptyState>
-    </Main>
+    </Grid>
   </>
 );


### PR DESCRIPTION
Fixes a small issue with the redux store being "null" or undefined.

A fix on the main ReduxProvider was already present but there was the use of "Main" component which was imported from the shared front-end components, which needed to be removed as it was using a provider internally.

NOTE TO QE: your main page container id may have changed, I'm not sure if this will affect your existing tests.