### PR TITLE
Refs 1964: Add snapshot toggle to edit/add modals

### DIFF
--- a/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
@@ -236,7 +236,7 @@ const AddContent = () => {
     formik.setTouched([...formik.touched, defaultTouchedState]);
     formik.setValues([
       ...formik.values.map((vals) => ({ ...vals, expanded: false })),
-      getDefaultFormikValues(),
+      getDefaultFormikValues({ snapshot: snapshottingEnabled }),
     ]);
     setChangeVerified(false);
   };
@@ -518,7 +518,7 @@ const AddContent = () => {
                     <Hide hide={!snapshottingEnabled}>
                       <FormGroup fieldId='snapshot'>
                         <Switch
-                          id='snapshot-switch'
+                          id={'snapshot-switch-' + index}
                           hasCheckIcon
                           label='Snapshot creation enabled'
                           labelOff='Snapshot creation disabled'

--- a/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Switch,
   FileUpload,
   Form,
   FormGroup,
@@ -12,6 +13,7 @@ import {
   StackItem,
   TextInput,
   Tooltip,
+  Alert,
 } from '@patternfly/react-core';
 import {
   OutlinedQuestionCircleIcon,
@@ -32,7 +34,7 @@ import {
   FormikValues,
   maxUploadSize,
   failedFileUpload,
-  defaultFormikValues,
+  getDefaultFormikValues,
 } from './helpers';
 import useNotification from '../../../../Hooks/useNotification';
 import ContentValidity from './components/ContentValidity';
@@ -52,6 +54,7 @@ import useDebounce from '../../../../Hooks/useDebounce';
 import { useNavigate } from 'react-router-dom';
 import { useClearCheckedRepositories } from '../../ContentListTable';
 import useRootPath from '../../../../Hooks/useRootPath';
+import { useAppContext } from '../../../../middleware/AppContext';
 
 const useStyles = createUseStyles({
   description: {
@@ -120,10 +123,15 @@ const AddContent = () => {
   const rootPath = useRootPath();
   const [changeVerified, setChangeVerified] = useState(false);
   const [gpgKeyList, setGpgKeyList] = useState<Array<string>>(['']);
+  const { features } = useAppContext();
+  const snapshottingEnabled = useMemo(
+    () => !!features?.snapshots?.enabled && !!features?.snapshots?.accessible,
+    [!!features?.snapshots?.enabled],
+  );
   const classes = useStyles();
   const queryClient = useQueryClient();
   const formik = useFormik({
-    initialValues: [defaultFormikValues],
+    initialValues: [getDefaultFormikValues({ snapshot: snapshottingEnabled })],
     validateOnBlur: false,
     validateOnChange: false,
     validationSchema: makeValidationSchema(),
@@ -228,7 +236,7 @@ const AddContent = () => {
     formik.setTouched([...formik.touched, defaultTouchedState]);
     formik.setValues([
       ...formik.values.map((vals) => ({ ...vals, expanded: false })),
-      defaultFormikValues,
+      getDefaultFormikValues(),
     ]);
     setChangeVerified(false);
   };
@@ -452,7 +460,17 @@ const AddContent = () => {
         </Hide>
         {formik.values.map(
           (
-            { expanded, name, url, arch, gpgKey, versions, gpgLoading, metadataVerification },
+            {
+              expanded,
+              name,
+              url,
+              arch,
+              gpgKey,
+              versions,
+              gpgLoading,
+              metadataVerification,
+              snapshot,
+            },
             index,
           ) => (
             <Tbody key={index} isExpanded={createDataLengthOf1 ? undefined : expanded}>
@@ -497,6 +515,35 @@ const AddContent = () => {
                   }
                 >
                   <Form>
+                    <Hide hide={!snapshottingEnabled}>
+                      <FormGroup fieldId='snapshot'>
+                        <Switch
+                          id='snapshot-switch'
+                          hasCheckIcon
+                          label='Snapshot creation enabled'
+                          labelOff='Snapshot creation disabled'
+                          isChecked={snapshot}
+                          onChange={() => {
+                            updateVariable(index, { snapshot: !snapshot });
+                          }}
+                        />
+                        <Tooltip content='Automatically create daily snapshots of this repository.'>
+                          <OutlinedQuestionCircleIcon
+                            className='pf-u-ml-xs'
+                            color={global_Color_200.value}
+                          />
+                        </Tooltip>
+                        <Hide hide={snapshot}>
+                          <Alert
+                            variant='warning'
+                            style={{ paddingTop: '10px' }}
+                            title='Disabling snapshots may result in a higher risk of losing content or unintentionally modifying it irreversibly.'
+                            isInline
+                            isPlain
+                          />
+                        </Hide>
+                      </FormGroup>
+                    </Hide>
                     <FormGroup
                       label='Name'
                       isRequired

--- a/src/Pages/ContentListTable/components/AddContent/helpers.test.ts
+++ b/src/Pages/ContentListTable/components/AddContent/helpers.test.ts
@@ -32,6 +32,7 @@ it('mapFormikToAPIValues', () => {
       gpgLoading: false,
       expanded: false,
       metadataVerification: false,
+      snapshot: true,
     },
   ];
 
@@ -43,6 +44,7 @@ it('mapFormikToAPIValues', () => {
       distribution_versions: ['el7'],
       gpg_key: '',
       metadata_verification: false,
+      snapshot: true,
     },
   ];
 

--- a/src/Pages/ContentListTable/components/AddContent/helpers.ts
+++ b/src/Pages/ContentListTable/components/AddContent/helpers.ts
@@ -15,9 +15,10 @@ export interface FormikValues {
   gpgLoading: boolean;
   metadataVerification: boolean;
   expanded: boolean;
+  snapshot: boolean;
 }
 
-export const defaultFormikValues: FormikValues = {
+export const getDefaultFormikValues = (overrides: Partial<FormikValues> = {}): FormikValues => ({
   name: '',
   url: '',
   gpgKey: '',
@@ -26,7 +27,9 @@ export const defaultFormikValues: FormikValues = {
   gpgLoading: false,
   expanded: true,
   metadataVerification: false,
-};
+  snapshot: false,
+  ...overrides,
+});
 
 export const REGEX_URL =
   /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
@@ -38,12 +41,13 @@ export const isValidURL = (val: string) => {
 };
 
 export const mapFormikToAPIValues = (formikValues: FormikValues[]) =>
-  formikValues.map(({ name, url, arch, versions, gpgKey, metadataVerification }) => ({
+  formikValues.map(({ name, url, arch, versions, gpgKey, metadataVerification, snapshot }) => ({
     name,
     url,
     distribution_arch: arch,
     distribution_versions: versions,
     gpg_key: gpgKey,
+    snapshot,
     metadata_verification: metadataVerification,
   }));
 

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
@@ -1,10 +1,14 @@
 import {
+  Alert,
+  Button,
   FileUpload,
   Form,
   FormGroup,
+  Popover,
   Radio,
   SelectVariant,
   TextInput,
+  Switch,
   Tooltip,
 } from '@patternfly/react-core';
 import { CheckCircleIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
@@ -44,6 +48,7 @@ import { isEmpty, isEqual } from 'lodash';
 import ConditionalTooltip from '../../../../components/ConditionalTooltip/ConditionalTooltip';
 import useNotification from '../../../../Hooks/useNotification';
 import useDeepCompareEffect from '../../../../Hooks/useDeepCompareEffect';
+import { useAppContext } from '../../../../middleware/AppContext';
 
 const green = global_success_color_100.value;
 
@@ -119,6 +124,12 @@ const EditContentForm = ({
   );
   const classes = useStyles();
   const queryClient = useQueryClient();
+  const { features } = useAppContext();
+  const snapshottingEnabled = useMemo(
+    () => !!features?.snapshots?.enabled && !!features?.snapshots?.accessible,
+    [!!features?.snapshots?.enabled],
+  );
+
   const formik = useFormik({
     initialValues: initialValues,
     validateOnBlur: false,
@@ -334,7 +345,17 @@ const EditContentForm = ({
       </Hide>
       {formik.values.map(
         (
-          { expanded, name, url, arch, gpgKey, versions, gpgLoading, metadataVerification },
+          {
+            expanded,
+            name,
+            url,
+            arch,
+            gpgKey,
+            versions,
+            gpgLoading,
+            metadataVerification,
+            snapshot,
+          },
           index,
         ) => (
           <Tbody key={index} isExpanded={createDataLengthOf1 ? undefined : expanded}>
@@ -363,6 +384,35 @@ const EditContentForm = ({
                 className={createDataLengthOf1 ? classes.singleContentCol : classes.mainContentCol}
               >
                 <Form>
+                  <Hide hide={!snapshottingEnabled}>
+                    <FormGroup fieldId='snapshot'>
+                      <Switch
+                        id='snapshot-switch'
+                        hasCheckIcon
+                        label='Snapshot creation enabled'
+                        labelOff='Snapshot creation disabled'
+                        isChecked={snapshot}
+                        onChange={() => {
+                          updateVariable(index, { snapshot: !snapshot });
+                        }}
+                      />
+                      <Tooltip content='Automatically create daily snapshots of this repository.'>
+                        <OutlinedQuestionCircleIcon
+                          className='pf-u-ml-xs'
+                          color={global_Color_200.value}
+                        />
+                      </Tooltip>
+                      <Hide hide={snapshot}>
+                        <Alert
+                          variant='warning'
+                          style={{ paddingTop: '10px' }}
+                          title='Disabling snapshots may result in a higher risk of losing content or unintentionally modifying it irreversibly.'
+                          isInline
+                          isPlain
+                        />
+                      </Hide>
+                    </FormGroup>
+                  </Hide>
                   <FormGroup
                     label='Name'
                     isRequired

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
@@ -1,10 +1,8 @@
 import {
   Alert,
-  Button,
   FileUpload,
   Form,
   FormGroup,
-  Popover,
   Radio,
   SelectVariant,
   TextInput,

--- a/src/Pages/ContentListTable/components/EditContentModal/helpers.test.ts
+++ b/src/Pages/ContentListTable/components/EditContentModal/helpers.test.ts
@@ -13,6 +13,7 @@ it('mapFormikToEditAPIValues', () => {
       expanded: false,
       uuid: 'stuff',
       metadataVerification: false,
+      snapshot: false,
     },
   ];
 
@@ -24,6 +25,7 @@ it('mapFormikToEditAPIValues', () => {
       distribution_versions: ['el7'],
       gpg_key: '',
       uuid: 'stuff',
+      snapshot: false,
       metadata_verification: false,
     },
   ];
@@ -58,6 +60,7 @@ it('mapToDefaultFormikValues', () => {
       arch: 'stuffAndThings',
       versions: ['version1', 'etc'],
       gpgKey: 'stuffAndThings',
+      snapshot: false,
       gpgLoading: false,
       metadataVerification: false,
       expanded: true,

--- a/src/Pages/ContentListTable/components/EditContentModal/helpers.ts
+++ b/src/Pages/ContentListTable/components/EditContentModal/helpers.ts
@@ -10,18 +10,22 @@ export interface FormikEditValues {
   gpgLoading: boolean;
   expanded: boolean;
   uuid: string;
+  snapshot: boolean;
 }
 
 export const mapFormikToEditAPIValues = (formikValues: FormikEditValues[]): EditContentRequest =>
-  formikValues.map(({ name, url, arch, versions, gpgKey, metadataVerification, uuid }) => ({
-    uuid,
-    name,
-    url,
-    distribution_arch: arch,
-    distribution_versions: versions,
-    gpg_key: gpgKey,
-    metadata_verification: metadataVerification,
-  }));
+  formikValues.map(
+    ({ name, url, arch, versions, gpgKey, metadataVerification, uuid, snapshot }) => ({
+      uuid,
+      name,
+      url,
+      distribution_arch: arch,
+      distribution_versions: versions,
+      gpg_key: gpgKey,
+      metadata_verification: metadataVerification,
+      snapshot,
+    }),
+  );
 
 export const mapToDefaultFormikValues = (values: ContentItem[]): FormikEditValues[] =>
   values.map(
@@ -34,6 +38,7 @@ export const mapToDefaultFormikValues = (values: ContentItem[]): FormikEditValue
         uuid,
         gpg_key: gpgKey,
         metadata_verification: metadataVerification,
+        snapshot,
       },
       index,
     ) => ({
@@ -46,6 +51,7 @@ export const mapToDefaultFormikValues = (values: ContentItem[]): FormikEditValue
       metadataVerification,
       expanded: index + 1 === values.length,
       uuid,
+      snapshot,
     }),
   );
 

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -61,6 +61,7 @@ export interface EditContentRequestItem {
   distribution_versions: string[];
   gpg_key: string;
   metadata_verification: boolean;
+  snapshot: boolean;
 }
 
 export type EditContentRequest = Array<EditContentRequestItem>;


### PR DESCRIPTION
## Summary

Adds a toggle to the add/edit modals for those orgs/users that have correct permissions. 
![Screen Shot 2023-07-21 at 1 53 02 PM](https://github.com/content-services/content-sources-frontend/assets/38083295/d81c1976-c62f-4f15-89a9-8a6de143d7b0)
![Screen Shot 2023-07-21 at 1 51 11 PM](https://github.com/content-services/content-sources-frontend/assets/38083295/3f0c0546-b712-4375-8e81-d5f62c869f40)

(This needs to have [1881](https://github.com/content-services/content-sources-frontend/pull/128) merge first).

## Testing steps

- Ensure you have a user/org with the snapshot permissions
- Open the add or edit modals, and see that the user should have snapshots toggled on by default.
- Further testing, for users that do not have access to snapshots, upon create the snapshot variable sent to the API (Check this via the network tab) should default to: snapshot:false

