### PR TITLE
Fixes 2190: added snapshot info to content list table

### DIFF
--- a/src/Pages/ContentListTable/ContentListTable.test.tsx
+++ b/src/Pages/ContentListTable/ContentListTable.test.tsx
@@ -1,6 +1,11 @@
 import { render, waitFor } from '@testing-library/react';
 import dayjs from 'dayjs';
-import { ReactQueryTestWrapper, defaultContentItemWithSnapshot, defaultSnapshotItem, testRepositoryParamsResponse } from '../../testingHelpers';
+import {
+  ReactQueryTestWrapper,
+  defaultContentItemWithSnapshot,
+  defaultSnapshotItem,
+  testRepositoryParamsResponse,
+} from '../../testingHelpers';
 import ContentListTable from './ContentListTable';
 import { useContentListQuery, useRepositoryParams } from '../../services/Content/ContentQueries';
 import AddContent from './components/AddContent/AddContent';
@@ -64,7 +69,7 @@ it('Render a loading state', () => {
 
 it('Render with a single row', () => {
   jest.mock('../../middleware/AppContext', () => ({
-    useAppContext: (features) => ({  features: features.snapshot.accessible,}),
+    useAppContext: (features) => ({ features: features.snapshot.accessible }),
   }));
 
   (useRepositoryParams as jest.Mock).mockImplementation(() => ({
@@ -87,9 +92,27 @@ it('Render with a single row', () => {
 
   expect(queryByText('AwesomeNamewwyylse12')).toBeInTheDocument();
   expect(queryByText('https://google.ca/wwyylse12/x86_64/el7')).toBeInTheDocument();
-  waitFor(() => expect(queryByText(dayjs(defaultSnapshotItem.created_at).fromNow())).toBeInTheDocument());
-  waitFor(() => expect(queryByText(((defaultSnapshotItem.added_counts['rpm.package'] as number) 
-    + (defaultSnapshotItem.added_counts['rpm.advisory'] as number))?.toString())).toBeInTheDocument());
-  waitFor(() => expect(queryByText(((defaultSnapshotItem.removed_counts['rpm.package'] as number) 
-    + (defaultSnapshotItem.removed_counts['rpm.advisory'] as number))?.toString())).toBeInTheDocument());
+  waitFor(() =>
+    expect(queryByText(dayjs(defaultSnapshotItem.created_at).fromNow())).toBeInTheDocument(),
+  );
+  waitFor(() =>
+    expect(
+      queryByText(
+        (
+          (defaultSnapshotItem.added_counts['rpm.package'] as number) +
+          (defaultSnapshotItem.added_counts['rpm.advisory'] as number)
+        )?.toString(),
+      ),
+    ).toBeInTheDocument(),
+  );
+  waitFor(() =>
+    expect(
+      queryByText(
+        (
+          (defaultSnapshotItem.removed_counts['rpm.package'] as number) +
+          (defaultSnapshotItem.removed_counts['rpm.advisory'] as number)
+        )?.toString(),
+      ),
+    ).toBeInTheDocument(),
+  );
 });

--- a/src/Pages/ContentListTable/ContentListTable.test.tsx
+++ b/src/Pages/ContentListTable/ContentListTable.test.tsx
@@ -1,5 +1,6 @@
-import { render } from '@testing-library/react';
-import { ReactQueryTestWrapper, testRepositoryParamsResponse } from '../../testingHelpers';
+import { render, waitFor } from '@testing-library/react';
+import dayjs from 'dayjs';
+import { ReactQueryTestWrapper, defaultContentItemWithSnapshot, defaultSnapshotItem, testRepositoryParamsResponse } from '../../testingHelpers';
 import ContentListTable from './ContentListTable';
 import { useContentListQuery, useRepositoryParams } from '../../services/Content/ContentQueries';
 import AddContent from './components/AddContent/AddContent';
@@ -62,6 +63,10 @@ it('Render a loading state', () => {
 });
 
 it('Render with a single row', () => {
+  jest.mock('../../middleware/AppContext', () => ({
+    useAppContext: (features) => ({  features: features.snapshot.accessible,}),
+  }));
+
   (useRepositoryParams as jest.Mock).mockImplementation(() => ({
     isLoading: false,
     data: testRepositoryParamsResponse,
@@ -69,18 +74,7 @@ it('Render with a single row', () => {
   (useContentListQuery as jest.Mock).mockImplementation(() => ({
     isLoading: false,
     data: {
-      data: [
-        {
-          account_id: 'undefined',
-          distribution_arch: 'x86_64',
-          distribution_versions: ['el7'],
-          name: 'AwesomeNamewwyylse12',
-          org_id: '13446804',
-          url: 'https://google.ca/wwyylse12/x86_64/el7',
-          uuid: '2375c35b-a67a-4ac2-a989-21139433c172',
-          package_count: 0,
-        },
-      ],
+      data: [defaultContentItemWithSnapshot],
       meta: { count: 1, limit: 20, offset: 0 },
     },
   }));
@@ -93,4 +87,9 @@ it('Render with a single row', () => {
 
   expect(queryByText('AwesomeNamewwyylse12')).toBeInTheDocument();
   expect(queryByText('https://google.ca/wwyylse12/x86_64/el7')).toBeInTheDocument();
+  waitFor(() => expect(queryByText(dayjs(defaultSnapshotItem.created_at).fromNow())).toBeInTheDocument());
+  waitFor(() => expect(queryByText(((defaultSnapshotItem.added_counts['rpm.package'] as number) 
+    + (defaultSnapshotItem.added_counts['rpm.advisory'] as number))?.toString())).toBeInTheDocument());
+  waitFor(() => expect(queryByText(((defaultSnapshotItem.removed_counts['rpm.package'] as number) 
+    + (defaultSnapshotItem.removed_counts['rpm.advisory'] as number))?.toString())).toBeInTheDocument());
 });

--- a/src/Pages/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/ContentListTable/ContentListTable.tsx
@@ -20,7 +20,7 @@ import {
   ThProps,
   Tr,
 } from '@patternfly/react-table';
-import { global_BackgroundColor_100 } from '@patternfly/react-tokens';
+import { global_BackgroundColor_100, global_Color_400 } from '@patternfly/react-tokens';
 import { useCallback, useMemo, useState } from 'react';
 import { createUseStyles } from 'react-jss';
 import {
@@ -76,15 +76,13 @@ const useStyles = createUseStyles({
     minWidth: '45px!important',
   },
   snapshotInfoText: {
-    color: 'grey',
+    color: global_Color_400.value,
     paddingRight: '20px',
   },
   inline: {
-    display: 'flex'
+    display: 'flex',
+    gap: '10px',
   },
-  snapshotInfoPadding: {
-    paddingTop: '10px'
-  }
 });
 
 const perPageKey = 'contentListPerPage';
@@ -461,19 +459,18 @@ const ContentListTable = () => {
                             }}
                           />
                         </Hide>
-                        <Td>
+                        <Td className={classes.inline}>
                           {name}
-                          <br />
                           <UrlWithExternalIcon href={url} />
-                          {features?.snapshots?.accessible && 
-                            <Flex className={classes.snapshotInfoPadding}>
+                          <Hide hide={!features?.snapshots?.accessible}>
+                            <Flex>
                               <FlexItem className={classes.snapshotInfoText}>
                                 {last_snapshot ? 
                                   `Last snapshot ${dayjs(last_snapshot?.created_at).fromNow()}` : 
                                   'No snapshot yet'
                                 }
                               </FlexItem>
-                              {last_snapshot &&
+                              <Hide hide={!last_snapshot}>
                                 <FlexItem className={classes.inline}>
                                   <FlexItem className={classes.snapshotInfoText}>Changes:</FlexItem>
                                   <ChangedArrows
@@ -483,9 +480,9 @@ const ContentListTable = () => {
                                                   (last_snapshot?.removed_counts?.['rpm.package'] || 0)}
                                   />
                                 </FlexItem>
-                              }
+                              </Hide>
                             </Flex>
-                          }
+                          </Hide> 
                         </Td>
                         <Td>{archesDisplay(distribution_arch)}</Td>
                         <Td>{versionDisplay(distribution_versions)}</Td>

--- a/src/Pages/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/ContentListTable/ContentListTable.tsx
@@ -461,7 +461,7 @@ const ContentListTable = () => {
                         <Td>
                           {name}
                           <UrlWithExternalIcon href={url} />
-                          <Hide hide={!features?.snapshots?.enabled}>
+                          <Hide hide={!features?.snapshots?.accessible}>
                             <Flex>
                               <FlexItem className={classes.snapshotInfoText}>
                                 {last_snapshot

--- a/src/Pages/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/ContentListTable/ContentListTable.tsx
@@ -77,11 +77,10 @@ const useStyles = createUseStyles({
   },
   snapshotInfoText: {
     color: global_Color_400.value,
-    paddingRight: '20px',
+    marginRight: '16px'
   },
   inline: {
     display: 'flex',
-    gap: '10px',
   },
 });
 
@@ -459,7 +458,7 @@ const ContentListTable = () => {
                             }}
                           />
                         </Hide>
-                        <Td className={classes.inline}>
+                        <Td>
                           {name}
                           <UrlWithExternalIcon href={url} />
                           <Hide hide={!features?.snapshots?.accessible}>

--- a/src/Pages/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/ContentListTable/ContentListTable.tsx
@@ -48,6 +48,7 @@ import { useAppContext } from '../../middleware/AppContext';
 import ConditionalTooltip from '../../components/ConditionalTooltip/ConditionalTooltip';
 import dayjs from 'dayjs';
 import { Outlet, useNavigate, useOutletContext } from 'react-router-dom';
+import ChangedArrows from './components/SnapshotListModal/components/ChangedArrows';
 
 const useStyles = createUseStyles({
   mainContainer: {
@@ -74,6 +75,16 @@ const useStyles = createUseStyles({
   checkboxMinWidth: {
     minWidth: '45px!important',
   },
+  snapshotInfoText: {
+    color: 'grey',
+    paddingRight: '20px',
+  },
+  inline: {
+    display: 'flex'
+  },
+  snapshotInfoPadding: {
+    paddingTop: '10px'
+  }
 });
 
 const perPageKey = 'contentListPerPage';
@@ -432,6 +443,7 @@ const ContentListTable = () => {
                       uuid,
                       name,
                       url,
+                      last_snapshot,
                       distribution_arch,
                       distribution_versions,
                       last_introspection_time,
@@ -453,6 +465,27 @@ const ContentListTable = () => {
                           {name}
                           <br />
                           <UrlWithExternalIcon href={url} />
+                          {features?.snapshots?.accessible && 
+                            <Flex className={classes.snapshotInfoPadding}>
+                              <FlexItem className={classes.snapshotInfoText}>
+                                {last_snapshot ? 
+                                  `Last snapshot ${dayjs(last_snapshot?.created_at).fromNow()}` : 
+                                  'No snapshot yet'
+                                }
+                              </FlexItem>
+                              {last_snapshot &&
+                                <FlexItem className={classes.inline}>
+                                  <FlexItem className={classes.snapshotInfoText}>Changes:</FlexItem>
+                                  <ChangedArrows
+                                    addedCount={(last_snapshot?.added_counts?.['rpm.advisory'] || 0) + 
+                                                (last_snapshot?.added_counts?.['rpm.package'] || 0)}
+                                    removedCount={(last_snapshot?.removed_counts?.['rpm.advisory'] || 0) + 
+                                                  (last_snapshot?.removed_counts?.['rpm.package'] || 0)}
+                                  />
+                                </FlexItem>
+                              }
+                            </Flex>
+                          }
                         </Td>
                         <Td>{archesDisplay(distribution_arch)}</Td>
                         <Td>{versionDisplay(distribution_versions)}</Td>

--- a/src/Pages/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/ContentListTable/ContentListTable.tsx
@@ -77,7 +77,7 @@ const useStyles = createUseStyles({
   },
   snapshotInfoText: {
     color: global_Color_400.value,
-    marginRight: '16px'
+    marginRight: '16px',
   },
   inline: {
     display: 'flex',
@@ -464,24 +464,27 @@ const ContentListTable = () => {
                           <Hide hide={!features?.snapshots?.accessible}>
                             <Flex>
                               <FlexItem className={classes.snapshotInfoText}>
-                                {last_snapshot ? 
-                                  `Last snapshot ${dayjs(last_snapshot?.created_at).fromNow()}` : 
-                                  'No snapshot yet'
-                                }
+                                {last_snapshot
+                                  ? `Last snapshot ${dayjs(last_snapshot?.created_at).fromNow()}`
+                                  : 'No snapshot yet'}
                               </FlexItem>
                               <Hide hide={!last_snapshot}>
                                 <FlexItem className={classes.inline}>
                                   <FlexItem className={classes.snapshotInfoText}>Changes:</FlexItem>
                                   <ChangedArrows
-                                    addedCount={(last_snapshot?.added_counts?.['rpm.advisory'] || 0) + 
-                                                (last_snapshot?.added_counts?.['rpm.package'] || 0)}
-                                    removedCount={(last_snapshot?.removed_counts?.['rpm.advisory'] || 0) + 
-                                                  (last_snapshot?.removed_counts?.['rpm.package'] || 0)}
+                                    addedCount={
+                                      (last_snapshot?.added_counts?.['rpm.advisory'] || 0) +
+                                      (last_snapshot?.added_counts?.['rpm.package'] || 0)
+                                    }
+                                    removedCount={
+                                      (last_snapshot?.removed_counts?.['rpm.advisory'] || 0) +
+                                      (last_snapshot?.removed_counts?.['rpm.package'] || 0)
+                                    }
                                   />
                                 </FlexItem>
                               </Hide>
                             </Flex>
-                          </Hide> 
+                          </Hide>
                         </Td>
                         <Td>{archesDisplay(distribution_arch)}</Td>
                         <Td>{versionDisplay(distribution_versions)}</Td>

--- a/src/Pages/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/ContentListTable/ContentListTable.tsx
@@ -461,7 +461,7 @@ const ContentListTable = () => {
                         <Td>
                           {name}
                           <UrlWithExternalIcon href={url} />
-                          <Hide hide={!features?.snapshots?.accessible}>
+                          <Hide hide={!features?.snapshots?.enabled}>
                             <Flex>
                               <FlexItem className={classes.snapshotInfoText}>
                                 {last_snapshot

--- a/src/Pages/ContentListTable/components/AddContent/helpers.ts
+++ b/src/Pages/ContentListTable/components/AddContent/helpers.ts
@@ -135,7 +135,7 @@ export const makeValidationSchema = () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore-next-line
       .uniqueProperty('name', 'Names must be unique')
-      .uniqueProperty('url', 'Url\'s must be unique'),
+      .uniqueProperty('url', "Url's must be unique"),
   );
 };
 

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -226,4 +226,4 @@ export const defaultContentItemWithSnapshot: ContentItem = {
   metadata_verification: false,
   snapshot: true,
   last_snapshot: defaultSnapshotItem,
-}
+};

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -208,3 +208,22 @@ export const defaultSnapshotItem: SnapshotItem = {
   },
   removed_counts: {},
 };
+
+export const defaultContentItemWithSnapshot: ContentItem = {
+  account_id: 'undefined',
+  distribution_arch: 'x86_64',
+  distribution_versions: ['el7'],
+  name: 'AwesomeNamewwyylse12',
+  org_id: '13446804',
+  url: 'https://google.ca/wwyylse12/x86_64/el7',
+  uuid: '2375c35b-a67a-4ac2-a989-21139433c172',
+  package_count: 0,
+  status: '',
+  last_introspection_error: '',
+  last_introspection_time: '',
+  failed_introspections_count: 0,
+  gpg_key: '',
+  metadata_verification: false,
+  snapshot: true,
+  last_snapshot: defaultSnapshotItem,
+}


### PR DESCRIPTION
## Summary

- Added "Snapshot" related info to the repositories list table (sketch reference [here](https://www.sketch.com/s/b55e75a8-9a53-4eb0-989e-aad208521aba/a/VEkGYmq))
- Displays "No snapshot yet" if there are no snapshots, otherwise displays "Last snapshot (creation time of last snapshot) Changes: " with # of additions and # of removals using the ChangedArrows component
- Displays nothing if feature not enabled
- Updated tests

## Testing steps

- Enable snapshot feature, snapshot info should be displayed
- When feature is disabled, it should look as before
- Depends on [this PR](https://github.com/content-services/content-sources-backend/pull/457)
