### PR TITLE
Fixes 1116: Can't upload non-txt gpg key

### DIFF
--- a/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
@@ -635,8 +635,7 @@ const AddContent = ({ isDisabled: isButtonDisabled }: Props) => {
                             onTextChange={(value) => updateGpgKey(index, value)}
                             onClearClick={() => updateGpgKey(index, '')}
                             dropzoneProps={{
-                              accept: '.txt',
-                              maxSize: 4096,
+                              maxSize: 8096,
                               onDropRejected: (e) => console.log('onDropRejected', e),
                             }}
                             allowEditingUploadedText

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentModal.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentModal.tsx
@@ -536,8 +536,7 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
                         onTextChange={(value) => updateGpgKey(index, value)}
                         onClearClick={() => updateGpgKey(index, '')}
                         dropzoneProps={{
-                          accept: '.txt',
-                          maxSize: 4096,
+                          maxSize: 8096,
                           onDropRejected: (e) => console.log('onDropRejected', e),
                         }}
                         allowEditingUploadedText


### PR DESCRIPTION
removes the .txt requirement
slightly increases max filesize to 8096 (bytes).
Most gpg-keys would be under 4000 but this gives us some headroom for larger keys.