### PR TITLE
Fixes 248: Allow gpgKey URL to be updated via onchange

### DIFF
--- a/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
@@ -119,6 +119,7 @@ const AddContent = ({ isDisabled: isButtonDisabled }: Props) => {
   const { hidePackageVerification, rbac } = useAppContext();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [changeVerified, setChangeVerified] = useState(false);
+  const [gpgKeyList, setGpgKeyList] = useState<Array<string>>(['']);
   const classes = useStyles();
   const queryClient = useQueryClient();
   const formik = useFormik({
@@ -130,10 +131,59 @@ const AddContent = ({ isDisabled: isButtonDisabled }: Props) => {
     onSubmit: () => undefined,
   });
 
+  const updateGpgKey = (index: number, value: string) => {
+    setChangeVerified(false);
+    const updatedData: Array<string> = [...gpgKeyList];
+    updatedData[index] = value;
+    setGpgKeyList(updatedData);
+  };
+
+  const { fetchGpgKey } = useFetchGpgKey();
+
+  const debouncedGpgKeyList = useDebounce(gpgKeyList, 300);
+
+  const updateGpgKeyList = async (list: Array<string>) => {
+    const updatedData = await Promise.all(
+      [...formik.values].map(async (values, index) => {
+        const updateValue = list[index];
+        if (isValidURL(updateValue)) {
+          const result = await fetchGpgKey(updateValue);
+          // If successful
+          if (result !== updateValue) {
+            updateGpgKey(index, result);
+            return {
+              ...values,
+              gpgKey: result,
+              ...(!hidePackageVerification && values.gpgKey === '' && !!updateValue
+                ? {
+                    metadataVerification:
+                      !!validationList?.[index]?.url?.metadata_signature_present,
+                  }
+                : {}),
+            };
+          }
+        }
+        return {
+          ...values,
+          gpgKey: updateValue,
+          ...(!hidePackageVerification && values.gpgKey === '' && !!updateValue
+            ? {
+                metadataVerification: !!validationList?.[index]?.url?.metadata_signature_present,
+              }
+            : {}),
+        };
+      }),
+    );
+
+    formik.setValues(updatedData);
+  };
+
   const { distribution_arches: distArches = [], distribution_versions: distVersions = [] } =
     queryClient.getQueryData<RepositoryParamsResponse>(REPOSITORY_PARAMS_KEY) || {};
 
-  const { fetchGpgKey } = useFetchGpgKey();
+  useEffect(() => {
+    updateGpgKeyList(debouncedGpgKeyList);
+  }, [debouncedGpgKeyList]);
 
   const { distributionArches, distributionVersions } = useMemo(() => {
     const distributionArches = {};
@@ -149,6 +199,7 @@ const AddContent = ({ isDisabled: isButtonDisabled }: Props) => {
     setIsModalOpen(false);
     formik.setTouched([defaultTouchedState]);
     formik.resetForm();
+    setGpgKeyList(['']);
   };
 
   const { mutateAsync: addContent, isLoading: isAdding } = useAddContentQuery(
@@ -593,40 +644,12 @@ const AddContent = ({ isDisabled: isButtonDisabled }: Props) => {
                             type='text'
                             filenamePlaceholder='Drag a file here or upload one'
                             textAreaPlaceholder='Paste GPG key or URL here'
-                            value={gpgKey}
+                            value={gpgKeyList[index]}
                             isLoading={gpgLoading}
                             spellCheck={false}
-                            onDataChange={(value) => updateVariable(index, { gpgKey: value })}
-                            onPaste={async ({ clipboardData }) => {
-                              const value = clipboardData.getData('text');
-                              if (isValidURL(value)) {
-                                updateVariable(index, { gpgLoading: true });
-                                const gpgData = await fetchGpgKey(value);
-                                updateVariable(index, {
-                                  gpgKey: gpgData,
-                                  gpgLoading: false,
-                                  ...(!hidePackageVerification && gpgKey === '' && !!value
-                                    ? {
-                                        metadataVerification:
-                                          !!validationList?.[index]?.url
-                                            ?.metadata_signature_present,
-                                      }
-                                    : {}),
-                                });
-                              }
-                            }}
-                            onTextChange={(value) =>
-                              updateVariable(index, {
-                                gpgKey: value,
-                                ...(!hidePackageVerification && gpgKey === '' && !!value
-                                  ? {
-                                      metadataVerification:
-                                        !!validationList?.[index]?.url?.metadata_signature_present,
-                                    }
-                                  : {}),
-                              })
-                            }
-                            onClearClick={() => updateVariable(index, { gpgKey: '' })}
+                            onDataChange={(value) => updateGpgKey(index, value)}
+                            onTextChange={(value) => updateGpgKey(index, value)}
+                            onClearClick={() => updateGpgKey(index, '')}
                             dropzoneProps={{
                               accept: '.txt',
                               maxSize: 4096,

--- a/src/Pages/ContentListTable/components/AddContent/helpers.ts
+++ b/src/Pages/ContentListTable/components/AddContent/helpers.ts
@@ -19,6 +19,7 @@ export const REGEX_URL =
   /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
 
 export const isValidURL = (val: string) => {
+  if (!val) return false;
   const regex = new RegExp(REGEX_URL);
   return val.match(regex);
 };

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentModal.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentModal.tsx
@@ -97,6 +97,9 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
   const { hidePackageVerification } = useAppContext();
   const initialValues = mapToDefaultFormikValues(values);
   const [changeVerified, setChangeVerified] = useState(false);
+  const [gpgKeyList, setGpgKeyList] = useState<Array<string>>(
+    initialValues.map(({ gpgKey }) => gpgKey),
+  );
   const classes = useStyles();
   const queryClient = useQueryClient();
   const formik = useFormik({
@@ -112,8 +115,61 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
     () => !isEqual(initialValues, formik.values),
     [initialValues, formik.values],
   );
+
+  const updateGpgKey = (index: number, value: string) => {
+    setChangeVerified(false);
+    const updatedData: Array<string> = [...gpgKeyList];
+    updatedData[index] = value;
+    setGpgKeyList(updatedData);
+  };
+
+  const { fetchGpgKey } = useFetchGpgKey();
+
+  const debouncedGpgKeyList = useDebounce(gpgKeyList, 300);
+
+  const updateGpgKeyList = async (list: Array<string>) => {
+    const updatedData = await Promise.all(
+      [...formik.values].map(async (values, index) => {
+        const updateValue = list[index];
+        if (isValidURL(updateValue)) {
+          const result = await fetchGpgKey(updateValue);
+          // If successful
+          if (result !== updateValue) {
+            updateGpgKey(index, result);
+            return {
+              ...values,
+              gpgKey: result,
+              ...(!hidePackageVerification && values.gpgKey === '' && !!updateValue
+                ? {
+                    metadataVerification:
+                      !!validationList?.[index]?.url?.metadata_signature_present,
+                  }
+                : {}),
+            };
+          }
+        }
+
+        return {
+          ...values,
+          gpgKey: updateValue,
+          ...(!hidePackageVerification && values.gpgKey === '' && !!updateValue
+            ? {
+                metadataVerification: !!validationList?.[index]?.url?.metadata_signature_present,
+              }
+            : {}),
+        };
+      }),
+    );
+
+    formik.setValues(updatedData);
+  };
+
   const { distribution_arches: distArches = [], distribution_versions: distVersions = [] } =
     queryClient.getQueryData<RepositoryParamsResponse>(REPOSITORY_PARAMS_KEY) || {};
+
+  useEffect(() => {
+    updateGpgKeyList(debouncedGpgKeyList);
+  }, [debouncedGpgKeyList]);
 
   const { distributionArches, distributionVersions } = useMemo(() => {
     const distributionArches = {};
@@ -126,14 +182,13 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
   const closeModal = () => {
     setClosed();
     formik.resetForm();
+    setGpgKeyList(['']);
   };
 
   const { mutateAsync: editContent, isLoading: isEditing } = useEditContentQuery(
     queryClient,
     mapFormikToEditAPIValues(formik.values),
   );
-
-  const { fetchGpgKey } = useFetchGpgKey();
 
   const createDataLengthOf1 = formik.values.length === 1;
 
@@ -459,45 +514,18 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
                       helperTextInvalid={formik.errors[index]?.gpgKey}
                     >
                       <FileUpload
+                        validated={getFieldValidation(index, 'gpgKey')}
                         id='gpgKey-uploader'
                         aria-label='gpgkey_file_to_upload'
                         type='text'
                         filenamePlaceholder='Drag a file here or upload one'
                         textAreaPlaceholder='Paste GPG key or URL here'
-                        value={gpgKey}
+                        value={gpgKeyList[index]}
                         isLoading={gpgLoading}
-                        validated={getFieldValidation(index, 'gpgKey')}
                         spellCheck={false}
-                        onDataChange={(value) => updateVariable(index, { gpgKey: value })}
-                        onPaste={async ({ clipboardData }) => {
-                          const value = clipboardData.getData('text');
-                          if (isValidURL(value)) {
-                            updateVariable(index, { gpgLoading: true });
-                            const gpgData = await fetchGpgKey(value);
-                            updateVariable(index, {
-                              gpgKey: gpgData,
-                              gpgLoading: false,
-                              ...(!hidePackageVerification && gpgKey === '' && !!value
-                                ? {
-                                    metadataVerification:
-                                      !!validationList?.[index]?.url?.metadata_signature_present,
-                                  }
-                                : {}),
-                            });
-                          }
-                        }}
-                        onTextChange={(value) =>
-                          updateVariable(index, {
-                            gpgKey: value,
-                            ...(!hidePackageVerification && gpgKey === '' && !!value
-                              ? {
-                                  metadataVerification:
-                                    !!validationList?.[index]?.url?.metadata_signature_present,
-                                }
-                              : {}),
-                          })
-                        }
-                        onClearClick={() => updateVariable(index, { gpgKey: '' })}
+                        onDataChange={(value) => updateGpgKey(index, value)}
+                        onTextChange={(value) => updateGpgKey(index, value)}
+                        onClearClick={() => updateGpgKey(index, '')}
                         dropzoneProps={{
                           accept: '.txt',
                           maxSize: 4096,


### PR DESCRIPTION
This updates the gpgKey input in both the Edit/Add content modals to use a new separate debounce for the gpgKey value via onchange. 