### PR TITLE
Fixes 1173: Add optimistic updates to popular repositories

### DIFF
--- a/src/Pages/PopularRepositoriesTable/PopularRepositoriesTable.test.tsx
+++ b/src/Pages/PopularRepositoriesTable/PopularRepositoriesTable.test.tsx
@@ -21,8 +21,8 @@ const EPEL_9 = {
 jest.mock('../../services/Content/ContentQueries', () => ({
   useRepositoryParams: jest.fn(),
   usePopularRepositoriesQuery: jest.fn(),
-  useAddContentQuery: () => ({ isLoading: false }),
-  useDeleteContentItemMutate: () => ({ isLoading: false }),
+  useAddPopularRepositoryQuery: () => ({ isLoading: false }),
+  useDeletePopularRepositoryMutate: () => ({ isLoading: false }),
   useFetchGpgKey: () => ({ fetchGpgKey: () => '' }),
 }));
 

--- a/src/Pages/PopularRepositoriesTable/PopularRepositoriesTable.tsx
+++ b/src/Pages/PopularRepositoriesTable/PopularRepositoriesTable.tsx
@@ -23,11 +23,11 @@ import { SkeletonTable } from '@redhat-cloud-services/frontend-components';
 
 import {
   usePopularRepositoriesQuery,
-  useDeleteContentItemMutate,
+  useDeletePopularRepositoryMutate,
   useRepositoryParams,
-  useAddContentQuery,
+  useAddPopularRepositoryQuery,
 } from '../../services/Content/ContentQueries';
-import { CreateContentRequest } from '../../services/Content/ContentApi';
+import { CreateContentRequest, FilterData } from '../../services/Content/ContentApi';
 import Hide from '../../components/Hide/Hide';
 import { useQueryClient } from 'react-query';
 import { useAppContext } from '../../middleware/AppContext';
@@ -122,9 +122,12 @@ const PopularRepositoriesTable = () => {
     },
   } = useRepositoryParams();
 
-  const { mutateAsync: addContentQuery, isLoading: isAdding } = useAddContentQuery(
+  const { mutateAsync: addContentQuery, isLoading: isAdding } = useAddPopularRepositoryQuery(
     queryClient,
     selectedData,
+    page,
+    perPage,
+    { searchQuery: debouncedSearchValue } as FilterData,
   );
 
   useEffect(() => {
@@ -173,10 +176,11 @@ const PopularRepositoriesTable = () => {
       .map(({ name }) => name)
       .join(', ');
 
-  const { mutateAsync: deleteItem, isLoading: isDeleting } = useDeleteContentItemMutate(
+  const { mutateAsync: deleteItem, isLoading: isDeleting } = useDeletePopularRepositoryMutate(
     queryClient,
     page,
     perPage,
+    { searchQuery: debouncedSearchValue } as FilterData,
   );
 
   // Other update actions will be added to this later.
@@ -365,7 +369,7 @@ const PopularRepositoriesTable = () => {
                       >
                         {uuid ? (
                           <Button
-                            isDisabled={uuid === selectedUUID || isFetching || isDeleting}
+                            isDisabled={uuid === selectedUUID || isAdding}
                             onClick={() => setSelectedUUID(uuid)}
                             variant='danger'
                             ouiaId='remove_popular_repo'
@@ -375,7 +379,7 @@ const PopularRepositoriesTable = () => {
                         ) : (
                           <Button
                             variant='secondary'
-                            isDisabled={selectedData[key]?.url === url || isFetching || isAdding}
+                            isDisabled={selectedData[key]?.url === url || isFetching || isDeleting}
                             onClick={() => {
                               const newData: CreateContentRequest = [];
                               newData[key] = {


### PR DESCRIPTION
This change makes it so that the Add/Delete options in popular repositories update the list "optimistically", IE before getting a response from the API. 

One should now be able to perform back to back to actions when clicking add or remove (not both) .
![Add](https://user-images.githubusercontent.com/38083295/218866976-06f2290b-788b-490b-a484-da11ccd55f3b.gif)
![Deleting](https://user-images.githubusercontent.com/38083295/218866996-10b113ae-8d94-4c17-aa3d-037d65fcd57c.gif)

FYI QE: To test this make sure to [slow down your network speed ](https://www.browserstack.com/guide/how-to-perform-network-throttling-in-chrome)in the browser.