### PR TITLE
Fixes 2189,Fixes 2277: Add snapshotListModal (View only)

### DIFF
--- a/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
@@ -684,10 +684,6 @@ const AddContent = () => {
                     <Hide hide={!gpgKey}>
                       <FormGroup fieldId='metadataVerification' label='Use GPG key for' isInline>
                         <Radio
-                          isDisabled={
-                            !validationList?.[index]?.url?.metadata_signature_present ||
-                            !!formik?.errors?.[index]?.gpgKey
-                          }
                           id='package-verification-only'
                           name='package-verification-only'
                           label='Package verification only'
@@ -699,10 +695,6 @@ const AddContent = () => {
                           content="This repository's metadata is not signed, metadata verification is not possible."
                         >
                           <Radio
-                            isDisabled={
-                              !validationList?.[index]?.url?.metadata_signature_present ||
-                              !!formik?.errors?.[index]?.gpgKey
-                            }
                             id='package-and-repository-verification'
                             name='package-and-repository-verification'
                             label='Package and metadata verification'

--- a/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
@@ -52,7 +52,7 @@ import { isEmpty, isEqual } from 'lodash';
 import useDeepCompareEffect from '../../../../Hooks/useDeepCompareEffect';
 import useDebounce from '../../../../Hooks/useDebounce';
 import { useNavigate } from 'react-router-dom';
-import { useClearCheckedRepositories } from '../../ContentListTable';
+import { useContentListOutletContext } from '../../ContentListTable';
 import useRootPath from '../../../../Hooks/useRootPath';
 import { useAppContext } from '../../../../middleware/AppContext';
 
@@ -138,7 +138,8 @@ const AddContent = () => {
     initialTouched: [defaultTouchedState],
     onSubmit: () => undefined,
   });
-  const clearCheckedRepositories = useClearCheckedRepositories();
+
+  const { clearCheckedRepositories } = useContentListOutletContext();
 
   const updateGpgKey = (index: number, value: string) => {
     setChangeVerified(false);

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
@@ -553,8 +553,8 @@ const EditContentForm = ({
                     <FormGroup fieldId='metadataVerification' label='Use GPG key for' isInline>
                       <Radio
                         isDisabled={
-                          validationList?.[index]?.url?.metadata_signature_present === false ||
-                          !!formik?.errors?.[index]?.gpgKey
+                          validationList?.[index]?.url?.metadata_signature_present === false
+                          //    || !!formik?.errors?.[index]?.gpgKey
                         }
                         id='package verification only'
                         name='package-verification-only'
@@ -568,8 +568,8 @@ const EditContentForm = ({
                       >
                         <Radio
                           isDisabled={
-                            validationList?.[index]?.url?.metadata_signature_present === false ||
-                            !!formik?.errors?.[index]?.gpgKey
+                            validationList?.[index]?.url?.metadata_signature_present === false
+                            // || !!formik?.errors?.[index]?.gpgKey
                           }
                           id='Package and metadata verification'
                           name='package-and-repository-verification'

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
@@ -552,10 +552,6 @@ const EditContentForm = ({
                   <Hide hide={!gpgKey}>
                     <FormGroup fieldId='metadataVerification' label='Use GPG key for' isInline>
                       <Radio
-                        isDisabled={
-                          validationList?.[index]?.url?.metadata_signature_present === false
-                          //    || !!formik?.errors?.[index]?.gpgKey
-                        }
                         id='package verification only'
                         name='package-verification-only'
                         label='Package verification only'
@@ -567,10 +563,6 @@ const EditContentForm = ({
                         content="This repository's metadata is not signed, metadata verification is not possible."
                       >
                         <Radio
-                          isDisabled={
-                            validationList?.[index]?.url?.metadata_signature_present === false
-                            // || !!formik?.errors?.[index]?.gpgKey
-                          }
                           id='Package and metadata verification'
                           name='package-and-repository-verification'
                           label='Package and metadata verification'

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentModal.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentModal.tsx
@@ -24,7 +24,7 @@ import EditContentForm from './EditContentForm';
 import { EditContentRequest } from '../../../../services/Content/ContentApi';
 import { isEqual } from 'lodash';
 import { mapToContentItemsToEditContentRequest } from './helpers';
-import { useClearCheckedRepositories } from '../../ContentListTable';
+import { useContentListOutletContext } from '../../ContentListTable';
 import useRootPath from '../../../../Hooks/useRootPath';
 
 const useStyles = createUseStyles({
@@ -48,7 +48,7 @@ const EditContentModal = () => {
   const [updatedValues, setUpdatedValues] = useState<EditContentRequest>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isValid, setIsValid] = useState(false);
-  const clearCheckedRepositories = useClearCheckedRepositories();
+  const { clearCheckedRepositories } = useContentListOutletContext();
 
   const uuids = new URLSearchParams(search).get('repoUUIDS')?.split(',') || [];
 

--- a/src/Pages/ContentListTable/components/SnapshotListModal/SnapshotListModal.test.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotListModal/SnapshotListModal.test.tsx
@@ -1,0 +1,82 @@
+import { render, waitFor } from '@testing-library/react';
+import SnapshotListModal from './SnapshotListModal';
+import {
+  ReactQueryTestWrapper,
+  defaultContentItem,
+  defaultMetaItem,
+  defaultSnapshotItem,
+} from '../../../../testingHelpers';
+import { useFetchContent, useGetSnapshotList } from '../../../../services/Content/ContentQueries';
+
+jest.mock('../../../../Hooks/useRootPath', () => () => 'someUrl');
+
+jest.mock('../../../../services/Content/ContentQueries', () => ({
+  useFetchContent: jest.fn(),
+  useGetSnapshotList: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+  useParams: () => ({
+    repoUUID: 'some-uuid',
+  }),
+}));
+
+it('Render 1 item', async () => {
+  (useFetchContent as jest.Mock).mockImplementation(() => ({
+    data: [defaultContentItem],
+  }));
+  (useGetSnapshotList as jest.Mock).mockImplementation(() => ({
+    data: {
+      meta: defaultMetaItem,
+      data: [defaultSnapshotItem],
+    },
+    isLoading: false,
+    isFetching: false,
+  }));
+  const { queryByText } = render(
+    <ReactQueryTestWrapper>
+      <SnapshotListModal />
+    </ReactQueryTestWrapper>,
+  );
+
+  waitFor(() => expect(queryByText(defaultContentItem.name)).toBeInTheDocument());
+
+  expect(
+    queryByText((defaultSnapshotItem.content_counts['rpm.package'] as number)?.toString()),
+  ).toBeInTheDocument();
+});
+
+it('Render 20 items', async () => {
+  (useFetchContent as jest.Mock).mockImplementation(() => ({
+    data: [defaultContentItem],
+  }));
+  (useGetSnapshotList as jest.Mock).mockImplementation(() => ({
+    data: {
+      meta: { defaultMetaItem, count: 21 }, // Make count larger so next button is available for pagination
+      data: Array(20)
+        .fill(defaultSnapshotItem)
+        .map((val, index) => ({
+          ...val,
+          name: index + val.name,
+          content_counts: {
+            ...val.content_counts,
+            'rpm.package': val.content_counts['rpm.package'] + index,
+          },
+        })),
+    },
+    isLoading: false,
+    isFetching: false,
+  }));
+  const { queryByText } = render(
+    <ReactQueryTestWrapper>
+      <SnapshotListModal />
+    </ReactQueryTestWrapper>,
+  );
+
+  waitFor(() => expect(queryByText(0 + defaultContentItem.name)).toBeInTheDocument());
+
+  expect(
+    queryByText((defaultSnapshotItem.content_counts['rpm.package'] as number)?.toString()),
+  ).toBeInTheDocument();
+});

--- a/src/Pages/ContentListTable/components/SnapshotListModal/components/ChangedArrows.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotListModal/components/ChangedArrows.tsx
@@ -1,0 +1,43 @@
+import { LongArrowAltDownIcon, LongArrowAltUpIcon } from '@patternfly/react-icons';
+import { Flex, FlexItem } from '@patternfly/react-core';
+import { global_danger_color_100, global_success_color_100 } from '@patternfly/react-tokens';
+import { createUseStyles } from 'react-jss';
+
+const red = global_danger_color_100.value;
+const green = global_success_color_100.value;
+
+const useStyles = createUseStyles({
+  base: {
+    fontWeight: 'bold',
+    alignItems: 'center',
+    display: 'flex',
+    '& svg': {
+      marginRight: '5px',
+    },
+  },
+  red: { extend: 'base', color: red },
+  green: { extend: 'base', color: green },
+});
+
+interface Props {
+  addedCount: number;
+  removedCount: number;
+}
+
+const ChangedArrows = ({ addedCount, removedCount }: Props) => {
+  const classes = useStyles();
+  return (
+    <Flex>
+      <FlexItem className={classes.green}>
+        <LongArrowAltUpIcon />
+        {addedCount}
+      </FlexItem>
+      <FlexItem className={classes.red}>
+        <LongArrowAltDownIcon />
+        {removedCount}
+      </FlexItem>
+    </Flex>
+  );
+};
+
+export default ChangedArrows;

--- a/src/Routes/useTabbedRoutes.tsx
+++ b/src/Routes/useTabbedRoutes.tsx
@@ -7,6 +7,7 @@ import EditContentModal from '../Pages/ContentListTable/components/EditContentMo
 import PackageModal from '../Pages/ContentListTable/components/PackageModal/PackageModal';
 import PopularRepositoriesTable from '../Pages/PopularRepositoriesTable/PopularRepositoriesTable';
 import { useAppContext } from '../middleware/AppContext';
+import SnapshotListModal from '../Pages/ContentListTable/components/SnapshotListModal/SnapshotListModal';
 
 export const DEFAULT_ROUTE = '';
 export const POPULAR_REPOSITORIES_ROUTE = 'popular-repositories';
@@ -36,6 +37,9 @@ export default function useTabbedRoutes(): TabbedRoute[] {
                 { path: 'edit-repository', Element: EditContentModal },
                 { path: 'add-repository', Element: AddContent },
               ]
+            : []),
+          ...(features?.admintasks?.enabled && features.snapshots?.accessible
+            ? [{ path: ':repoUUID/snapshots', Element: SnapshotListModal }]
             : []),
           { path: ':repoUUID/packages', Element: PackageModal },
         ],

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -16,6 +16,8 @@ export interface ContentItem {
   gpg_key: string;
   metadata_verification: boolean;
   snapshot: boolean;
+  last_snapshot_uuid?: string;
+  last_snapshot?: SnapshotItem;
 }
 
 export interface PopularRepository {
@@ -71,8 +73,8 @@ export type ContentList = Array<ContentItem>;
 export type Links = {
   first: string;
   last: string;
-  next: string;
-  prev: string;
+  next?: string;
+  prev?: string;
 };
 
 export type Meta = {
@@ -147,6 +149,28 @@ export interface PackageItem {
 
 export type PackagesResponse = {
   data: PackageItem[];
+  links: Links;
+  meta: Meta;
+};
+
+export type ContentCounts = {
+  'rpm.advisory'?: number;
+  'rpm.package'?: number;
+  'rpm.packagecategory'?: number;
+  'rpm.packageenvironment'?: number;
+  'rpm.packagegroup'?: number;
+};
+
+export interface SnapshotItem {
+  created_at: string;
+  distribution_path: string;
+  content_counts: ContentCounts;
+  added_counts: ContentCounts;
+  removed_counts: ContentCounts;
+}
+
+export type SnapshotListResponse = {
+  data: SnapshotItem[];
   links: Links;
   meta: Meta;
 };
@@ -263,6 +287,27 @@ export const getPackages: (
 ) => {
   const { data } = await axios.get(
     `/api/content-sources/v1.0/repositories/${uuid}/rpms?offset=${
+      (page - 1) * limit
+    }&limit=${limit}&search=${searchQuery}&sort_by=${sortBy}`,
+  );
+  return data;
+};
+
+export const getSnapshotList: (
+  uuid: string,
+  page: number,
+  limit: number,
+  searchQuery: string,
+  sortBy: string,
+) => Promise<SnapshotListResponse> = async (
+  uuid: string,
+  page: number,
+  limit: number,
+  searchQuery: string,
+  sortBy: string,
+) => {
+  const { data } = await axios.get(
+    `/api/content-sources/v1.0/repositories/${uuid}/snapshots/?offset=${
       (page - 1) * limit
     }&limit=${limit}&search=${searchQuery}&sort_by=${sortBy}`,
   );

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -28,6 +28,8 @@ import {
   deleteContentListItems,
   Meta,
   ErrorResponse,
+  getSnapshotList,
+  SnapshotListResponse,
 } from './ContentApi';
 import { ADMIN_TASK_LIST_KEY } from '../AdminTasks/AdminTaskQueries';
 import useErrorNotification from '../../Hooks/useErrorNotification';
@@ -38,6 +40,7 @@ export const POPULAR_REPOSITORIES_LIST_KEY = 'POPULAR_REPOSITORIES_LIST_KEY';
 export const REPOSITORY_PARAMS_KEY = 'REPOSITORY_PARAMS_KEY';
 export const CREATE_PARAMS_KEY = 'CREATE_PARAMS_KEY';
 export const PACKAGES_KEY = 'PACKAGES_KEY';
+export const LIST_SNAPSHOTS_KEY = 'PACKAGES_KEY';
 export const CONTENT_ITEM_KEY = 'CONTENT_ITEM_KEY';
 
 const CONTENT_LIST_POLLING_TIME = 15000; // 15 seconds
@@ -458,6 +461,29 @@ export const useFetchGpgKey = () => {
   };
 
   return { fetchGpgKey, isLoading };
+};
+
+export const useGetSnapshotList = (
+  uuid: string,
+  page: number,
+  limit: number,
+  searchQuery: string,
+  sortBy: string,
+) => {
+  const errorNotifier = useErrorNotification();
+  return useQuery<SnapshotListResponse>(
+    [LIST_SNAPSHOTS_KEY, uuid, page, limit, searchQuery, sortBy],
+    () => getSnapshotList(uuid, page, limit, searchQuery, sortBy),
+    {
+      keepPreviousData: true,
+      optimisticResults: true,
+      staleTime: 60000,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      onError: (err: any) => {
+        errorNotifier('Unable to find snapshots with the given UUID.', 'An error occurred', err);
+      },
+    },
+  );
 };
 
 export const useGetPackagesQuery = (

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -1,8 +1,11 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
 import {
   ContentItem,
+  Links,
+  Meta,
   PopularRepository,
   RepositoryParamsResponse,
+  SnapshotItem,
   ValidationResponse,
 } from './services/Content/ContentApi';
 import { AdminTask } from './services/AdminTasks/AdminTaskApi';
@@ -115,7 +118,7 @@ export const passingValidationErrorData: ValidationResponse = [
 
 export const defaultContentItem: ContentItem = {
   uuid: '',
-  name: '',
+  name: 'SteveTheRepo',
   package_count: 100,
   url: '',
   status: 'Pending',
@@ -172,4 +175,36 @@ export const defaultSnapshotTask: AdminTask = {
       distributionData: 'distributionValue',
     },
   },
+};
+
+export const defaultMetaItem: Meta = {
+  limit: 10,
+  offset: 0,
+  count: 1,
+};
+
+export const defaultLinkItem: Links = {
+  first:
+    '/api/content-sources/v1/repositories/?arch=&limit=20&offset=0&search=&sort_by=name:asc&status=&version=',
+  last: '/api/content-sources/v1/repositories/?arch=&limit=20&offset=0&search=&sort_by=name:asc&status=&version=',
+};
+
+export const defaultSnapshotItem: SnapshotItem = {
+  created_at: '2023-08-08T20:23:32.711372-06:00',
+  distribution_path: 'b68beca3-d081-4c9f-9d8f-9868107c30e2/ea837ff5-62ed-4507-876d-2c600f55df54',
+  content_counts: {
+    'rpm.advisory': 3864,
+    'rpm.package': 17208,
+    'rpm.packagecategory': 1,
+    'rpm.packageenvironment': 1,
+    'rpm.packagegroup': 20,
+  },
+  added_counts: {
+    'rpm.advisory': 3864,
+    'rpm.package': 17208,
+    'rpm.packagecategory': 1,
+    'rpm.packageenvironment': 1,
+    'rpm.packagegroup': 20,
+  },
+  removed_counts: {},
 };


### PR DESCRIPTION
## Summary

Adds the snapshotListModal seen below: 
![Screen Shot 2023-08-11 at 11 49 59 AM](https://github.com/content-services/content-sources-frontend/assets/38083295/cb86409e-b2cb-42eb-8daf-3e09cdbd767e)

One can access the above modal through the repository list row kebab seen here: 
![Screen Shot 2023-08-09 at 4 18 28 PM](https://github.com/content-services/content-sources-frontend/assets/38083295/e33411ee-5546-4032-8995-5601bc86d88c)

If the repository doesn't yet have a snapshot (and snapshots are enabled, IE right after creation) one should see: 
![Screen Shot 2023-08-09 at 4 18 24 PM](https://github.com/content-services/content-sources-frontend/assets/38083295/939e965b-67d3-4d2c-8865-3dab9fcc52d9)

If snapshots are not enabled, the "View Snapshot List" menu option should be hidden.

Additional changes: 

- This ticket incorporates a very small change to satisfy [HMS-2277](https://issues.redhat.com/browse/HMS-2277) until [HMS-1700](https://issues.redhat.com/browse/HMS-1700) can be completed.

Notes: 
- This ticket is dependent on the backend ticket [HMS-2188](https://issues.redhat.com/browse/HMS-2188) which is currently in progress, so merging will need to be delayed until that work has been completed.

## Testing steps 

- Confirm the above changes are visible and working as intended.