### PR TITLE
Fixes 1518: Refactor/centralize react test data

### DIFF
--- a/src/Pages/ContentListTable/components/AddContent/helpers.test.ts
+++ b/src/Pages/ContentListTable/components/AddContent/helpers.test.ts
@@ -4,7 +4,8 @@ import {
   failedFileUpload,
   isValidURL,
   mapFormikToAPIValues,
-  mapValidationData, maxUploadSize
+  mapValidationData,
+  maxUploadSize,
 } from './helpers';
 
 it('REGEX_URL', () => {
@@ -80,7 +81,7 @@ it('mapValidationData', () => {
 it('Notifies on file upload failure due to size', () => {
   const notif = jest.fn((payload) => payload);
   const f = new File([''], 'filename', { type: 'text/html' });
-  Object.defineProperty(f, 'size', { value: maxUploadSize+1 });
+  Object.defineProperty(f, 'size', { value: maxUploadSize + 1 });
 
   failedFileUpload([f], notif);
   expect(notif.mock.calls).toHaveLength(1);

--- a/src/Pages/ContentListTable/components/AddContent/helpers.ts
+++ b/src/Pages/ContentListTable/components/AddContent/helpers.ts
@@ -99,7 +99,7 @@ export const makeValidationSchema = () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore-next-line
       .uniqueProperty('name', 'Names must be unique')
-      .uniqueProperty('url', "Url's must be unique"),
+      .uniqueProperty('url', 'Url\'s must be unique'),
   );
 };
 

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentModal.test.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentModal.test.tsx
@@ -1,4 +1,5 @@
 import {
+  defaultContentItem,
   passingValidationErrorData,
   ReactQueryTestWrapper,
   testRepositoryParamsResponse,
@@ -7,25 +8,17 @@ import EditContentModal from './EditContentModal';
 import { act, fireEvent, render } from '@testing-library/react';
 import { useValidateContentList } from '../../../../services/Content/ContentQueries';
 import { useQueryClient } from 'react-query';
+import { ContentItem } from '../../../../services/Content/ContentApi';
 
-const singleEditValues = [
-  {
-    uuid: 'a68feaa3-9746-4719-8e33-3ff4688fed85',
-    name: 'google',
-    url: 'https://www.google.com',
-    distribution_versions: ['7'],
-    package_count: 24,
-    distribution_arch: 'x86_64',
-    status: 'Pending',
-    last_introspection_error: '',
-    last_introspection_time: '2023-03-07 17:13:48.619192 -0500 EST',
-    failed_introspections_count: 0,
-    account_id: '6414238',
-    org_id: '13446804',
-    gpg_key: 'test GPG key',
-    metadata_verification: false,
-  },
-];
+const editItem: ContentItem = {
+  ...defaultContentItem,
+  name: 'google',
+  url: 'https://www.google.com',
+  distribution_versions: ['7'],
+  distribution_arch: 'x86_64',
+  gpg_key: 'test GPG key',
+  metadata_verification: false,
+};
 
 jest.mock('../../../../services/Content/ContentQueries', () => ({
   useEditContentQuery: () => ({ isLoading: false }),
@@ -56,7 +49,7 @@ it('Open, confirming values, edit an item, enabling Save button', async () => {
 
   const { queryByText, queryByPlaceholderText, queryAllByLabelText } = render(
     <ReactQueryTestWrapper>
-      <EditContentModal open values={singleEditValues} setClosed={() => undefined} />
+      <EditContentModal open values={[editItem]} setClosed={() => undefined} />
     </ReactQueryTestWrapper>,
   );
 
@@ -65,12 +58,12 @@ it('Open, confirming values, edit an item, enabling Save button', async () => {
   ).toBeInTheDocument();
   const NameTextfield = queryByPlaceholderText('Enter name');
   expect(NameTextfield).toBeInTheDocument();
-  expect(NameTextfield).toHaveAttribute('value', singleEditValues[0].name);
+  expect(NameTextfield).toHaveAttribute('value', editItem.name);
 
   const UrlTextfield = queryByPlaceholderText('https://');
   expect(UrlTextfield).toBeInTheDocument();
-  expect(UrlTextfield).toHaveAttribute('value', singleEditValues[0].url);
-  expect(queryByText(singleEditValues[0].distribution_arch)).toBeInTheDocument();
+  expect(UrlTextfield).toHaveAttribute('value', editItem.url);
+  expect(queryByText(editItem.distribution_arch)).toBeInTheDocument();
   expect(queryByText('el7')).toBeInTheDocument();
   expect(queryByText('No changes')).toBeInTheDocument();
   const optionsMenuButton = queryAllByLabelText('Options menu')[1];

--- a/src/Pages/ContentListTable/components/PackageCount.test.tsx
+++ b/src/Pages/ContentListTable/components/PackageCount.test.tsx
@@ -1,68 +1,27 @@
 import { render } from '@testing-library/react';
 import PackageCount from './PackageCount';
+import { defaultContentItem } from '../../../testingHelpers';
 
 it('Render PackageCount for Invalid state', async () => {
-  const data = {
-    uuid: '',
-    name: '',
-    package_count: 100,
-    url: '',
-    status: 'Invalid',
-    account_id: '',
-    distribution_arch: '',
-    gpg_key: '',
-    distribution_versions: [''],
-    last_introspection_error: '',
-    last_introspection_time: '2023-03-07 17:13:48.619192 -0500 EST',
-    failed_introspections_count: 0,
-    metadata_verification: false,
-    org_id: 'acme',
-  };
-  const { queryByText } = render(<PackageCount rowData={data} />);
+  const { queryByText } = render(
+    <PackageCount rowData={{ ...defaultContentItem, status: 'Invalid' }} />,
+  );
 
   expect(queryByText('N/A')).toBeInTheDocument();
 });
 
 it('Render PackageCount for Pending state', () => {
-  const data = {
-    uuid: '',
-    name: '',
-    package_count: 0,
-    url: '',
-    status: 'Pending',
-    account_id: '',
-    distribution_arch: '',
-    gpg_key: '',
-    distribution_versions: [''],
-    last_introspection_error: '',
-    last_introspection_time: '2023-03-07 17:13:48.619192 -0500 EST',
-    failed_introspections_count: 0,
-    metadata_verification: false,
-    org_id: 'acme',
-  };
-  const { queryByText } = render(<PackageCount rowData={data} />);
+  const { queryByText } = render(
+    <PackageCount rowData={{ ...defaultContentItem, package_count: 0 }} />,
+  );
 
   expect(queryByText('N/A')).toBeInTheDocument();
 });
 
 it('Render PackageCount normally', () => {
-  const data = {
-    uuid: '88a8417e-65ab-11ed-b54c-482ae3863d30',
-    name: 'My test repository',
-    package_count: 100,
-    url: 'https://www.example.test/my-repository',
-    status: 'Valid',
-    account_id: '',
-    distribution_arch: 'x86_64',
-    gpg_key: '',
-    distribution_versions: ['el8'],
-    last_introspection_error: '',
-    last_introspection_time: '2023-03-07 17:13:48.619192 -0500 EST',
-    failed_introspections_count: 0,
-    metadata_verification: false,
-    org_id: 'acme',
-  };
-  const { queryByText } = render(<PackageCount rowData={data} />);
+  const { queryByText } = render(
+    <PackageCount rowData={{ ...defaultContentItem, status: 'Valid' }} />,
+  );
 
   expect(queryByText('100')).toBeInTheDocument();
 });

--- a/src/Pages/ContentListTable/components/PackageModal/PackageModal.test.tsx
+++ b/src/Pages/ContentListTable/components/PackageModal/PackageModal.test.tsx
@@ -1,26 +1,15 @@
 import { render } from '@testing-library/react';
 import PackageModal from './PackageModal';
 import { ContentItem, PackageItem } from '../../../../services/Content/ContentApi';
-import { ReactQueryTestWrapper } from '../../../../testingHelpers';
+import { ReactQueryTestWrapper, defaultContentItem } from '../../../../testingHelpers';
 import { useGetPackagesQuery } from '../../../../services/Content/ContentQueries';
 
 const rowData: ContentItem = {
+  ...defaultContentItem,
   // Used variables
   uuid: 'boop-beep-boop-blop',
   name: 'steve',
   package_count: 0,
-  // Placeholders for TS
-  url: '',
-  distribution_versions: [],
-  distribution_arch: '',
-  account_id: '',
-  org_id: '',
-  status: '',
-  last_introspection_error: '',
-  last_introspection_time: '2023-03-07 17:13:48.619192 -0500 EST',
-  failed_introspections_count: 0,
-  gpg_key: '',
-  metadata_verification: false,
 };
 
 const packageItem: PackageItem = {

--- a/src/Pages/ContentListTable/components/StatusIcon.test.tsx
+++ b/src/Pages/ContentListTable/components/StatusIcon.test.tsx
@@ -1,50 +1,39 @@
 import { act, render, waitFor } from '@testing-library/react';
 import StatusIcon from './StatusIcon';
-import { ContentItem } from '../../../services/Content/ContentApi';
-
-const defaultData: ContentItem = {
-  uuid: '',
-  name: '',
-  package_count: 100,
-  url: '',
-  status: 'Pending',
-  account_id: '',
-  org_id: 'acme',
-  distribution_arch: '',
-  gpg_key: '',
-  distribution_versions: [''],
-  last_introspection_error: '',
-  last_introspection_time: '2023-03-07 17:13:48.619192 -0500 EST',
-  failed_introspections_count: 0,
-  metadata_verification: false,
-};
+import { defaultContentItem } from '../../../testingHelpers';
 
 jest.mock('../../../middleware/AppContext', () => ({
   useAppContext: () => ({ rbac: { read: true, write: true } }),
 }));
 
 it('Render with Pending status', () => {
-  const { queryByText } = render(<StatusIcon rowData={{ ...defaultData, status: 'Pending' }} />);
+  const { queryByText } = render(
+    <StatusIcon rowData={{ ...defaultContentItem, status: 'Pending' }} />,
+  );
 
   const SelectComponent = queryByText('In progress');
   expect(SelectComponent).toBeInTheDocument();
 });
 
 it('Render with Valid status', () => {
-  const { queryByText } = render(<StatusIcon rowData={{ ...defaultData, status: 'Valid' }} />);
+  const { queryByText } = render(
+    <StatusIcon rowData={{ ...defaultContentItem, status: 'Valid' }} />,
+  );
   const SelectComponent = queryByText('Valid');
   expect(SelectComponent).toBeInTheDocument();
 });
 
 it('Render with Invalid status', () => {
-  const { queryByText } = render(<StatusIcon rowData={{ ...defaultData, status: 'Invalid' }} />);
+  const { queryByText } = render(
+    <StatusIcon rowData={{ ...defaultContentItem, status: 'Invalid' }} />,
+  );
   const SelectComponent = queryByText('Invalid');
   expect(SelectComponent).toBeInTheDocument();
 });
 
 it('Render with Unavailable status', async () => {
   const { queryByText } = render(
-    <StatusIcon rowData={{ ...defaultData, status: 'Unavailable' }} />,
+    <StatusIcon rowData={{ ...defaultContentItem, status: 'Unavailable' }} />,
   );
   const SelectComponent = queryByText('Unavailable');
   expect(SelectComponent).toBeInTheDocument();
@@ -59,7 +48,9 @@ it('Render with Unavailable status', async () => {
 });
 
 it('Render with Invalid status', async () => {
-  const { queryByText } = render(<StatusIcon rowData={{ ...defaultData, status: 'Invalid' }} />);
+  const { queryByText } = render(
+    <StatusIcon rowData={{ ...defaultContentItem, status: 'Invalid' }} />,
+  );
   const SelectComponent = queryByText('Invalid');
   expect(SelectComponent).toBeInTheDocument();
 

--- a/src/Pages/PopularRepositoriesTable/PopularRepositoriesTable.test.tsx
+++ b/src/Pages/PopularRepositoriesTable/PopularRepositoriesTable.test.tsx
@@ -1,22 +1,14 @@
 import { render } from '@testing-library/react';
-import { ReactQueryTestWrapper, testRepositoryParamsResponse } from '../../testingHelpers';
+import {
+  ReactQueryTestWrapper,
+  defaultPopularRepository,
+  testRepositoryParamsResponse,
+} from '../../testingHelpers';
 import PopularRepositoriesTable from './PopularRepositoriesTable';
 import {
   usePopularRepositoriesQuery,
   useRepositoryParams,
 } from '../../services/Content/ContentQueries';
-
-const EPEL_9 = {
-  uuid: '',
-  existing_name: '',
-  suggested_name: 'EPEL 9 Everything x86_64',
-  url: 'https://download-i2.fedoraproject.org/pub/epel/9/Everything/x86_64/',
-  distribution_versions: ['9'],
-  distribution_arch: 'x86_64',
-  gpg_key:
-    '-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGE3mOsBEACsU+XwJWDJVkItBaugXhXIIkb9oe+7aadELuVo0kBmc3HXt/Yp\nCJW9hHEiGZ6z2jwgPqyJjZhCvcAWvgzKcvqE+9i0NItV1rzfxrBe2BtUtZmVcuE6\n2b+SPfxQ2Hr8llaawRjt8BCFX/ZzM4/1Qk+EzlfTcEcpkMf6wdO7kD6ulBk/tbsW\nDHX2lNcxszTf+XP9HXHWJlA2xBfP+Dk4gl4DnO2Y1xR0OSywE/QtvEbN5cY94ieu\nn7CBy29AleMhmbnx9pw3NyxcFIAsEZHJoU4ZW9ulAJ/ogttSyAWeacW7eJGW31/Z\n39cS+I4KXJgeGRI20RmpqfH0tuT+X5Da59YpjYxkbhSK3HYBVnNPhoJFUc2j5iKy\nXLgkapu1xRnEJhw05kr4LCbud0NTvfecqSqa+59kuVc+zWmfTnGTYc0PXZ6Oa3rK\n44UOmE6eAT5zd/ToleDO0VesN+EO7CXfRsm7HWGpABF5wNK3vIEF2uRr2VJMvgqS\n9eNwhJyOzoca4xFSwCkc6dACGGkV+CqhufdFBhmcAsUotSxe3zmrBjqA0B/nxIvH\nDVgOAMnVCe+Lmv8T0mFgqZSJdIUdKjnOLu/GRFhjDKIak4jeMBMTYpVnU+HhMHLq\nuDiZkNEvEEGhBQmZuI8J55F/a6UURnxUwT3piyi3Pmr2IFD7ahBxPzOBCQARAQAB\ntCdGZWRvcmEgKGVwZWw5KSA8ZXBlbEBmZWRvcmFwcm9qZWN0Lm9yZz6JAk4EEwEI\nADgWIQT/itE0RZcQbs6BO5GKOHK/MihGfAUCYTeY6wIbDwULCQgHAgYVCgkICwIE\nFgIDAQIeAQIXgAAKCRCKOHK/MihGfFX/EACBPWv20+ttYu1A5WvtHJPzwbj0U4yF\n3zTQpBglQ2UfkRpYdipTlT3Ih6j5h2VmgRPtINCc/ZE28adrWpBoeFIS2YAKOCLC\nnZYtHl2nCoLq1U7FSttUGsZ/t8uGCBgnugTfnIYcmlP1jKKA6RJAclK89evDQX5n\nR9ZD+Cq3CBMlttvSTCht0qQVlwycedH8iWyYgP/mF0W35BIn7NuuZwWhgR00n/VG\n4nbKPOzTWbsP45awcmivdrS74P6mL84WfkghipdmcoyVb1B8ZP4Y/Ke0RXOnLhNe\nCfrXXvuW+Pvg2RTfwRDtehGQPAgXbmLmz2ZkV69RGIr54HJv84NDbqZovRTMr7gL\n9k3ciCzXCiYQgM8yAyGHV0KEhFSQ1HV7gMnt9UmxbxBE2pGU7vu3CwjYga5DpwU7\nw5wu1TmM5KgZtZvuWOTDnqDLf0cKoIbW8FeeCOn24elcj32bnQDuF9DPey1mqcvT\n/yEo/Ushyz6CVYxN8DGgcy2M9JOsnmjDx02h6qgWGWDuKgb9jZrvRedpAQCeemEd\nfhEs6ihqVxRFl16HxC4EVijybhAL76SsM2nbtIqW1apBQJQpXWtQwwdvgTVpdEtE\nr4ArVJYX5LrswnWEQMOelugUG6S3ZjMfcyOa/O0364iY73vyVgaYK+2XtT2usMux\nVL469Kj5m13T6w==\n=Mjs/\n-----END PGP PUBLIC KEY BLOCK-----',
-  metadata_verification: false,
-};
 
 jest.mock('../../services/Content/ContentQueries', () => ({
   useRepositoryParams: jest.fn(),
@@ -34,7 +26,7 @@ it('expect PopularRepositoriesTable to render with one item', () => {
   (useRepositoryParams as jest.Mock).mockImplementation(() => ({ isLoading: false }));
   (usePopularRepositoriesQuery as jest.Mock).mockImplementation(() => ({
     isLoading: false,
-    data: { data: [EPEL_9], meta: { count: 1, limit: 20, offset: 0 } },
+    data: { data: [defaultPopularRepository], meta: { count: 1, limit: 20, offset: 0 } },
   }));
 
   const { queryByText } = render(
@@ -43,8 +35,8 @@ it('expect PopularRepositoriesTable to render with one item', () => {
     </ReactQueryTestWrapper>,
   );
 
-  expect(queryByText(EPEL_9.suggested_name)).toBeInTheDocument();
-  expect(queryByText(EPEL_9.url)).toBeInTheDocument();
+  expect(queryByText(defaultPopularRepository.suggested_name)).toBeInTheDocument();
+  expect(queryByText(defaultPopularRepository.url)).toBeInTheDocument();
   expect(queryByText('Add')).toBeInTheDocument();
 });
 
@@ -53,7 +45,7 @@ it('expect PopularRepositoriesTable to render with one item', () => {
   (usePopularRepositoriesQuery as jest.Mock).mockImplementation(() => ({
     isLoading: false,
     data: {
-      data: [{ ...EPEL_9, uuid: 'ifThisExistsThanButtonIsRemove' }],
+      data: [{ ...defaultPopularRepository, uuid: 'ifThisExistsThanButtonIsRemove' }],
       meta: { count: 1, limit: 20, offset: 0 },
     },
   }));
@@ -64,8 +56,8 @@ it('expect PopularRepositoriesTable to render with one item', () => {
     </ReactQueryTestWrapper>,
   );
 
-  expect(queryByText(EPEL_9.suggested_name)).toBeInTheDocument();
-  expect(queryByText(EPEL_9.url)).toBeInTheDocument();
+  expect(queryByText(defaultPopularRepository.suggested_name)).toBeInTheDocument();
+  expect(queryByText(defaultPopularRepository.url)).toBeInTheDocument();
   expect(queryByText('Remove')).toBeInTheDocument();
 });
 

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -17,7 +17,7 @@ export interface ContentItem {
   metadata_verification: boolean;
 }
 
-export interface PopularRepositories {
+export interface PopularRepository {
   uuid: string;
   existing_name: string;
   suggested_name: string;
@@ -85,7 +85,7 @@ export interface ContentListResponse {
 }
 
 export interface PopularRepositoriesResponse {
-  data: PopularRepositories[];
+  data: PopularRepository[];
   links: Links;
   meta: Meta;
 }

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -1,5 +1,10 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { RepositoryParamsResponse, ValidationResponse } from './services/Content/ContentApi';
+import {
+  ContentItem,
+  PopularRepository,
+  RepositoryParamsResponse,
+  ValidationResponse,
+} from './services/Content/ContentApi';
 
 const queryClient = new QueryClient({
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -106,3 +111,32 @@ export const passingValidationErrorData: ValidationResponse = [
     },
   },
 ];
+
+export const defaultContentItem: ContentItem = {
+  uuid: '',
+  name: '',
+  package_count: 100,
+  url: '',
+  status: 'Pending',
+  account_id: '',
+  org_id: 'acme',
+  distribution_arch: '',
+  gpg_key: '',
+  distribution_versions: [''],
+  last_introspection_error: '',
+  last_introspection_time: '2023-03-07 17:13:48.619192 -0500 EST',
+  failed_introspections_count: 0,
+  metadata_verification: false,
+};
+
+export const defaultPopularRepository: PopularRepository = {
+  uuid: '',
+  existing_name: '',
+  suggested_name: 'EPEL 9 Everything x86_64',
+  url: 'https://download-i2.fedoraproject.org/pub/epel/9/Everything/x86_64/',
+  distribution_versions: ['9'],
+  distribution_arch: 'x86_64',
+  gpg_key:
+    '-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGE3mOsBEACsU+XwJWDJVkItBaugXhXIIkb9oe+7aadELuVo0kBmc3HXt/Yp\nCJW9hHEiGZ6z2jwgPqyJjZhCvcAWvgzKcvqE+9i0NItV1rzfxrBe2BtUtZmVcuE6\n2b+SPfxQ2Hr8llaawRjt8BCFX/ZzM4/1Qk+EzlfTcEcpkMf6wdO7kD6ulBk/tbsW\nDHX2lNcxszTf+XP9HXHWJlA2xBfP+Dk4gl4DnO2Y1xR0OSywE/QtvEbN5cY94ieu\nn7CBy29AleMhmbnx9pw3NyxcFIAsEZHJoU4ZW9ulAJ/ogttSyAWeacW7eJGW31/Z\n39cS+I4KXJgeGRI20RmpqfH0tuT+X5Da59YpjYxkbhSK3HYBVnNPhoJFUc2j5iKy\nXLgkapu1xRnEJhw05kr4LCbud0NTvfecqSqa+59kuVc+zWmfTnGTYc0PXZ6Oa3rK\n44UOmE6eAT5zd/ToleDO0VesN+EO7CXfRsm7HWGpABF5wNK3vIEF2uRr2VJMvgqS\n9eNwhJyOzoca4xFSwCkc6dACGGkV+CqhufdFBhmcAsUotSxe3zmrBjqA0B/nxIvH\nDVgOAMnVCe+Lmv8T0mFgqZSJdIUdKjnOLu/GRFhjDKIak4jeMBMTYpVnU+HhMHLq\nuDiZkNEvEEGhBQmZuI8J55F/a6UURnxUwT3piyi3Pmr2IFD7ahBxPzOBCQARAQAB\ntCdGZWRvcmEgKGVwZWw5KSA8ZXBlbEBmZWRvcmFwcm9qZWN0Lm9yZz6JAk4EEwEI\nADgWIQT/itE0RZcQbs6BO5GKOHK/MihGfAUCYTeY6wIbDwULCQgHAgYVCgkICwIE\nFgIDAQIeAQIXgAAKCRCKOHK/MihGfFX/EACBPWv20+ttYu1A5WvtHJPzwbj0U4yF\n3zTQpBglQ2UfkRpYdipTlT3Ih6j5h2VmgRPtINCc/ZE28adrWpBoeFIS2YAKOCLC\nnZYtHl2nCoLq1U7FSttUGsZ/t8uGCBgnugTfnIYcmlP1jKKA6RJAclK89evDQX5n\nR9ZD+Cq3CBMlttvSTCht0qQVlwycedH8iWyYgP/mF0W35BIn7NuuZwWhgR00n/VG\n4nbKPOzTWbsP45awcmivdrS74P6mL84WfkghipdmcoyVb1B8ZP4Y/Ke0RXOnLhNe\nCfrXXvuW+Pvg2RTfwRDtehGQPAgXbmLmz2ZkV69RGIr54HJv84NDbqZovRTMr7gL\n9k3ciCzXCiYQgM8yAyGHV0KEhFSQ1HV7gMnt9UmxbxBE2pGU7vu3CwjYga5DpwU7\nw5wu1TmM5KgZtZvuWOTDnqDLf0cKoIbW8FeeCOn24elcj32bnQDuF9DPey1mqcvT\n/yEo/Ushyz6CVYxN8DGgcy2M9JOsnmjDx02h6qgWGWDuKgb9jZrvRedpAQCeemEd\nfhEs6ihqVxRFl16HxC4EVijybhAL76SsM2nbtIqW1apBQJQpXWtQwwdvgTVpdEtE\nr4ArVJYX5LrswnWEQMOelugUG6S3ZjMfcyOa/O0364iY73vyVgaYK+2XtT2usMux\nVL469Kj5m13T6w==\n=Mjs/\n-----END PGP PUBLIC KEY BLOCK-----',
+  metadata_verification: false,
+};


### PR DESCRIPTION
## Summary

This centralizes both the PublicRepositories and ContentItem default data objects for all tests. 

The resulting centralized values in the tope level testingHelpers.ts file now satisfies the tickets requirements: - Adding a new field to these objects can now be done in a single location.

## Testing steps

- no testing steps, passing tests and code review only.