### PR TITLE
Fixes 2726: Custom repositories missing zero state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,45 @@
 import '@redhat-cloud-services/frontend-components-utilities/styles/_all';
 import 'react18-json-view/src/style.css';
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import { useEffect, /* useMemo,*/ useState } from 'react';
+// import { useLocation } from 'react-router-dom';
+// import { last } from 'lodash';
+
 import Routes from './Routes';
 import { useAppContext } from './middleware/AppContext';
 import { NoPermissionsPage } from './components/NoPermissionsPage/NoPermissionsPage';
-
-import { Bullseye, Spinner } from '@patternfly/react-core';
+import { ContentOrigin, FilterData } from './services/Content/ContentApi';
+import { useContentListQuery } from './services/Content/ContentQueries';
+import { perPageKey } from './Pages/ContentListTable/ContentListTable';
+// import { REPOSITORIES_ROUTE } from './Routes/constants';
 
 export default function App() {
-  const { rbac, isFetchingFeatures } = useAppContext();
+  const { rbac, isFetchingFeatures, zeroState, setZeroState } = useAppContext();
+  const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
+  // const { pathname } = useLocation();
+  // const isDefaultRoute = useMemo(() => last(pathname.split('/')) === REPOSITORIES_ROUTE, [pathname]);
+
+  const [filterData] = useState<FilterData>({
+    searchQuery: '',
+    versions: [],
+    arches: [],
+    statuses: [],
+  });
+
+  const { data = { data: [], meta: { count: 0, limit: 20, offset: 0 } }, isLoading } =
+    useContentListQuery(1, storedPerPage, filterData, '', ContentOrigin.EXTERNAL, /* !isDefaultRoute */);
+
+  // Check for user's custom repositories to determine whether we need to show zero state
+  useEffect(() => {
+    // Zero state may be true AND a user may have repositories if they have signed in via a different machine for the first time
+    if (zeroState && data.data.length > 0 /* && !isDefaultRoute */) {
+      setZeroState(false);
+    }
+  }, [data.data.length]);
 
   switch (true) {
-    case !rbac || isFetchingFeatures:
+    case !rbac || isFetchingFeatures || isLoading:
       return (
         <Bullseye>
           <Spinner size='xl' />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,9 @@ import '@redhat-cloud-services/frontend-components-utilities/styles/_all';
 import 'react18-json-view/src/style.css';
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-import { useEffect, /* useMemo,*/ useState } from 'react';
-// import { useLocation } from 'react-router-dom';
-// import { last } from 'lodash';
+import { useEffect, useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { last } from 'lodash';
 
 import Routes from './Routes';
 import { useAppContext } from './middleware/AppContext';
@@ -12,13 +12,16 @@ import { NoPermissionsPage } from './components/NoPermissionsPage/NoPermissionsP
 import { ContentOrigin, FilterData } from './services/Content/ContentApi';
 import { useContentListQuery } from './services/Content/ContentQueries';
 import { perPageKey } from './Pages/ContentListTable/ContentListTable';
-// import { REPOSITORIES_ROUTE } from './Routes/constants';
+import { REPOSITORIES_ROUTE } from './Routes/constants';
 
 export default function App() {
   const { rbac, isFetchingFeatures, zeroState, setZeroState } = useAppContext();
   const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
-  // const { pathname } = useLocation();
-  // const isDefaultRoute = useMemo(() => last(pathname.split('/')) === REPOSITORIES_ROUTE, [pathname]);
+  const { pathname } = useLocation();
+  const isDefaultRoute = useMemo(
+    () => last(pathname.split('/')) === REPOSITORIES_ROUTE,
+    [pathname],
+  );
 
   const [filterData] = useState<FilterData>({
     searchQuery: '',
@@ -28,12 +31,19 @@ export default function App() {
   });
 
   const { data = { data: [], meta: { count: 0, limit: 20, offset: 0 } }, isLoading } =
-    useContentListQuery(1, storedPerPage, filterData, '', ContentOrigin.EXTERNAL, /* !isDefaultRoute */);
+    useContentListQuery(
+      1,
+      storedPerPage,
+      filterData,
+      '',
+      ContentOrigin.EXTERNAL,
+      isDefaultRoute && zeroState, // We only check if the route is correct and zerostate is true (defaults to true)
+    );
 
   // Check for user's custom repositories to determine whether we need to show zero state
   useEffect(() => {
     // Zero state may be true AND a user may have repositories if they have signed in via a different machine for the first time
-    if (zeroState && data.data.length > 0 /* && !isDefaultRoute */) {
+    if ((zeroState && data.data.length > 0) || (zeroState && !isDefaultRoute)) {
       setZeroState(false);
     }
   }, [data.data.length]);

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -1,10 +1,11 @@
 import { Grid } from '@patternfly/react-core';
 import { Routes, Route, Navigate } from 'react-router-dom';
-
 import { createUseStyles } from 'react-jss';
+import { useMemo } from 'react';
+
 import { ErrorPage } from '../components/Error/ErrorPage';
 import RepositoryLayout from './Repositories/RepositoryLayout';
-import { useMemo } from 'react';
+import { ZeroState } from '../components/ZeroState/ZeroState';
 import useRepositoryRoutes from './Repositories/useRepositoryRoutes';
 import { REPOSITORIES_ROUTE } from './constants';
 import useTemplateRoutes from './Templates/useTemplateRoutes';
@@ -22,10 +23,12 @@ export default function RepositoriesRoutes() {
   const key = useMemo(() => Math.random(), []);
   const repositoryRoutes = useRepositoryRoutes();
   const templateRoutes = useTemplateRoutes();
-  const { features } = useAppContext();
+  const { features, zeroState } = useAppContext();
 
   return (
     <Routes key={key}>
+      {zeroState ? <Route path={REPOSITORIES_ROUTE} element={<ZeroState />} /> : <></>}
+
       <Route element={<RepositoryLayout tabs={repositoryRoutes} />}>
         {repositoryRoutes.map(({ route, Element, ChildRoutes }, key) => (
           <Route

--- a/src/components/ZeroState/ZeroState.tsx
+++ b/src/components/ZeroState/ZeroState.tsx
@@ -1,0 +1,61 @@
+import { Suspense } from 'react';
+import { Bullseye, Button, Grid, Spinner } from '@patternfly/react-core';
+import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
+import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
+import { Outlet, useNavigate } from 'react-router-dom';
+import { createUseStyles } from 'react-jss';
+
+import { useAppContext } from '../../middleware/AppContext';
+
+const useStyles = createUseStyles({
+  minHeight: {
+    minHeight: '100%',
+    '& .bannerBefore': { maxHeight: '320px!important' },
+  },
+});
+
+export const ZeroState = () => {
+  const classes = useStyles();
+  const navigate = useNavigate();
+  const { setZeroState } = useAppContext();
+
+  const handleClick = () => {
+    setZeroState(false);
+    navigate('add');
+  };
+
+  return (
+    <>
+      <Suspense
+        fallback={
+          <Bullseye>
+            <Spinner size='xl' />
+          </Bullseye>
+        }
+      >
+        <Grid className={classes.minHeight}>
+          <AsyncComponent
+            appId='content_zero_state'
+            appName='dashboard'
+            module='./AppZeroState'
+            scope='dashboard'
+            ErrorComponent={<ErrorState />}
+            app='Content_management'
+            customText='Get started with Insights by adding custom repositories'
+            customButton={
+              <Button
+                id='add-custom-repositories-button'
+                ouiaId='add_custom_repositories_button'
+                className='pf-c-button pf-m-primary pf-u-p-md pf-u-font-size-md'
+                onClick={() => handleClick()}
+              >
+                Add custom repositories
+              </Button>
+            }
+          />
+        </Grid>
+      </Suspense>
+      <Outlet />
+    </>
+  );
+};

--- a/src/middleware/AppContext.tsx
+++ b/src/middleware/AppContext.tsx
@@ -19,11 +19,14 @@ export interface AppContextInterface {
   contentOrigin: ContentOrigin;
   setContentOrigin: (contentOrigin: ContentOrigin) => void;
   chrome?: ChromeAPI;
+  zeroState: boolean;
+  setZeroState: (zeroState: boolean) => void;
 }
 export const AppContext = createContext({} as AppContextInterface);
 
 export const ContextProvider = ({ children }: { children: ReactNode }) => {
   const [rbac, setRbac] = useState<Rbac | undefined>(undefined);
+  const [zeroState, setZeroState] = useState(true);
   const [features, setFeatures] = useState<Features | null>(null);
   const chrome = useChrome();
   const [contentOrigin, setContentOrigin] = useState<ContentOrigin>(ContentOrigin.EXTERNAL);
@@ -65,6 +68,8 @@ export const ContextProvider = ({ children }: { children: ReactNode }) => {
         contentOrigin,
         setContentOrigin,
         chrome: chrome as ChromeAPI,
+        zeroState,
+        setZeroState,
       }}
     >
       {children}

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -110,7 +110,7 @@ export const useContentListQuery = (
   filterData: FilterData,
   sortBy: string,
   contentOrigin: ContentOrigin = ContentOrigin.EXTERNAL,
-  enabled?: boolean,
+  enabled: boolean = true,
 ) => {
   const [polling, setPolling] = useState(false);
   const [pollCount, setPollCount] = useState(0);


### PR DESCRIPTION
## Summary

Adds a zero state for when a user has no custom repositories added yet. 

This is the current zero state:

![Screenshot 2024-01-25 at 12 10 07 PM](https://github.com/content-services/content-sources-frontend/assets/28575816/9fc64ee0-3c73-40c8-a350-1f518ad113ce)

## Testing steps

- When a user enters the app and has no custom repositories, they should see the zero state
- Clicking the `Add custom repositories` button from the zero state component should route them to the modal to add a repository
- Once they add a repository, they should not see the zero state once they leave and visit the app again. In that case they should instead be routed to the Repositories page 
- If a user enters the modal to add a repository from the zero state, and closes the modal before adding a repository, the empty repository table state should be shown. If they refresh the page, they should see the zero state again. 
- If a user has repositories and then deletes them all, upon refresh or navigating away and back to the app they should see the zero state