### PR TITLE
Fixes 3473: snapshot status update

### DIFF
--- a/src/Pages/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/ContentListTable/ContentListTable.tsx
@@ -541,10 +541,10 @@ const ContentListTable = () => {
                         distribution_arch,
                         distribution_versions,
                         last_introspection_time,
-                        status
+                        status,
                       } = rowData;
                       return (
-                        <Tr key={uuid+status}>
+                        <Tr key={uuid + status}>
                           <Hide hide={!rbac?.write || isRedHatRepository}>
                             <Td
                               select={{

--- a/src/Pages/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/ContentListTable/ContentListTable.tsx
@@ -407,6 +407,19 @@ const ContentListTable = () => {
     throw new Error('Unable to load Red Hat repositories');
   }
 
+  const showPendingTooltip = (
+    snapshotStatus: string | undefined,
+    introspectStatus: string | undefined,
+  ) => {
+    if (!snapshotStatus && !introspectStatus) {
+      return 'Introspection or snapshotting is in progress';
+    } else if (snapshotStatus === 'running' || snapshotStatus === 'pending') {
+      return 'Snapshotting is in progress';
+    } else if (introspectStatus === 'Pending') {
+      return 'Introspection is in progress';
+    }
+  };
+
   return (
     <>
       <Outlet
@@ -528,9 +541,10 @@ const ContentListTable = () => {
                         distribution_arch,
                         distribution_versions,
                         last_introspection_time,
+                        status
                       } = rowData;
                       return (
-                        <Tr key={uuid}>
+                        <Tr key={uuid+status}>
                           <Hide hide={!rbac?.write || isRedHatRepository}>
                             <Td
                               select={{
@@ -582,7 +596,10 @@ const ContentListTable = () => {
                               <ConditionalTooltip
                                 content={
                                   rowData?.status == 'Pending'
-                                    ? 'Introspection is in progress'
+                                    ? showPendingTooltip(
+                                        rowData?.last_snapshot_task?.status,
+                                        rowData.status,
+                                      )
                                     : 'You do not have the required permissions to perform this action.'
                                 }
                                 show={

--- a/src/Pages/ContentListTable/components/EditContentModal/helpers.test.ts
+++ b/src/Pages/ContentListTable/components/EditContentModal/helpers.test.ts
@@ -54,6 +54,7 @@ it('mapToDefaultFormikValues', () => {
       metadata_verification: false,
       snapshot: false,
       module_hotfixes: false,
+      last_introspection_status: 'stuffAndThings',
     },
   ];
   const mapped = [

--- a/src/Pages/ContentListTable/components/StatusIcon.test.tsx
+++ b/src/Pages/ContentListTable/components/StatusIcon.test.tsx
@@ -23,14 +23,6 @@ it('Render with Valid status', () => {
   expect(SelectComponent).toBeInTheDocument();
 });
 
-it('Render with Invalid status', () => {
-  const { queryByText } = render(
-    <StatusIcon rowData={{ ...defaultContentItem, status: 'Invalid' }} />,
-  );
-  const SelectComponent = queryByText('Invalid');
-  expect(SelectComponent).toBeInTheDocument();
-});
-
 it('Render with Unavailable status', async () => {
   const { queryByText } = render(
     <StatusIcon rowData={{ ...defaultContentItem, status: 'Unavailable' }} />,
@@ -44,6 +36,7 @@ it('Render with Unavailable status', async () => {
 
   await waitFor(() => {
     expect(queryByText('Retry')).toBeInTheDocument();
+    expect(queryByText('snapshot failed')).toBeInTheDocument();
   });
 });
 
@@ -60,5 +53,6 @@ it('Render with Invalid status', async () => {
 
   await waitFor(() => {
     expect(queryByText('Retry')).toBeInTheDocument();
+    expect(queryByText('snapshot failed')).toBeInTheDocument();
   });
 });

--- a/src/Pages/ContentListTable/components/StatusIcon.tsx
+++ b/src/Pages/ContentListTable/components/StatusIcon.tsx
@@ -98,15 +98,26 @@ const StatusIcon = ({
     failed_introspections_count: failedIntrospectionsCount,
     last_introspection_time: lastIntrospectionTime,
     last_introspection_error: error,
+    last_snapshot_task,
   },
   retryHandler,
 }: Props) => {
   const classes = useStyles();
 
+  const showError = (snapshotError: string | undefined, introspectError: string | undefined) => {
+    if (!snapshotError && !introspectError) {
+      return 'An unknown error occurred';
+    } else if (snapshotError) {
+      return snapshotError;
+    } else if (introspectError) {
+      return introspectError;
+    }
+  };
+
   switch (status) {
     case 'Valid':
       return (
-        <Flex alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'row' }}>
+        <Flex key={`${status}_${uuid}`} alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'row' }}>
           <FlexItem spacer={{ default: 'spacerSm' }}>
             <CheckCircleIcon color={green} />
           </FlexItem>
@@ -117,7 +128,7 @@ const StatusIcon = ({
       );
     case 'Invalid':
       return (
-        <Flex alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'row' }}>
+        <Flex key={`${status}_${uuid}`} alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'row' }}>
           <FlexItem spacer={{ default: 'spacerSm' }}>
             <ExclamationCircleIcon color={red} />
           </FlexItem>
@@ -129,7 +140,7 @@ const StatusIcon = ({
               headerIcon={<ExclamationCircleIcon />}
               bodyContent={
                 <PopoverDescription
-                  error={error}
+                  error={showError(last_snapshot_task?.error, error)}
                   count={failedIntrospectionsCount}
                   time={lastIntrospectionTime}
                 />
@@ -148,7 +159,7 @@ const StatusIcon = ({
       );
     case 'Unavailable':
       return (
-        <Flex alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'row' }}>
+        <Flex key={`${status}_${uuid}`} alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'row' }}>
           <FlexItem spacer={{ default: 'spacerSm' }}>
             <ExclamationTriangleIcon color={gold} />
           </FlexItem>
@@ -160,7 +171,7 @@ const StatusIcon = ({
               headerIcon={<ExclamationTriangleIcon />}
               bodyContent={
                 <PopoverDescription
-                  error={error}
+                  error={showError(last_snapshot_task?.error, error)}
                   count={failedIntrospectionsCount}
                   time={lastIntrospectionTime}
                 />
@@ -177,8 +188,15 @@ const StatusIcon = ({
       );
     case 'Pending':
       return (
-        <Tooltip position='top-start' content='Repository is being introspected'>
-          <Flex alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'row' }}>
+        <Tooltip
+          position='top-start'
+          content={
+            last_snapshot_task?.status === 'running' || last_snapshot_task?.status === 'pending'
+              ? 'Repository snapshot in progress'
+              : 'Repository introspection in progress'
+          }
+        >
+          <Flex key={`${status}_${uuid}`} alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'row' }}>
             <FlexItem spacer={{ default: 'spacerSm' }}>
               <Spinner size='md' className={classes.spinner} />
             </FlexItem>
@@ -188,8 +206,8 @@ const StatusIcon = ({
           </Flex>
         </Tooltip>
       );
-    default:
-      return <></>;
+    default: 
+      return <></>;  
   }
 };
 

--- a/src/Pages/ContentListTable/components/StatusIcon.tsx
+++ b/src/Pages/ContentListTable/components/StatusIcon.tsx
@@ -117,7 +117,11 @@ const StatusIcon = ({
   switch (status) {
     case 'Valid':
       return (
-        <Flex key={`${status}_${uuid}`} alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'row' }}>
+        <Flex
+          key={`${status}_${uuid}`}
+          alignContent={{ default: 'alignContentCenter' }}
+          direction={{ default: 'row' }}
+        >
           <FlexItem spacer={{ default: 'spacerSm' }}>
             <CheckCircleIcon color={green} />
           </FlexItem>
@@ -128,7 +132,11 @@ const StatusIcon = ({
       );
     case 'Invalid':
       return (
-        <Flex key={`${status}_${uuid}`} alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'row' }}>
+        <Flex
+          key={`${status}_${uuid}`}
+          alignContent={{ default: 'alignContentCenter' }}
+          direction={{ default: 'row' }}
+        >
           <FlexItem spacer={{ default: 'spacerSm' }}>
             <ExclamationCircleIcon color={red} />
           </FlexItem>
@@ -159,7 +167,11 @@ const StatusIcon = ({
       );
     case 'Unavailable':
       return (
-        <Flex key={`${status}_${uuid}`} alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'row' }}>
+        <Flex
+          key={`${status}_${uuid}`}
+          alignContent={{ default: 'alignContentCenter' }}
+          direction={{ default: 'row' }}
+        >
           <FlexItem spacer={{ default: 'spacerSm' }}>
             <ExclamationTriangleIcon color={gold} />
           </FlexItem>
@@ -196,7 +208,11 @@ const StatusIcon = ({
               : 'Repository introspection in progress'
           }
         >
-          <Flex key={`${status}_${uuid}`} alignContent={{ default: 'alignContentCenter' }} direction={{ default: 'row' }}>
+          <Flex
+            key={`${status}_${uuid}`}
+            alignContent={{ default: 'alignContentCenter' }}
+            direction={{ default: 'row' }}
+          >
             <FlexItem spacer={{ default: 'spacerSm' }}>
               <Spinner size='md' className={classes.spinner} />
             </FlexItem>
@@ -206,8 +222,8 @@ const StatusIcon = ({
           </Flex>
         </Tooltip>
       );
-    default: 
-      return <></>;  
+    default:
+      return <></>;
   }
 };
 

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { objectToUrlParams } from '../../helpers';
+import { AdminTask } from '../AdminTasks/AdminTaskApi';
 
 export interface ContentItem {
   uuid: string;
@@ -21,6 +22,8 @@ export interface ContentItem {
   last_snapshot_uuid?: string;
   last_snapshot?: SnapshotItem;
   label?: string;
+  last_snapshot_task?: AdminTask;
+  last_introspection_status: string;
 }
 
 export interface PopularRepository {

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -165,7 +165,7 @@ export const useAddContentQuery = (queryClient: QueryClient, request: CreateCont
   const { notify } = useNotification();
   return useMutation(() => AddContentListItems(request.filter((item) => !!item)), {
     onSuccess: (data: CreateContentRequestResponse) => {
-      const hasPending = (data as ContentItem[]).some(({ status }) =>  status === 'Pending');
+      const hasPending = (data as ContentItem[]).some(({ status }) => status === 'Pending');
 
       notify({
         variant: AlertVariant.success,

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -165,7 +165,7 @@ export const useAddContentQuery = (queryClient: QueryClient, request: CreateCont
   const { notify } = useNotification();
   return useMutation(() => AddContentListItems(request.filter((item) => !!item)), {
     onSuccess: (data: CreateContentRequestResponse) => {
-      const hasPending = (data as ContentItem[]).some(({ status }) => status === 'Pending');
+      const hasPending = (data as ContentItem[]).some(({ status }) =>  status === 'Pending');
 
       notify({
         variant: AlertVariant.success,

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -130,25 +130,6 @@ export const defaultPopularRepository: PopularRepository = {
   metadata_verification: false,
 };
 
-export const defaultContentItem: ContentItem = {
-  uuid: '053603c7-6ef0-4abe-8542-feacb8f7d575',
-  name: 'SteveTheRepo',
-  package_count: 100,
-  url: 'https://stevetheRepo.org/epel/9',
-  status: 'Pending',
-  account_id: '',
-  org_id: 'acme',
-  distribution_arch: 'x86_64',
-  gpg_key: defaultPopularRepository.gpg_key,
-  distribution_versions: ['9'],
-  last_introspection_error: '',
-  last_introspection_time: '2023-03-07 17:13:48.619192 -0500 EST',
-  failed_introspections_count: 0,
-  metadata_verification: false,
-  snapshot: false,
-  module_hotfixes: false,
-};
-
 export const defaultIntrospectTask: AdminTask = {
   uuid: '2375c35b-a67a-4ac2-a989-21139433c172',
   account_id: '11593016',
@@ -167,6 +148,7 @@ export const defaultIntrospectTask: AdminTask = {
 export const defaultSnapshotTask: AdminTask = {
   ...defaultIntrospectTask,
   typename: 'snapshot',
+  error: 'snapshot failed',
   pulp: {
     sync: {
       syncData: 'syncValue',
@@ -178,6 +160,27 @@ export const defaultSnapshotTask: AdminTask = {
       distributionData: 'distributionValue',
     },
   },
+};
+
+export const defaultContentItem: ContentItem = {
+  uuid: '053603c7-6ef0-4abe-8542-feacb8f7d575',
+  name: 'SteveTheRepo',
+  package_count: 100,
+  url: 'https://stevetheRepo.org/epel/9',
+  status: 'Pending',
+  account_id: '',
+  org_id: 'acme',
+  distribution_arch: 'x86_64',
+  gpg_key: defaultPopularRepository.gpg_key,
+  distribution_versions: ['9'],
+  last_introspection_error: '',
+  last_introspection_time: '2023-03-07 17:13:48.619192 -0500 EST',
+  failed_introspections_count: 0,
+  metadata_verification: false,
+  snapshot: false,
+  module_hotfixes: false,
+  last_snapshot_task: defaultSnapshotTask,
+  last_introspection_status: 'Pending',
 };
 
 export const defaultMetaItem: Meta = {
@@ -237,6 +240,7 @@ export const defaultContentItemWithSnapshot: ContentItem = {
   snapshot: true,
   last_snapshot: defaultSnapshotItem,
   module_hotfixes: false,
+  last_introspection_status: '',
 };
 
 export const defaultTemplateItem: TemplateItem = {


### PR DESCRIPTION
## Summary

- Updates ContentListTable's StatusIcon to use the unified status for introspection and snapshotting

## Testing steps

- Needs to be tested with this [backend PR](https://github.com/content-services/content-sources-backend/pull/587)
- Introspect and snapshot a few repositories 
- The repository's unified status should be reflected in the UI instead of the last introspection status
- If a repository's status is In progress and the snapshot task is running, you should see a tooltip on the status with content `Repository snapshot in progress`. Otherwise if the status is pending you should see `Repository is being introspected`
- If a repository's status is Invalid and there is a snapshot error, you should see that error in the tooltip. Otherwise, if there's an introspection error, you should see that one. If neither has an error, you should see `An unknown error occurred`
- Same as above if a repository's status is Unavailable