### PR TITLE
Fixes 2271: Make url derived from history object for nav

### DIFF
--- a/src/Hooks/useRootPath.tsx
+++ b/src/Hooks/useRootPath.tsx
@@ -1,0 +1,14 @@
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+
+function useRootPath(): string {
+  const { pathname } = useLocation();
+  const rootPath = useMemo(
+    () => pathname.split('content')[0] + 'content',
+    [pathname.split('content')[0]],
+  );
+
+  return rootPath;
+}
+
+export default useRootPath;

--- a/src/Pages/AdminTaskTable/components/ViewPayloadModal/ViewPayloadModal.test.tsx
+++ b/src/Pages/AdminTaskTable/components/ViewPayloadModal/ViewPayloadModal.test.tsx
@@ -14,6 +14,7 @@ jest.mock('../../../../services/AdminTasks/AdminTaskQueries', () => ({
   useFetchAdminTaskQuery: jest.fn(),
 }));
 
+jest.mock('../../../../Hooks/useRootPath', () => () => 'someUrl');
 jest.mock('../../../../Hooks/useDebounce', () => (value) => value);
 jest.mock('../../../../middleware/AppContext', () => ({ useAppContext: () => ({}) }));
 

--- a/src/Pages/AdminTaskTable/components/ViewPayloadModal/ViewPayloadModal.tsx
+++ b/src/Pages/AdminTaskTable/components/ViewPayloadModal/ViewPayloadModal.tsx
@@ -16,7 +16,8 @@ import ReactJson from 'react-json-view';
 import Hide from '../../../../components/Hide/Hide';
 import { useFetchAdminTaskQuery } from '../../../../services/AdminTasks/AdminTaskQueries';
 import { useNavigate, useParams } from 'react-router-dom';
