### PR TITLE
Fixes 1700: Update edit/add modal checkmark functionality

### DIFF
--- a/src/Pages/ContentListTable/components/AddContent/helpers.test.ts
+++ b/src/Pages/ContentListTable/components/AddContent/helpers.test.ts
@@ -1,5 +1,7 @@
+import { FormikErrors } from 'formik';
 import { ValidationResponse } from '../../../../services/Content/ContentApi';
 import {
+  FormikValues,
   REGEX_URL,
   failedFileUpload,
   isValidURL,
@@ -77,6 +79,44 @@ it('mapValidationData', () => {
     },
   ];
   expect(mapValidationData([], [])).toEqual([]);
+  expect(mapValidationData(validationData, formikErrors)).toEqual(success);
+});
+
+it('mapValidationData, ensure url error heirarchy', () => {
+  const validationData: ValidationResponse = [
+    {
+      name: {
+        skipped: false,
+        valid: true,
+        error: '',
+      },
+      url: {
+        skipped: false,
+        valid: true,
+        error:
+          'Error fetching YUM metadata: Head "https://bobjull.co": dial tcp: lookup bobjull.co: no such host',
+        http_code: 0,
+        metadata_present: false,
+        metadata_signature_present: false,
+      },
+      // We expect gpgKey errors not to be shown, as they are dependent on the url which has an error!
+      gpg_key: {
+        skipped: false,
+        valid: false,
+        error: 'Error loading GPG Key: unexpected EOF.  Is this a valid GPG Key?',
+      },
+    },
+  ];
+  const formikErrors: FormikErrors<FormikValues | undefined>[] = [
+    { name: 'name error booga booga!' },
+  ];
+  const success = [
+    {
+      name: 'name error booga booga!',
+      url: 'Error fetching YUM metadata: Head "https://bobjull.co": dial tcp: lookup bobjull.co: no such host',
+    },
+  ];
+
   expect(mapValidationData(validationData, formikErrors)).toEqual(success);
 });
 

--- a/src/Pages/ContentListTable/components/AddContent/helpers.ts
+++ b/src/Pages/ContentListTable/components/AddContent/helpers.ts
@@ -70,14 +70,18 @@ export const mapValidationData = (
   formikErrors: FormikErrors<FormikValues | undefined>[],
 ) => {
   const updatedValidationData = mapNoMetaDataError(validationData);
-  const errors = updatedValidationData.map(({ name, url, gpg_key: gpgKey }, index: number) => ({
-    // First apply the errors found in the ValidationAPI
-    ...(name?.error ? { name: name?.error } : {}),
-    ...(url?.error ? { url: url?.error } : {}),
-    ...(gpgKey?.error ? { gpgKey: gpgKey?.error } : {}),
-    // Overwrite any errors with errors found within the UI itself
-    ...formikErrors[index],
-  }));
+
+  const errors = updatedValidationData.map(({ name, url, gpg_key: gpgKey }, index: number) => {
+    const hasUrlErrors = url?.error || formikErrors[index]?.url;
+    return {
+      // First apply the errors found in the ValidationAPI
+      ...(name?.error ? { name: name?.error } : {}),
+      ...(url?.error ? { url: url?.error } : {}),
+      ...(!hasUrlErrors && gpgKey?.error ? { gpgKey: gpgKey?.error } : {}),
+      // Overwrite any errors with errors found within the UI itself
+      ...formikErrors[index],
+    };
+  });
 
   if (errors.every((err) => isEmpty(err))) {
     return [];

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
@@ -218,12 +218,17 @@ const EditContentForm = ({
     index: number,
     field: keyof FormikEditValues,
   ): 'default' | 'success' | 'error' => {
-    const hasNotChanged = isEqual(initialValues[index]?.[field], formik.values[index]?.[field]);
+    let hasNotChanged = isEqual(initialValues[index]?.[field], formik.values[index]?.[field]);
+    if (field === 'metadataVerification') {
+      if (!initialValues[index].gpgKey) {
+        hasNotChanged = false;
+      }
+    }
     const errors = !!formik.errors[index]?.[field];
     switch (true) {
       case errors:
         return 'error';
-      case hasNotChanged:
+      case hasNotChanged || !isEmpty(formik.errors[index]) || !changeVerified:
         return 'default';
       case !hasNotChanged:
         return 'success';


### PR DESCRIPTION
## Summary

This updates the add/edit modals with the following functionality around validation: 

For the add modal: 
- The controller will focus on url errors first, even if the gpg key has the wrong value as it is dependant on the URL for validation.
- Only mandatory fields have a green check mark and the input gpg key box will only have a red mark if we enter the wrong value.
- if the name and gpgkey both have errors they will both show a red check as they are not hierarchally dependent.

For the Edit modal: 

- Validation will only show green checkmarks (showing updated values) if there are no errors showing, and when the validation API returns clear. 
- If an error is present, no checkmarks will show, forcing the user to focus on the error before confirming any other changes. 
- The same error flow (gpg key dependent on URL) is present from add modal, on the edit modal.


## Testing steps

- Step through the add/create modals, noting the above new behaviour. 
- Highlight any inconsistencies if found.