### PR TITLE
Fixes 3274: Hides RH repo when snapshots not enabled

### DIFF
--- a/src/Pages/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/ContentListTable/ContentListTable.tsx
@@ -109,6 +109,7 @@ const ContentListTable = () => {
   });
 
   const setOriginAndSearchParams = (origin: ContentOrigin) => {
+    if (!features?.snapshots?.accessible) return;
     setContentOrigin(origin);
     setUrlSearchParams(origin === ContentOrigin.EXTERNAL ? {} : { origin });
   };

--- a/src/Pages/ContentListTable/components/ContentListFilters.tsx
+++ b/src/Pages/ContentListTable/components/ContentListFilters.tsx
@@ -72,7 +72,7 @@ const ContentListFilters = ({
   contentOrigin,
 }: Props) => {
   const classes = useStyles();
-  const { rbac } = useAppContext();
+  const { rbac, features } = useAppContext();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const filters = ['Name/URL', 'Version', 'Architecture', 'Status'];
@@ -272,34 +272,36 @@ const ContentListFilters = ({
           </InputGroupItem>
         </InputGroup>
       </FlexItem>
-      <FlexItem>
-        <ToggleGroup aria-label='Default with single selectable'>
-          <ToggleGroupItem
-            text='Custom'
-            buttonId='custom-repositories-toggle-button'
-            data-ouia-component-id='custom-repositories-toggle'
-            isSelected={contentOrigin === ContentOrigin.EXTERNAL}
-            onChange={() => {
-              if (contentOrigin !== ContentOrigin.EXTERNAL) {
-                setContentOrigin(ContentOrigin.EXTERNAL);
-                // clearFilters(); //This resets the filters when changing Origins if desired.
-              }
-            }}
-          />
-          <ToggleGroupItem
-            text='Red Hat'
-            buttonId='redhat-repositories-toggle-button'
-            data-ouia-component-id='redhat-repositories-toggle'
-            isSelected={contentOrigin === ContentOrigin.REDHAT}
-            onChange={() => {
-              if (contentOrigin !== ContentOrigin.REDHAT) {
-                setContentOrigin(ContentOrigin.REDHAT);
-                // clearFilters();//This resets the filters when changing Origins if desired.
-              }
-            }}
-          />
-        </ToggleGroup>
-      </FlexItem>
+      <Hide hide={!features?.snapshots?.accessible}>
+        <FlexItem>
+          <ToggleGroup aria-label='Default with single selectable'>
+            <ToggleGroupItem
+              text='Custom'
+              buttonId='custom-repositories-toggle-button'
+              data-ouia-component-id='custom-repositories-toggle'
+              isSelected={contentOrigin === ContentOrigin.EXTERNAL}
+              onChange={() => {
+                if (contentOrigin !== ContentOrigin.EXTERNAL) {
+                  setContentOrigin(ContentOrigin.EXTERNAL);
+                  // clearFilters(); //This resets the filters when changing Origins if desired.
+                }
+              }}
+            />
+            <ToggleGroupItem
+              text='Red Hat'
+              buttonId='redhat-repositories-toggle-button'
+              data-ouia-component-id='redhat-repositories-toggle'
+              isSelected={contentOrigin === ContentOrigin.REDHAT}
+              onChange={() => {
+                if (contentOrigin !== ContentOrigin.REDHAT) {
+                  setContentOrigin(ContentOrigin.REDHAT);
+                  // clearFilters();//This resets the filters when changing Origins if desired.
+                }
+              }}
+            />
+          </ToggleGroup>
+        </FlexItem>
+      </Hide>
       <FlexItem className={classes.repositoryActions}>
         <ConditionalTooltip
           content='You do not have the required permissions to perform this action.'


### PR DESCRIPTION
## Summary

- Makes it so that Red hat repositories will not be accessible without feature.snapshot permissions.

## Testing steps

- Turn off snapshotting in the backend config
- Run the ui, the toggle button for redhat repositories should no longer be accessible
- Deeplinking to content?origin=redhat will also not work.
