### PR TITLE
Fixes 2617: copy/download repo config from snapshot list

### DIFF
--- a/src/Pages/ContentListTable/components/SnapshotListModal/SnapshotListModal.test.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotListModal/SnapshotListModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import {render, waitFor} from '@testing-library/react';
 import SnapshotListModal from './SnapshotListModal';
 import {
   ReactQueryTestWrapper,
@@ -13,6 +13,7 @@ jest.mock('../../../../Hooks/useRootPath', () => () => 'someUrl');
 jest.mock('../../../../services/Content/ContentQueries', () => ({
   useFetchContent: jest.fn(),
   useGetSnapshotList: jest.fn(),
+  useGetRepoConfigFileQuery: () => ({ mutateAsync: jest.fn() })
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -79,4 +80,5 @@ it('Render 20 items', async () => {
   expect(
     queryByText((defaultSnapshotItem.content_counts['rpm.package'] as number)?.toString()),
   ).toBeInTheDocument();
+
 });

--- a/src/Pages/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
@@ -37,6 +37,7 @@ import EmptyPackageState from '../PackageModal/components/EmptyPackageState';
 import ChangedArrows from './components/ChangedArrows';
 import { SearchIcon } from '@patternfly/react-icons';
 import { useAppContext } from '../../../../middleware/AppContext';
+import RepoConfig from './components/RepoConfig';
 
 const useStyles = createUseStyles({
   description: {
@@ -76,7 +77,7 @@ export default function SnapshotListModal() {
   const [activeSortIndex, setActiveSortIndex] = useState<number>(0);
   const [activeSortDirection, setActiveSortDirection] = useState<'asc' | 'desc'>('asc');
 
-  const columnHeaders = ['Snapshots', 'Change', 'Packages', 'Errata'];
+  const columnHeaders = ['Snapshots', 'Change', 'Packages', 'Errata', 'Config'];
 
   const columnSortAttributes = ['created_at'];
 
@@ -227,7 +228,7 @@ export default function SnapshotListModal() {
               <Tbody>
                 {snapshotsList.map(
                   (
-                    { created_at, content_counts, added_counts, removed_counts }: SnapshotItem,
+                    { uuid: snap_uuid, created_at, content_counts, added_counts, removed_counts }: SnapshotItem,
                     index: number,
                   ) => (
                     <Tr key={created_at + index}>
@@ -246,6 +247,9 @@ export default function SnapshotListModal() {
                       </Td>
                       <Td>{content_counts?.['rpm.package'] || 0}</Td>
                       <Td>{content_counts?.['rpm.advisory'] || 0}</Td>
+                      <Td>
+                        <RepoConfig repoUUID={uuid} snapUUID={snap_uuid}/>
+                        </Td>
                     </Tr>
                   ),
                 )}

--- a/src/Pages/ContentListTable/components/SnapshotListModal/components/RepoConfig.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotListModal/components/RepoConfig.tsx
@@ -1,0 +1,75 @@
+import { Button, Flex, FlexItem, Icon } from '@patternfly/react-core';
+import { createUseStyles } from 'react-jss';
+import { global_disabled_color_100 } from '@patternfly/react-tokens';
+
+import { useGetRepoConfigFileQuery } from '../../../../../services/Content/ContentQueries';
+import { CopyIcon, DownloadIcon } from '@patternfly/react-icons';
+
+const useStyles = createUseStyles({
+  text: {
+    color: global_disabled_color_100.value,
+    width: 'fit-content',
+  },
+  link: {
+    padding: 0,
+  },
+});
+
+interface Props {
+  repoUUID: string;
+  snapUUID: string;
+}
+
+const RepoConfig = ({ repoUUID, snapUUID }: Props) => {
+  const classes = useStyles();
+
+  const { mutateAsync } = useGetRepoConfigFileQuery(repoUUID, snapUUID);
+
+  const copyConfigFile = async () => {
+    const data = await mutateAsync();
+    navigator.clipboard.writeText(data);
+  };
+
+  const downloadConfigFile = async () => {
+    const data = await mutateAsync();
+    const element = document.createElement('a');
+    const file = new Blob([data], {type: 'text/plain'});
+    element.href = URL.createObjectURL(file);
+    element.download = 'config.repo';
+    document.body.appendChild(element);
+    element.click();
+  };
+
+  return (
+    <Flex>
+      <FlexItem>
+        <Button
+          ouiaId='repo_config_file_copy_button'
+          label='repo_config_file_copy_button'
+          variant='link'
+          className={classes.link}
+          onClick={() => copyConfigFile()}
+        >
+          <Icon>
+            <CopyIcon />
+          </Icon>
+        </Button>
+      </FlexItem>
+      <FlexItem>
+        <Button
+          ouiaId='repo_config_file_download_button'
+          label='repo_config_file_download_button'
+          variant='link'
+          className={classes.link}
+          onClick={() => downloadConfigFile()}
+        >
+          <Icon>
+            <DownloadIcon />
+          </Icon>
+        </Button>
+      </FlexItem>
+    </Flex>
+  );
+};
+
+export default RepoConfig;

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -162,6 +162,7 @@ export type ContentCounts = {
 };
 
 export interface SnapshotItem {
+  uuid: string;
   created_at: string;
   distribution_path: string;
   content_counts: ContentCounts;
@@ -328,3 +329,13 @@ export const introspectRepository: (
   );
   return data;
 };
+
+export const getRepoConfigFile: (
+    repo_uuid: string,
+    snapshot_uuid: string,
+) => Promise<string> = async (repo_uuid, snapshot_uuid) => {
+  const { data } =  await axios.get(
+      `/api/content-sources/v1/repositories/${repo_uuid}/snapshots/${snapshot_uuid}/config.repo`
+  );
+  return data;
+}

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -31,6 +31,7 @@ import {
   getSnapshotList,
   SnapshotListResponse,
   ContentOrigin,
+  getRepoConfigFile,
 } from './ContentApi';
 import { ADMIN_TASK_LIST_KEY } from '../AdminTasks/AdminTaskQueries';
 import useErrorNotification from '../../Hooks/useErrorNotification';
@@ -43,6 +44,7 @@ export const CREATE_PARAMS_KEY = 'CREATE_PARAMS_KEY';
 export const PACKAGES_KEY = 'PACKAGES_KEY';
 export const LIST_SNAPSHOTS_KEY = 'PACKAGES_KEY';
 export const CONTENT_ITEM_KEY = 'CONTENT_ITEM_KEY';
+export const REPO_CONFIG_FILE_KEY = 'REPO_CONFIG_FILE_KEY';
 
 const CONTENT_LIST_POLLING_TIME = 15000; // 15 seconds
 
@@ -570,4 +572,18 @@ export const useIntrospectRepositoryMutate = (
       errorNotifier('Error introspecting repository', 'An error occurred', err);
     },
   });
+};
+
+export const useGetRepoConfigFileQuery = (repo_uuid: string, snapshot_uuid: string) => {
+  const errorNotifier = useErrorNotification();
+  return useMutation<string>(
+    [REPO_CONFIG_FILE_KEY, repo_uuid, snapshot_uuid],
+    async () => await getRepoConfigFile(repo_uuid, snapshot_uuid),
+    {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      onError: (err: any) => {
+        errorNotifier('Unable to find config.repo with the given UUID.', 'An error occurred', err);
+      },
+    },
+  );
 };

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -190,6 +190,7 @@ export const defaultLinkItem: Links = {
 };
 
 export const defaultSnapshotItem: SnapshotItem = {
+  uuid: '2375c35b-a67a-4ac2-a989-21139433c172',
   created_at: '2023-08-08T20:23:32.711372-06:00',
   distribution_path: 'b68beca3-d081-4c9f-9d8f-9868107c30e2/ea837ff5-62ed-4507-876d-2c600f55df54',
   content_counts: {


### PR DESCRIPTION
## Summary
Adds a new column to the snapshot list modal that allows the user to either copy or download the repo config file for the snapshot.

## Testing steps
1. Create a repository with snapshotting enabled
2. Click "view all snapshots" on the kebab
3. Under the "Config" tab, try clicking the copy icon (to copy) and the download icon (to download)