### PR TITLE
Fixes 1473: Add data-ouia-page-safe for QA test usage

### DIFF
--- a/src/Pages/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/ContentListTable/ContentListTable.tsx
@@ -232,13 +232,17 @@ const ContentListTable = () => {
 
   if (countIsZero && notFiltered && !isLoading)
     return (
-      <Bullseye>
+      <Bullseye data-ouia-safe={!actionTakingPlace} data-ouia-component-id='content_list_page'>
         <EmptyTableState notFiltered={notFiltered} clearFilters={clearFilters} />
       </Bullseye>
     );
 
   return (
-    <Grid className={countIsZero ? classes.mainContainer100Height : classes.mainContainer}>
+    <Grid
+      data-ouia-safe={!actionTakingPlace}
+      data-ouia-component-id='content_list_page'
+      className={countIsZero ? classes.mainContainer100Height : classes.mainContainer}
+    >
       <EditContentModal
         values={editValues}
         open={editModalOpen}

--- a/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
@@ -144,7 +144,7 @@ const AddContent = ({ isDisabled: isButtonDisabled }: Props) => {
     setGpgKeyList(updatedData);
   };
 
-  const { fetchGpgKey } = useFetchGpgKey();
+  const { fetchGpgKey, isLoading: isFetchingGpgKey } = useFetchGpgKey();
 
   const debouncedGpgKeyList = useDebounce(gpgKeyList, 300);
 
@@ -284,7 +284,11 @@ const AddContent = ({ isDisabled: isButtonDisabled }: Props) => {
 
   let debouncedValues = useDebounce(formik.values) || []; // Initial value of []
 
-  const { mutateAsync: validateContentList, data: validationList } = useValidateContentList();
+  const {
+    mutateAsync: validateContentList,
+    data: validationList,
+    isLoading: isValidating,
+  } = useValidateContentList();
 
   useEffect(() => {
     // If validate is getting called to often, we could useDeepCompare
@@ -371,6 +375,8 @@ const AddContent = ({ isDisabled: isButtonDisabled }: Props) => {
 
   const { notify } = useNotification();
 
+  const actionTakingPlace = isFetchingGpgKey || isAdding || isValidating || !changeVerified;
+
   return (
     <>
       <ConditionalTooltip
@@ -394,6 +400,7 @@ const AddContent = ({ isDisabled: isButtonDisabled }: Props) => {
           variant={ModalVariant.medium}
           title='Add custom repositories'
           ouiaId='add_custom_repository'
+          ouiaSafe={!actionTakingPlace}
           help={
             <Popover
               headerContent={<div>Add a custom repository</div>}

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentModal.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentModal.tsx
@@ -133,7 +133,7 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
     updatedData[index] = value;
     setGpgKeyList(updatedData);
   };
-  const { fetchGpgKey } = useFetchGpgKey();
+  const { fetchGpgKey, isLoading: isFetchingGpgKey } = useFetchGpgKey();
 
   const debouncedGpgKeyList = useDebounce(gpgKeyList, 300);
 
@@ -235,7 +235,11 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
 
   const debouncedValues = useDebounce(formik.values);
 
-  const { mutateAsync: validateContentList, data: validationList } = useValidateContentList();
+  const {
+    mutateAsync: validateContentList,
+    data: validationList,
+    isLoading: isValidating,
+  } = useValidateContentList();
 
   useEffect(() => {
     if (open)
@@ -310,12 +314,15 @@ const EditContentModal = ({ values, open, setClosed }: EditContentProps) => {
 
   const { notify } = useNotification();
 
+  const actionTakingPlace = isFetchingGpgKey || isEditing || isValidating || !changeVerified;
+
   return (
     <Modal
       position='top'
       variant={ModalVariant.medium}
       title='Edit custom repository'
       ouiaId='edit_custom_repository'
+      ouiaSafe={!actionTakingPlace}
       help={
         <Popover
           headerContent={<div>Edit custom repository</div>}

--- a/src/Pages/ContentListTable/components/PackageModal/PackageModal.tsx
+++ b/src/Pages/ContentListTable/components/PackageModal/PackageModal.tsx
@@ -156,6 +156,7 @@ export default function PackageModal({
       hasNoBodyWrapper
       aria-label='RPM package modal'
       ouiaId='rpm_package_modal'
+      ouiaSafe={fetchingOrLoading}
       variant={ModalVariant.medium}
       title='Packages'
       description={

--- a/src/Pages/PopularRepositoriesTable/PopularRepositoriesTable.tsx
+++ b/src/Pages/PopularRepositoriesTable/PopularRepositoriesTable.tsx
@@ -233,7 +233,11 @@ const PopularRepositoriesTable = () => {
   } = data;
 
   return (
-    <Grid className={classes.mainContainer}>
+    <Grid
+      data-ouia-safe={!actionTakingPlace}
+      data-ouia-component-id='popular_repositories_page'
+      className={classes.mainContainer}
+    >
       <Flex className={classes.topContainer}>
         <FlexItem>
           <InputGroup>

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -35,6 +35,7 @@ export interface CreateContentRequestItem {
   distribution_arch?: string;
   gpg_key?: string;
   metadata_verification?: boolean;
+  snapshot?: boolean;
 }
 
 export interface ErrorItem {

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -401,13 +401,15 @@ export const useRepositoryParams = () =>
 
 export const useFetchGpgKey = () => {
   const { notify } = useNotification();
+  const [isLoading, setIsLoading] = useState(false);
 
   const fetchGpgKey = async (url: string): Promise<string> => {
+    setIsLoading(true);
     let gpg_key = url;
     try {
       const data = await getGpgKey(url);
       gpg_key = data.gpg_key;
-    } catch ({ response = {} }) {
+    } catch ({ response = {} }: any) {
       const { data } = response as { data: { message: string | undefined } | string };
       const description = typeof data === 'string' ? data : data?.message;
       notify({
@@ -416,10 +418,11 @@ export const useFetchGpgKey = () => {
         description,
       });
     }
+    setIsLoading(false);
     return gpg_key;
   };
 
-  return { fetchGpgKey };
+  return { fetchGpgKey, isLoading };
 };
 
 export const useGetPackagesQuery = (


### PR DESCRIPTION
## Summary

This satisfies the first acceptance requirement on the 1473 ticket found [here](https://issues.redhat.com/browse/HMS-1473). 

_- A solution including the use of ouia pagesafe [1] would be  ideal._

Further QE test changes are needed to integrate fully.
![ouia-safe](https://github.com/content-services/content-sources-frontend/assets/38083295/3488cdde-0253-407c-8814-37fb073ad5c8)


## Testing steps