-import { ADMIN_TASKS_ROUTE, BASE_ROUTE } from '../../../../Routes/useTabbedRoutes';
+import { ADMIN_TASKS_ROUTE } from '../../../../Routes/useTabbedRoutes';
+import useRootPath from '../../../../Hooks/useRootPath';
 
 const useStyles = createUseStyles({
   jsonView: {
@@ -34,8 +35,9 @@ const ViewPayloadModal = () => {
   const { taskUUID: uuid } = useParams();
   const classes = useStyles();
   const navigate = useNavigate();
+  const rootPath = useRootPath();
 
-  const onClose = () => navigate(`${BASE_ROUTE}/${ADMIN_TASKS_ROUTE}`);
+  const onClose = () => navigate(`${rootPath}/${ADMIN_TASKS_ROUTE}`);
 
   const [activeTabKey, setActiveTabKey] = useState<string | number>(0);
   const detailRef = createRef<HTMLElement>();

--- a/src/Pages/ContentListTable/components/AddContent/AddContent.test.tsx
+++ b/src/Pages/ContentListTable/components/AddContent/AddContent.test.tsx
@@ -36,6 +36,8 @@ jest.mock('../../../../services/Content/ContentQueries', () => ({
 
 jest.mock('../../../../Hooks/useDebounce', () => (value) => value);
 
+jest.mock('../../../../Hooks/useRootPath', () => () => 'someUrl');
+
 jest.mock('../../../../Hooks/useNotification', () => () => ({ notify: () => null }));
 
 jest.mock('react-router-dom', () => ({

--- a/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
@@ -50,8 +50,8 @@ import { isEmpty, isEqual } from 'lodash';
 import useDeepCompareEffect from '../../../../Hooks/useDeepCompareEffect';
 import useDebounce from '../../../../Hooks/useDebounce';
 import { useNavigate } from 'react-router-dom';
-import { BASE_ROUTE } from '../../../../Routes/useTabbedRoutes';
 import { useClearCheckedRepositories } from '../../ContentListTable';
+import useRootPath from '../../../../Hooks/useRootPath';
 
 const useStyles = createUseStyles({
   description: {
@@ -117,6 +117,7 @@ const defaultTouchedState = { name: false, url: false, gpgKey: false };
 
 const AddContent = () => {
   const navigate = useNavigate();
+  const rootPath = useRootPath();
   const [changeVerified, setChangeVerified] = useState(false);
   const [gpgKeyList, setGpgKeyList] = useState<Array<string>>(['']);
   const classes = useStyles();
@@ -193,7 +194,7 @@ const AddContent = () => {
     return { distributionArches, distributionVersions };
   }, [distArches, distVersions]);
 
-  const onClose = () => navigate(BASE_ROUTE);
+  const onClose = () => navigate(rootPath);
 
   const { mutateAsync: addContent, isLoading: isAdding } = useAddContentQuery(
     queryClient,

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentModal.test.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentModal.test.tsx
@@ -32,6 +32,7 @@ jest.mock('react-query', () => ({
   useQueryClient: jest.fn(),
 }));
 
+jest.mock('../../../../Hooks/useRootPath', () => () => 'someUrl');
 jest.mock('../../../../Hooks/useNotification', () => () => ({ notify: () => null }));
 jest.mock('../../../../Hooks/useDebounce', () => (value) => value);
 jest.mock('../../../../middleware/AppContext', () => ({ useAppContext: () => ({}) }));

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentModal.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentModal.tsx
@@ -24,8 +24,8 @@ import EditContentForm from './EditContentForm';
 import { EditContentRequest } from '../../../../services/Content/ContentApi';
 import { isEqual } from 'lodash';
 import { mapToContentItemsToEditContentRequest } from './helpers';
-import { BASE_ROUTE } from '../../../../Routes/useTabbedRoutes';
 import { useClearCheckedRepositories } from '../../ContentListTable';
+import useRootPath from '../../../../Hooks/useRootPath';
 
 const useStyles = createUseStyles({
   description: {
@@ -41,6 +41,7 @@ const useStyles = createUseStyles({
 const EditContentModal = () => {
   const classes = useStyles();
   const navigate = useNavigate();
+  const rootPath = useRootPath();
   const queryClient = useQueryClient();
   const { search } = useLocation();
   const [initialLoad, setInitialLoad] = useState(true);
@@ -56,7 +57,7 @@ const EditContentModal = () => {
     updatedValues,
   );
 
-  const onClose = () => navigate(BASE_ROUTE);
+  const onClose = () => navigate(rootPath);
   const onSave = async () =>
     editContent().then(() => {
       onClose();

--- a/src/Pages/ContentListTable/components/PackageModal/PackageModal.test.tsx
+++ b/src/Pages/ContentListTable/components/PackageModal/PackageModal.test.tsx
@@ -17,6 +17,8 @@ const packageItem: PackageItem = {
   uuid: '',
 };
 
+jest.mock('../../../../Hooks/useRootPath', () => () => 'someUrl');
+
 jest.mock('../../../../services/Content/ContentQueries', () => ({
   useGetPackagesQuery: jest.fn(),
 }));

--- a/src/Pages/ContentListTable/components/PackageModal/PackageModal.tsx
+++ b/src/Pages/ContentListTable/components/PackageModal/PackageModal.tsx
@@ -37,7 +37,7 @@ import { SearchIcon } from '@patternfly/react-icons';
 import useDebounce from '../../../../Hooks/useDebounce';
 import EmptyPackageState from './components/EmptyPackageState';
 import { useNavigate, useParams } from 'react-router-dom';
-import { BASE_ROUTE } from '../../../../Routes/useTabbedRoutes';
+import useRootPath from '../../../../Hooks/useRootPath';
 
 const useStyles = createUseStyles({
   description: {
@@ -78,7 +78,7 @@ const perPageKey = 'packagePerPage';
 export default function PackageModal() {
   const classes = useStyles();
   const { repoUUID: uuid } = useParams();
-
+  const rootPath = useRootPath();
   const navigate = useNavigate();
   const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
   const [page, setPage] = useState(1);
@@ -141,7 +141,7 @@ export default function PackageModal() {
     };
   };
 
-  const onClose = () => navigate(BASE_ROUTE);
+  const onClose = () => navigate(rootPath);
 
   const {
     data: packageList = [],

--- a/src/Routes/useTabbedRoutes.tsx
+++ b/src/Routes/useTabbedRoutes.tsx
@@ -7,9 +7,7 @@ import EditContentModal from '../Pages/ContentListTable/components/EditContentMo
 import PackageModal from '../Pages/ContentListTable/components/PackageModal/PackageModal';
 import PopularRepositoriesTable from '../Pages/PopularRepositoriesTable/PopularRepositoriesTable';
 import { useAppContext } from '../middleware/AppContext';
-import fecConfig from '../../fec.config';
 
-export const BASE_ROUTE = fecConfig.appUrl;
 export const DEFAULT_ROUTE = '';
 export const POPULAR_REPOSITORIES_ROUTE = 'popular-repositories';
 export const ADMIN_TASKS_ROUTE = 'admin-tasks';


### PR DESCRIPTION
## Summary
This was causing an issue where root urls of non "insights" would reroute to "settings". 

Expected behaviour is now to inherit the root url, cross domain jumping should not occur.

## Testing steps

- Open and close all modals when on the "insights" root address. 
- On close of modal the insights address should remain, and not be replaced by "settings"