### PR TITLE
Refs 3720: Migrate to new snapshot apis

### DIFF
--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -287,7 +287,7 @@ export const getSnapshotsByDate = async (
   uuids: string[],
   date: string,
 ): Promise<SnapshotByDateResponse[]> => {
-  const { data } = await axios.post('/api/content-sources/v1/repositories/snapshots/for_date/', {
+  const { data } = await axios.post('/api/content-sources/v1/snapshots/for_date/', {
     repository_uuids: uuids,
     date,
   });
@@ -403,11 +403,10 @@ export const triggerSnapshot: (repositoryUUID: string) => Promise<void> = async 
 };
 
 export const getRepoConfigFile: (
-  repo_uuid: string,
   snapshot_uuid: string,
-) => Promise<string> = async (repo_uuid, snapshot_uuid) => {
+) => Promise<string> = async (snapshot_uuid) => {
   const { data } = await axios.get(
-    `/api/content-sources/v1/repositories/${repo_uuid}/snapshots/${snapshot_uuid}/config.repo`,
+    `/api/content-sources/v1/snapshots/${snapshot_uuid}/config.repo`,
   );
   return data;
 };

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -615,7 +615,7 @@ export const useGetRepoConfigFileQuery = (repo_uuid: string, snapshot_uuid: stri
   const errorNotifier = useErrorNotification();
   return useMutation<string>(
     [REPO_CONFIG_FILE_KEY, repo_uuid, snapshot_uuid],
-    async () => await getRepoConfigFile(repo_uuid, snapshot_uuid),
+    async () => await getRepoConfigFile(snapshot_uuid),
     {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       onError: (err: any) => {


### PR DESCRIPTION
## Summary

adapts the frontend to the changes here: https://github.com/content-services/content-sources-backend/pull/596

## Testing steps

Test with backend and see that fetching snapshot config file works and that you can create a content template without error