### PR TITLE
Fixes 2312: Admin tasks interface append results

### DIFF
--- a/src/Pages/AdminTaskTable/AdminTaskTable.tsx
+++ b/src/Pages/AdminTaskTable/AdminTaskTable.tsx
@@ -21,7 +21,7 @@ import {
   Tr,
 } from '@patternfly/react-table';
 import { global_BackgroundColor_100 } from '@patternfly/react-tokens';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { createUseStyles } from 'react-jss';
 import { SkeletonTable } from '@redhat-cloud-services/frontend-components';
 import Hide from '../../components/Hide/Hide';
@@ -91,8 +91,10 @@ const AdminTaskTable = () => {
     'status',
   ];
 
-  const sortString = (): string =>
-    columnSortAttributes[activeSortIndex] + ':' + activeSortDirection;
+  const sortString = useMemo(
+    () => columnSortAttributes[activeSortIndex] + ':' + activeSortDirection,
+    [activeSortIndex, activeSortDirection],
+  );
 
   const {
     isLoading,
@@ -100,7 +102,7 @@ const AdminTaskTable = () => {
     isError,
     isFetching,
     data = { data: [], meta: { count: 0, limit: 20, offset: 0 } },
-  } = useAdminTaskListQuery(page, perPage, filterData, sortString());
+  } = useAdminTaskListQuery(page, perPage, filterData, sortString);
 
   const actionTakingPlace = isFetching;
 
@@ -215,8 +217,8 @@ const AdminTaskTable = () => {
               </Tr>
             </Thead>
             <Tbody>
-              {adminTaskList.map((adminTask: AdminTask) => (
-                <Tr key={adminTask.uuid}>
+              {adminTaskList.map((adminTask: AdminTask, index) => (
+                <Tr key={adminTask.uuid + index + ''}>
                   <Td>{adminTask.org_id}</Td>
                   <Td>{adminTask.account_id ? adminTask.account_id : 'Unknown'}</Td>
                   <Td>{adminTask.typename}</Td>

--- a/src/services/AdminTasks/AdminTaskQueries.ts
+++ b/src/services/AdminTasks/AdminTaskQueries.ts
@@ -23,8 +23,9 @@ export const useAdminTaskListQuery = (
   const [polling, setPolling] = useState(false);
   const [pollCount, setPollCount] = useState(0);
   const errorNotifier = useErrorNotification();
+  const flattenedFilterData = Object.values(filterData).flat(1);
   return useQuery<AdminTaskListResponse>(
-    [ADMIN_TASK_LIST_KEY, page, limit, sortBy, ...Object.values(filterData)],
+    [ADMIN_TASK_LIST_KEY, page, limit, sortBy, ...flattenedFilterData],
     () => getAdminTasks(page, limit, filterData, sortBy),
     {
       onSuccess: (data) => {


### PR DESCRIPTION
## Summary

- This is an attempted fix for the duplicate item error being appended in stage. 
- I was unable to replicated the issue locally, but have corrected a few issues in the code around paginating that could be causing this issue. 

## Testing steps

- One can check in ephemeral, but this likely needs to be pushed to stage to have its' functionality confirmed.