### PR TITLE
Fixes 318: Fix for Nan value upon deletion error 

### DIFF
--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -58,6 +58,7 @@ export const useContentListQuery = (
   const [pollCount, setPollCount] = useState(0);
 
   return useQuery<ContentListResponse>(
+    // Below MUST match the "contentListKeyArray" seen below in the useDeleteContent.
     [CONTENT_LIST_KEY, page, limit, sortBy, ...Object.values(filterData)],
     () => getContentList(page, limit, filterData, sortBy),
     {
@@ -201,12 +202,13 @@ export const useDeleteContentItemMutate = (
   filterData?: FilterData,
   sortString?: string,
 ) => {
+  // Below MUST match the "useContentList" key found above or updates will fail.
   const contentListKeyArray = [
     CONTENT_LIST_KEY,
     page,
     perPage,
-    ...Object.values(filterData || {}),
     sortString,
+    ...Object.values(filterData || {}),
   ];
   const { notify } = useNotification();
   return useMutation(deleteContentListItem, {


### PR DESCRIPTION
Fix for Nan value on pagination component upon deleting an item from the list.

To recreate, simply have a list of greater than 10 items, set the pagination perPage value to 10 and delete 1 item on the first page. 
Looking at the console without this change you should see a react error around Nan values (if using a 3g network connection setting this is also viewable in the pagination component as "Nan")