### PR TITLE
Fixes 3630: hide snapshotting in prod stable

### DIFF
--- a/src/middleware/AppContext.tsx
+++ b/src/middleware/AppContext.tsx
@@ -39,6 +39,12 @@ export const ContextProvider = ({ children }: { children: ReactNode }) => {
 
     (async () => {
       const fetchedFeatures = await fetchFeatures();
+      // Disable snapshotting in prod stable
+      if (chrome.isProd() && !chrome.isBeta()) {
+        if (fetchedFeatures !== null && fetchedFeatures.snapshots !== undefined) {
+          fetchedFeatures.snapshots.accessible = false
+        }
+      }
       setFeatures(fetchedFeatures);
     })();
   }, [!!chrome]);

--- a/src/middleware/AppContext.tsx
+++ b/src/middleware/AppContext.tsx
@@ -40,7 +40,7 @@ export const ContextProvider = ({ children }: { children: ReactNode }) => {
     (async () => {
       const fetchedFeatures = await fetchFeatures();
       // Disable snapshotting in prod stable
-      if (chrome.isProd() && !chrome.isBeta()) {
+      if (chrome.isProd() && !chrome.isBeta() && fetchedFeatures?. snapshots?.accessible) {
         if (fetchedFeatures !== null && fetchedFeatures.snapshots !== undefined) {
           fetchedFeatures.snapshots.accessible = false
         }


### PR DESCRIPTION
## Summary

Hides snapshotting in prod stable

## Testing steps

Turn on snapshotting in the backend:

```
features:
  snapshots:
    enabled: true
    accounts: 
    users: 
```

launch frontend with stage stable/beta, prod stable/beta.

It should not be available in prod stable, but should be elsewhere.