### PR TITLE
Fixes 3518: fix routing conditional for snapshot modal

### DIFF
--- a/src/Routes/useTabbedRoutes.tsx
+++ b/src/Routes/useTabbedRoutes.tsx
@@ -40,7 +40,7 @@ export default function useTabbedRoutes(): TabbedRoute[] {
                 { path: 'delete-repository', Element: DeleteContentModal },
               ]
             : []),
-          ...(features?.admintasks?.enabled && features.snapshots?.accessible
+          ...(features?.snapshots?.enabled && features.snapshots?.accessible
             ? [{ path: ':repoUUID/snapshots', Element: SnapshotListModal }]
             : []),
           { path: ':repoUUID/packages', Element: PackageModal },


### PR DESCRIPTION
## Summary

Fixes snapshot modal route to not require admin tasks to be enabled

## Testing steps

- Disable admin tasks feature in the backend
- Snapshot list modal should open normally
