### PR TITLE
Fixes 3472: change snapshot delta to only use package count

### DIFF
--- a/src/Pages/ContentListTable/ContentListTable.test.tsx
+++ b/src/Pages/ContentListTable/ContentListTable.test.tsx
@@ -103,8 +103,7 @@ it('Render with a single row', async () => {
     expect(
       queryByText(
         (
-          (defaultSnapshotItem.added_counts['rpm.package'] as number) +
-          (defaultSnapshotItem.added_counts['rpm.advisory'] as number)
+          (defaultSnapshotItem.added_counts['rpm.package'] as number)
         )?.toString(),
       ),
     ).toBeInTheDocument(),
@@ -113,8 +112,7 @@ it('Render with a single row', async () => {
     expect(
       queryByText(
         (
-          (defaultSnapshotItem.removed_counts['rpm.package'] as number) +
-          (defaultSnapshotItem.removed_counts['rpm.advisory'] as number)
+          (defaultSnapshotItem.removed_counts['rpm.package'] as number)
         )?.toString(),
       ),
     ).toBeInTheDocument(),

--- a/src/Pages/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/ContentListTable/ContentListTable.tsx
@@ -523,11 +523,9 @@ const ContentListTable = () => {
                                     </FlexItem>
                                     <ChangedArrows
                                       addedCount={
-                                        (last_snapshot?.added_counts?.['rpm.advisory'] || 0) +
                                         (last_snapshot?.added_counts?.['rpm.package'] || 0)
                                       }
                                       removedCount={
-                                        (last_snapshot?.removed_counts?.['rpm.advisory'] || 0) +
                                         (last_snapshot?.removed_counts?.['rpm.package'] || 0)
                                       }
                                     />

--- a/src/Pages/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
@@ -242,11 +242,9 @@ export default function SnapshotListModal() {
                       <Td>
                         <ChangedArrows
                           addedCount={
-                            (added_counts?.['rpm.advisory'] || 0) +
                             (added_counts?.['rpm.package'] || 0)
                           }
                           removedCount={
-                            (removed_counts?.['rpm.advisory'] || 0) +
                             (removed_counts?.['rpm.package'] || 0)
                           }
                         />

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -202,8 +202,8 @@ export const defaultSnapshotItem: SnapshotItem = {
     'rpm.packagegroup': 20,
   },
   added_counts: {
-    'rpm.advisory': 3864,
-    'rpm.package': 17208,
+    'rpm.advisory': 100,
+    'rpm.package': 200,
     'rpm.packagecategory': 1,
     'rpm.packageenvironment': 1,
     'rpm.packagegroup': 20,


### PR DESCRIPTION
## Summary

Errata delta in pulp is unreliable, as ordering of things seem to count as a new errata, throwing the counts off.  For now we will just show package change count.

## Testing steps

Snapshot a repo with package and errata (https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/) , view delta on repos table and snapshot list.  Delta count should match package count.
