### PR TITLE
Change navItem href in frontend YAML

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -21,7 +21,7 @@ objects:
       navItems:
         - appId: "content-sources"
           title: "Repositories"
-          href: "/insights/content"
+          href: "/settings/content"
           product: "Content"
       module:
         manifestLocation: "/apps/content-sources/fed-mods.json"


### PR DESCRIPTION
Change the navItems[0].href in the Frontend template to match what chrome is expecting to build the All Services menu