### PR TITLE
Fixes 3608: switches in repo modals cause infinite loading 

### DIFF
--- a/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
@@ -235,7 +235,10 @@ const AddContent = () => {
   };
 
   const updateVariable = (index: number, newValue, callback?: () => void) => {
-    setChangeVerified(false);
+    // ensures no unnecessary validation occurs 
+    if (newValue['name'] || newValue['url'] || newValue['gpgKey'] || newValue['metadataVerification']) {
+      setChangeVerified(false);
+    }
     const updatedData = [...formik.values];
     updatedData[index] = { ...updatedData[index], ...newValue };
     formik.setValues(updatedData).then(callback);

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
@@ -215,7 +215,10 @@ const EditContentForm = ({
   };
 
   const updateVariable = (index: number, newValue) => {
-    setChangeVerified(false);
+    // ensures no unnecessary validation occurs
+    if (newValue['name'] || newValue['url'] || newValue['gpgKey'] || newValue['metadataVerification']) {
+      setChangeVerified(false);
+    }
     const updatedData = [...formik.values];
     updatedData[index] = { ...updatedData[index], ...newValue };
     formik.setValues(updatedData);


### PR DESCRIPTION
## Summary

- In the add/edit repository modals, when a user rapidly toggles the switches to enable/disable snapshots or modularity filtering, this triggers an infinite loading state of the Save button and it never becomes clickable
- This change fixes that 

## Testing steps

- Toggle the snapshot or modularity filtering switches quickly, the Save button should become clickable 
