### PR TITLE
Refs 3488: disable sorting on status

### DIFF
--- a/src/Pages/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/ContentListTable/ContentListTable.tsx
@@ -148,7 +148,6 @@ const ContentListTable = () => {
     'distribution_versions',
     'package_count',
     'last_introspection_time',
-    'status',
   ];
 
   const sortString = (): string =>
@@ -472,11 +471,15 @@ const ContentListTable = () => {
                           }}
                         />
                       </Hide>
-                      {columnHeaders.map((columnHeader, index) => (
-                        <Th key={columnHeader + 'column'} sort={sortParams(index)}>
-                          {columnHeader}
-                        </Th>
-                      ))}
+                      {columnHeaders.map((columnHeader, index) =>
+                        columnHeader === 'Status' ? (
+                          <Th key={columnHeader + 'column'}>{columnHeader}</Th>
+                        ) : (
+                          <Th key={columnHeader + 'column'} sort={sortParams(index)}>
+                            {columnHeader}
+                          </Th>
+                        ),
+                      )}
                       <Th>
                         <Spinner size='md' className={actionTakingPlace ? '' : classes.invisible} />
                       </Th>

--- a/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
@@ -645,8 +645,8 @@ const AddContent = () => {
                         toggleId={'versionSelection' + index}
                         options={Object.keys(distributionVersions)}
                         variant={SelectVariant.typeaheadMulti}
-                        selectedProp={Object.keys(distributionVersions).filter((key: string) =>
-                          versions?.includes(distributionVersions[key]),
+                        selectedProp={Object.keys(distributionVersions).filter(
+                          (key: string) => versions?.includes(distributionVersions[key]),
                         )}
                         placeholderText={versions?.length ? '' : 'Any version'}
                         setSelected={(value) => setVersionSelected(value, index)}

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
@@ -516,8 +516,8 @@ const EditContentForm = ({
                       toggleId={'versionSelection' + index}
                       options={Object.keys(distributionVersions)}
                       variant={SelectVariant.typeaheadMulti}
-                      selectedProp={Object.keys(distributionVersions).filter((key: string) =>
-                        versions?.includes(distributionVersions[key]),
+                      selectedProp={Object.keys(distributionVersions).filter(
+                        (key: string) => versions?.includes(distributionVersions[key]),
                       )}
                       placeholderText={versions?.length ? '' : 'Any version'}
                       setSelected={(value) => setVersionSelected(value, index)}

--- a/src/Pages/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
@@ -241,12 +241,8 @@ export default function SnapshotListModal() {
                       <Td>{new Date(created_at).toUTCString()}</Td>
                       <Td>
                         <ChangedArrows
-                          addedCount={
-                            (added_counts?.['rpm.package'] || 0)
-                          }
-                          removedCount={
-                            (removed_counts?.['rpm.package'] || 0)
-                          }
+                          addedCount={added_counts?.['rpm.package'] || 0}
+                          removedCount={removed_counts?.['rpm.package'] || 0}
                         />
                       </Td>
                       <Td>{content_counts?.['rpm.package'] || 0}</Td>

--- a/src/middleware/AppContext.tsx
+++ b/src/middleware/AppContext.tsx
@@ -40,9 +40,9 @@ export const ContextProvider = ({ children }: { children: ReactNode }) => {
     (async () => {
       const fetchedFeatures = await fetchFeatures();
       // Disable snapshotting in prod stable
-      if (chrome.isProd() && !chrome.isBeta() && fetchedFeatures?. snapshots?.accessible) {
+      if (chrome.isProd() && !chrome.isBeta() && fetchedFeatures?.snapshots?.accessible) {
         if (fetchedFeatures !== null && fetchedFeatures.snapshots !== undefined) {
-          fetchedFeatures.snapshots.accessible = false
+          fetchedFeatures.snapshots.accessible = false;
         }
       }
       setFeatures(fetchedFeatures);


### PR DESCRIPTION
## Summary

- We can't sort on the combined status ([PR here](https://github.com/content-services/content-sources-backend/pull/587)) as it's not stored in the db, so this change disables sorting on the status column in the ContentListTable

## Testing steps

- Status column should not be sortable