### PR TITLE
Refs 1672: increase max gpg upload size

### DIFF
--- a/src/Pages/ContentListTable/components/AddContent/helpers.test.ts
+++ b/src/Pages/ContentListTable/components/AddContent/helpers.test.ts
@@ -4,7 +4,7 @@ import {
   failedFileUpload,
   isValidURL,
   mapFormikToAPIValues,
-  mapValidationData,
+  mapValidationData, maxUploadSize
 } from './helpers';
 
 it('REGEX_URL', () => {
@@ -80,7 +80,7 @@ it('mapValidationData', () => {
 it('Notifies on file upload failure due to size', () => {
   const notif = jest.fn((payload) => payload);
   const f = new File([''], 'filename', { type: 'text/html' });
-  Object.defineProperty(f, 'size', { value: 9000 });
+  Object.defineProperty(f, 'size', { value: maxUploadSize+1 });
 
   failedFileUpload([f], notif);
   expect(notif.mock.calls).toHaveLength(1);

--- a/src/Pages/ContentListTable/components/AddContent/helpers.ts
+++ b/src/Pages/ContentListTable/components/AddContent/helpers.ts
@@ -103,7 +103,7 @@ export const makeValidationSchema = () => {
   );
 };
 
-export const maxUploadSize = 8096;
+export const maxUploadSize = 32000;
 export const failedFileUpload = (files: File[], notify: (arg: NotificationPayload) => void) => {
   let description = 'Check the file and try again.';
   if (files.length != 1) {


### PR DESCRIPTION
## Summary
A particular gpg key file was found to be above the max upload size (max upload size was 8.096kB, file was 14.96kB).

I increased the limit to 32kB.
## Testing steps
1. Create this repo: https://dl.google.com/linux/chrome/rpm/stable/x86_64
2. Uploading this gpg key: https://dl.google.com/linux/linux_signing_key.pub
3. Before the changes it will fail because the file size is too big.
4. Could also test with files above/below the 32kB limit.
