### PR TITLE
Fixes 2938: Add Errata tab to snapshot details

### DIFF
--- a/src/Hooks/useDebounce.tsx
+++ b/src/Hooks/useDebounce.tsx
@@ -7,7 +7,7 @@ function useDebounce<T>(value: T, delay?: number): T {
   useEffect(() => {
     // We need to make sure that we compare-deep here as the default useEffect deps do not.
     if (!isEqual(value, debouncedValue)) {
-      const timer = setTimeout(() => setDebouncedValue(value), delay || 500);
+      const timer = setTimeout(() => setDebouncedValue(value), delay !== undefined ? delay : 500);
 
       return () => {
         clearTimeout(timer);

--- a/src/Pages/AdminTaskTable/AdminTaskTable.test.tsx
+++ b/src/Pages/AdminTaskTable/AdminTaskTable.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 import { ReactQueryTestWrapper, defaultIntrospectTask } from '../../testingHelpers';
 import AdminTaskTable from './AdminTaskTable';
 import { useAdminTaskListQuery } from '../../services/AdminTasks/AdminTaskQueries';
-import { formatDateToHumanReadable } from '../../helpers';
+import { formatDateDDMMMYYYY } from '../../helpers';
 
 jest.mock('../../services/AdminTasks/AdminTaskQueries', () => ({
   useAdminTaskListQuery: jest.fn(),
@@ -74,6 +74,6 @@ it('Render with a single row', () => {
     ),
   ).toBeInTheDocument();
   expect(
-    queryByText(formatDateToHumanReadable(defaultIntrospectTask.queued_at)),
+    queryByText(formatDateDDMMMYYYY(defaultIntrospectTask.queued_at, true)),
   ).toBeInTheDocument();
 });

--- a/src/Pages/AdminTaskTable/AdminTaskTable.tsx
+++ b/src/Pages/AdminTaskTable/AdminTaskTable.tsx
@@ -29,7 +29,7 @@ import StatusIcon from './components/StatusIcon';
 import { useAdminTaskListQuery } from '../../services/AdminTasks/AdminTaskQueries';
 import { AdminTaskFilterData, AdminTask } from '../../services/AdminTasks/AdminTaskApi';
 import { Outlet, useNavigate } from 'react-router-dom';
-import { formatDateToHumanReadable } from '../../helpers';
+import { formatDateDDMMMYYYY } from '../../helpers';
 
 const useStyles = createUseStyles({
   mainContainer: {
@@ -213,7 +213,7 @@ const AdminTaskTable = () => {
                   <Td>{adminTask.org_id}</Td>
                   <Td>{adminTask.account_id ? adminTask.account_id : 'Unknown'}</Td>
                   <Td>{adminTask.typename}</Td>
-                  <Td>{formatDateToHumanReadable(adminTask.queued_at)}</Td>
+                  <Td>{formatDateDDMMMYYYY(adminTask.queued_at, true)}</Td>
                   <Td>
                     <StatusIcon status={adminTask.status} />
                   </Td>

--- a/src/Pages/AdminTaskTable/components/AdminTaskFilters.tsx
+++ b/src/Pages/AdminTaskTable/components/AdminTaskFilters.tsx
@@ -11,7 +11,7 @@ import {
   InputGroupText,
 } from '@patternfly/react-core';
 import { SelectVariant } from '@patternfly/react-core/deprecated';
-import DropdownSelect from '../../../components/DropdownSelect/DropdownSelect';
+import DropdownSelect from '../../../components/DropdownSelect_Deprecated/DropdownSelect_Deprecated';
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import { global_BackgroundColor_100 } from '@patternfly/react-tokens';
 import Hide from '../../../components/Hide/Hide';

--- a/src/Pages/AdminTaskTable/components/ViewPayloadModal/components/AdminTaskInfo.test.tsx
+++ b/src/Pages/AdminTaskTable/components/ViewPayloadModal/components/AdminTaskInfo.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 import AdminTaskInfo from './AdminTaskInfo';
 import { AdminTask } from '../../../../../services/AdminTasks/AdminTaskApi';
 import { defaultIntrospectTask } from '../../../../../testingHelpers';
-import { formatDateToHumanReadable } from '../../../../../helpers';
+import { formatDateDDMMMYYYY } from '../../../../../helpers';
 
 jest.mock('../../../../../middleware/AppContext', () => ({
   useAppContext: () => ({ rbac: { read: true, write: true } }),
@@ -17,13 +17,13 @@ it('Render with all fields', () => {
   expect(queryByText(defaultIntrospectTask.typename)).toBeInTheDocument();
   expect(queryByText(defaultIntrospectTask.status)).toBeInTheDocument();
   expect(
-    queryByText(formatDateToHumanReadable(defaultIntrospectTask.queued_at)),
+    queryByText(formatDateDDMMMYYYY(defaultIntrospectTask.queued_at, true)),
   ).toBeInTheDocument();
   expect(
-    queryByText(formatDateToHumanReadable(defaultIntrospectTask.started_at)),
+    queryByText(formatDateDDMMMYYYY(defaultIntrospectTask.started_at, true)),
   ).toBeInTheDocument();
   expect(
-    queryByText(formatDateToHumanReadable(defaultIntrospectTask.finished_at)),
+    queryByText(formatDateDDMMMYYYY(defaultIntrospectTask.finished_at, true)),
   ).toBeInTheDocument();
   expect(queryByText(defaultIntrospectTask.error)).toBeInTheDocument();
 });
@@ -44,7 +44,7 @@ it('Render without optional fields', () => {
   expect(queryByText(missingOptional.org_id)).toBeInTheDocument();
   expect(queryByText(missingOptional.typename)).toBeInTheDocument();
   expect(queryByText(missingOptional.status)).toBeInTheDocument();
-  expect(queryByText(formatDateToHumanReadable(missingOptional.queued_at))).toBeInTheDocument();
+  expect(queryByText(formatDateDDMMMYYYY(missingOptional.queued_at, true))).toBeInTheDocument();
   expect(queryByText('Not started')).toBeInTheDocument();
   expect(queryByText('Not finished')).toBeInTheDocument();
   expect(queryByText('None')).toBeInTheDocument();

--- a/src/Pages/AdminTaskTable/components/ViewPayloadModal/components/AdminTaskInfo.tsx
+++ b/src/Pages/AdminTaskTable/components/ViewPayloadModal/components/AdminTaskInfo.tsx
@@ -5,7 +5,7 @@ import {
   DescriptionListTerm,
 } from '@patternfly/react-core';
 import { AdminTask } from '../../../../../services/AdminTasks/AdminTaskApi';
-import { formatDateToHumanReadable } from '../../../../../helpers';
+import { formatDateDDMMMYYYY } from '../../../../../helpers';
 
 export interface AdminTaskInfoProps {
   adminTask: AdminTask;
@@ -37,19 +37,19 @@ const AdminTaskInfo = ({ adminTask }: AdminTaskInfoProps) => (
     <DescriptionListGroup>
       <DescriptionListTerm>Queued At</DescriptionListTerm>
       <DescriptionListDescription>
-        {formatDateToHumanReadable(adminTask.queued_at)}
+        {formatDateDDMMMYYYY(adminTask.queued_at, true)}
       </DescriptionListDescription>
     </DescriptionListGroup>
     <DescriptionListGroup>
       <DescriptionListTerm>Started At</DescriptionListTerm>
       <DescriptionListDescription>
-        {adminTask.started_at ? formatDateToHumanReadable(adminTask.started_at) : 'Not started'}
+        {adminTask.started_at ? formatDateDDMMMYYYY(adminTask.started_at, true) : 'Not started'}
       </DescriptionListDescription>
     </DescriptionListGroup>
     <DescriptionListGroup>
       <DescriptionListTerm>Finished At</DescriptionListTerm>
       <DescriptionListDescription>
-        {adminTask.finished_at ? formatDateToHumanReadable(adminTask.finished_at) : 'Not finished'}
+        {adminTask.finished_at ? formatDateDDMMMYYYY(adminTask.finished_at, true) : 'Not finished'}
       </DescriptionListDescription>
     </DescriptionListGroup>
     <DescriptionListGroup>

--- a/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
@@ -46,7 +46,7 @@ import {
   useValidateContentList,
 } from '../../../../services/Content/ContentQueries';
 import { RepositoryParamsResponse } from '../../../../services/Content/ContentApi';
-import DropdownSelect from '../../../../components/DropdownSelect/DropdownSelect';
+import DropdownSelect from '../../../../components/DropdownSelect_Deprecated/DropdownSelect_Deprecated';
 import { useQueryClient } from 'react-query';
 import ConditionalTooltip from '../../../../components/ConditionalTooltip/ConditionalTooltip';
 import { isEmpty, isEqual } from 'lodash';

--- a/src/Pages/ContentListTable/components/ContentListFilters.tsx
+++ b/src/Pages/ContentListTable/components/ContentListFilters.tsx
@@ -13,7 +13,7 @@ import {
   ToggleGroupItem,
 } from '@patternfly/react-core';
 import { SelectVariant } from '@patternfly/react-core/deprecated';
-import DropdownSelect from '../../../components/DropdownSelect/DropdownSelect';
+import DropdownSelect from '../../../components/DropdownSelect_Deprecated/DropdownSelect_Deprecated';
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import { global_BackgroundColor_100 } from '@patternfly/react-tokens';
 import Hide from '../../../components/Hide/Hide';

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
@@ -31,7 +31,7 @@ import {
   EditContentRequest,
   RepositoryParamsResponse,
 } from '../../../../services/Content/ContentApi';
-import DropdownSelect from '../../../../components/DropdownSelect/DropdownSelect';
+import DropdownSelect from '../../../../components/DropdownSelect_Deprecated/DropdownSelect_Deprecated';
 import { useQueryClient } from 'react-query';
 import {
   failedFileUpload,

--- a/src/Pages/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.tsx
@@ -10,14 +10,15 @@ import {
 } from '@patternfly/react-core';
 import { InnerScrollContainer } from '@patternfly/react-table';
 import { ContentOrigin } from '../../../../services/Content/ContentApi';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import useRootPath from '../../../../Hooks/useRootPath';
 import { useAppContext } from '../../../../middleware/AppContext';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { SnapshotPackagesTab } from './Tabs/SnapshotPackagesTab';
 import { createUseStyles } from 'react-jss';
 import { SnapshotSelector } from './SnapshotSelector';
 import { REPOSITORIES_ROUTE } from '../../../../Routes/constants';
+import { SnapshotErrataTab } from './Tabs/SnapshotErrataTab';
 
 const useStyles = createUseStyles({
   modalBody: {
@@ -30,18 +31,34 @@ const useStyles = createUseStyles({
   },
 });
 
+export enum SnapshotDetailTab {
+  PACKAGES = 'packages',
+  ERRATA = 'errata',
+}
+
 export default function SnapshotDetailsModal() {
   const { contentOrigin } = useAppContext();
   const classes = useStyles();
   const { repoUUID, snapshotUUID } = useParams();
+  const [urlSearchParams, setUrlSearchParams] = useSearchParams();
   const rootPath = useRootPath();
   const navigate = useNavigate();
   const [activeTabKey, setActiveTabKey] = useState<string | number>(0);
+
+  useEffect(() => {
+    if (
+      contentOrigin === ContentOrigin.REDHAT ||
+      urlSearchParams.get('tab') === SnapshotDetailTab.ERRATA
+    ) {
+      setActiveTabKey(1);
+    }
+  }, []);
 
   const handleTabClick = (
     _: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: string | number,
   ) => {
+    setUrlSearchParams(tabIndex ? { tab: SnapshotDetailTab.ERRATA } : {});
     setActiveTabKey(tabIndex);
   };
 
@@ -88,6 +105,13 @@ export default function SnapshotDetailsModal() {
                 aria-label='Snapshot package detail tab'
               >
                 <SnapshotPackagesTab />
+              </Tab>
+              <Tab
+                eventKey={1}
+                title={<TabTitleText>Advisories</TabTitleText>}
+                aria-label='Snapshot errata detail tab'
+              >
+                <SnapshotErrataTab />
               </Tab>
             </Tabs>
           </StackItem>

--- a/src/Pages/ContentListTable/components/SnapshotDetailsModal/SnapshotSelector.test.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotDetailsModal/SnapshotSelector.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import { SnapshotSelector } from './SnapshotSelector';
 import { useGetSnapshotList } from '../../../../services/Content/ContentQueries';
 import { defaultMetaItem, defaultSnapshotItem } from '../../../../testingHelpers';
+import { formatDateDDMMMYYYY } from '../../../../helpers';
 
 jest.mock('../../../../Hooks/useRootPath', () => () => 'someUrl');
 
@@ -30,6 +31,6 @@ it('Render SnapshotSelector', () => {
 
   // This is testing the date format specifically.
   // if we update the date format, this test needs updating as well.
-  const selectorElement = getByText(new Date(defaultSnapshotItem.created_at).toUTCString());
+  const selectorElement = getByText(formatDateDDMMMYYYY(defaultSnapshotItem.created_at, true));
   expect(selectorElement).toBeInTheDocument();
 });

--- a/src/Pages/ContentListTable/components/SnapshotDetailsModal/SnapshotSelector.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotDetailsModal/SnapshotSelector.tsx
@@ -2,11 +2,12 @@ import { Form, FormGroup } from '@patternfly/react-core';
 import { createUseStyles } from 'react-jss';
 import { useNavigate, useParams } from 'react-router-dom';
 import { SelectVariant } from '@patternfly/react-core/deprecated';
-import DropdownSelect from '../../../../components/DropdownSelect/DropdownSelect';
+import DropdownSelect from '../../../../components/DropdownSelect_Deprecated/DropdownSelect_Deprecated';
 import { useGetSnapshotList } from '../../../../services/Content/ContentQueries';
 import { useMemo } from 'react';
 import useRootPath from '../../../../Hooks/useRootPath';
 import { REPOSITORIES_ROUTE } from '../../../../Routes/constants';
+import { formatDateDDMMMYYYY } from '../../../../helpers';
 
 const useStyles = createUseStyles({
   mainContainer: {
@@ -30,7 +31,7 @@ export function SnapshotSelector() {
     const dateMap = {};
     const uuidMap = {};
     data?.data.forEach(({ uuid, created_at }) => {
-      const date = new Date(created_at).toUTCString();
+      const date = formatDateDDMMMYYYY(created_at, true);
       uuidMap[uuid] = date;
       dateMap[date] = uuid;
     });

--- a/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataFilters.test.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataFilters.test.tsx
@@ -3,11 +3,10 @@ import SnapshotErrataFilters from './SnapshotErrataFilters';
 import { ContentOrigin } from '../../../../../services/Content/ContentApi';
 
 jest.mock('../../../../../middleware/AppContext', () => ({
-    useAppContext: () => ({
-      contentOrigin: ContentOrigin.EXTERNAL,
-    }),
-  }));
-  
+  useAppContext: () => ({
+    contentOrigin: ContentOrigin.EXTERNAL,
+  }),
+}));
 
 jest.mock('react-router-dom', () => ({
   useNavigate: jest.fn(),
@@ -45,7 +44,7 @@ it('Select a filter of each type and ensure chips are present', () => {
     />,
   );
 
-  // Filter on Name / Synopsis 
+  // Filter on Name / Synopsis
   const nameOrSynopsisFilter = getByRole('textbox');
   expect(nameOrSynopsisFilter).not.toHaveAttribute('disabled');
   fireEvent.change(nameOrSynopsisFilter, { target: { value: 'EPEL' } });

--- a/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataFilters.test.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataFilters.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import SnapshotErrataFilters from './SnapshotErrataFilters';
+import { ContentOrigin } from '../../../../../services/Content/ContentApi';
+
+jest.mock('../../../../../middleware/AppContext', () => ({
+    useAppContext: () => ({
+      contentOrigin: ContentOrigin.EXTERNAL,
+    }),
+  }));
+  
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock('../../../../../Hooks/useDebounce', () => (value) => value);
+
+it('Render loading state (disabled)', () => {
+  const { getByRole } = render(
+    <SnapshotErrataFilters
+      isLoading={true}
+      setFilterData={() => null}
+      filterData={{
+        search: '',
+        type: [],
+        severity: [],
+      }}
+    />,
+  );
+
+  const filterInput = getByRole('textbox');
+  expect(filterInput).toHaveAttribute('disabled');
+});
+
+it('Select a filter of each type and ensure chips are present', () => {
+  const { queryByText, getByRole } = render(
+    <SnapshotErrataFilters
+      isLoading={false}
+      setFilterData={() => null}
+      filterData={{
+        search: '',
+        type: [],
+        severity: [],
+      }}
+    />,
+  );
+
+  // Filter on Name / Synopsis 
+  const nameOrSynopsisFilter = getByRole('textbox');
+  expect(nameOrSynopsisFilter).not.toHaveAttribute('disabled');
+  fireEvent.change(nameOrSynopsisFilter, { target: { value: 'EPEL' } });
+
+  // Select a Type item
+  const optionMenu = document.getElementsByClassName('pf-v5-c-menu-toggle')[0];
+  waitFor(() => fireEvent.click(optionMenu));
+  const typeOption = queryByText('Type') as HTMLElement;
+  expect(typeOption).toBeInTheDocument();
+  fireEvent.click(typeOption);
+
+  expect(queryByText('Filter by Type')).toBeInTheDocument();
+  const typeSelector = document.getElementsByClassName('pf-v5-c-menu-toggle')[1];
+  fireEvent.click(typeSelector);
+  const typeItem = queryByText('Security') as Element;
+  expect(typeItem).toBeInTheDocument();
+  fireEvent.click(typeItem);
+
+  // Select a Severity item
+  fireEvent.click(optionMenu);
+  const severityOption = queryByText('Severity') as Element;
+  expect(severityOption).toBeInTheDocument();
+  fireEvent.click(severityOption);
+
+  expect(queryByText('Filter by Severity')).toBeInTheDocument();
+  const severitySelector = document.getElementsByClassName('pf-v5-c-menu-toggle')[1];
+  fireEvent.click(severitySelector);
+  const severityItem = queryByText('Critical') as Element;
+  expect(severityItem).toBeInTheDocument();
+  fireEvent.click(severityItem);
+  fireEvent.click(optionMenu);
+
+  // Check all the chips are there
+  expect(queryByText('EPEL')).toBeInTheDocument();
+  expect(queryByText('Security')).toBeInTheDocument();
+  expect(queryByText('Critical')).toBeInTheDocument();
+});

--- a/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataFilters.test.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataFilters.test.tsx
@@ -57,7 +57,7 @@ it('Select a filter of each type and ensure chips are present', () => {
   expect(typeOption).toBeInTheDocument();
   fireEvent.click(typeOption);
 
-  expect(queryByText('Filter by Type')).toBeInTheDocument();
+  expect(queryByText('Filter by type')).toBeInTheDocument();
   const typeSelector = document.getElementsByClassName('pf-v5-c-menu-toggle')[1];
   fireEvent.click(typeSelector);
   const typeItem = queryByText('Security') as Element;
@@ -70,7 +70,7 @@ it('Select a filter of each type and ensure chips are present', () => {
   expect(severityOption).toBeInTheDocument();
   fireEvent.click(severityOption);
 
-  expect(queryByText('Filter by Severity')).toBeInTheDocument();
+  expect(queryByText('Filter by severity')).toBeInTheDocument();
   const severitySelector = document.getElementsByClassName('pf-v5-c-menu-toggle')[1];
   fireEvent.click(severitySelector);
   const severityItem = queryByText('Critical') as Element;

--- a/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataFilters.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataFilters.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Chip,
+  ChipGroup,
+  Flex,
+  FlexItem,
+  InputGroup,
+  TextInput,
+  InputGroupItem,
+  InputGroupText,
+  SelectOptionProps,
+} from '@patternfly/react-core';
+
+import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
+import { global_BackgroundColor_100 } from '@patternfly/react-tokens';
+
+import { createUseStyles } from 'react-jss';
+import useDebounce from '../../../../../Hooks/useDebounce';
+import Hide from '../../../../../components/Hide/Hide';
+import SeverityWithIcon from '../../../../../components/SeverityWithIcon/SeverityWithIcon';
+import DropdownSelect from '../../../../../components/DropdownSelect/DropdownSelect';
+import { isEmpty } from 'lodash';
+
+const useStyles = createUseStyles({
+  chipsContainer: {
+    backgroundColor: global_BackgroundColor_100.value,
+    paddingTop: '16px',
+  },
+  clearFilters: {
+    marginLeft: '16px',
+  },
+});
+
+interface Props {
+  isLoading?: boolean;
+  setFilterData: (filterData: { search: string; type: string[]; severity: string[] }) => void;
+  filterData: { search: string; type: string[]; severity: string[] };
+}
+
+export type Filters = 'Name/Synopsis' | 'Type' | 'Severity';
+
+export default function SnapshotErrataFilters({ isLoading, setFilterData, filterData }: Props) {
+  const classes = useStyles();
+  const filters = ['Name/Synopsis', 'Type', 'Severity'];
+  const [filterType, setFilterType] = useState<Filters>('Name/Synopsis');
+  const [search, setSearch] = useState('');
+  const [types, setTypes] = useState<string[]>([]);
+  const [severities, setSeverities] = useState<string[]>([]);
+
+  const clearFilters = () => {
+    setSearch('');
+    setTypes([]);
+    setSeverities([]);
+  };
+
+  useEffect(() => {
+    // If the filters get cleared at the top level, sense that and clear them here.
+    if (!filterData.search && !filterData.type && !filterData.severity) {
+      clearFilters();
+    }
+  }, [filterData]);
+
+  const {
+    search: debouncedSearch,
+    types: debouncedTypes,
+    severities: debouncedSeverities,
+  } = useDebounce(
+    {
+      search,
+      types,
+      severities,
+    },
+    !search && isEmpty(types) && isEmpty(severities) ? 0 : 500,
+  );
+
+  const addOrRemoveSeverity = (sev: string) =>
+    setSeverities((prev) =>
+      prev.includes(sev) ? prev.filter((item) => item !== sev) : [...prev, sev],
+    );
+
+  const addOrRemoveTypes = (type: string) =>
+    setTypes((prev) =>
+      prev.includes(type) ? prev.filter((item) => item !== type) : [...prev, type],
+    );
+
+  useEffect(() => {
+    setFilterData({
+      search: debouncedSearch,
+      type: debouncedTypes,
+      severity: debouncedSeverities,
+    });
+  }, [debouncedSearch, debouncedTypes, debouncedSeverities]);
+
+  const Filter = useMemo(() => {
+    switch (filterType) {
+      case 'Name/Synopsis':
+        return (
+          <InputGroupItem isFill>
+            <TextInput
+              isDisabled={isLoading}
+              id='search'
+              ouiaId='filter_search'
+              placeholder='Filter by Name/Synopsis'
+              value={search}
+              onChange={(_event, value) => setSearch(value)}
+            />
+            <InputGroupText isDisabled={isLoading} id='search-icon'>
+              <SearchIcon />
+            </InputGroupText>
+          </InputGroupItem>
+        );
+      case 'Type':
+        return (
+          <DropdownSelect
+            onSelect={(_, val) => addOrRemoveTypes(val as string)}
+            options={
+              ['Security', 'Bugfix', 'Enhancement', 'Other'].map((type) => ({
+                key: type,
+                value: type,
+                hasCheckbox: true,
+                isSelected: types.includes(type),
+                children: type,
+              })) as SelectOptionProps[]
+            }
+            toggleValue='Filter by type'
+          />
+        );
+      case 'Severity':
+        return (
+          <DropdownSelect
+            onSelect={(_, val) => addOrRemoveSeverity(val as string)}
+            options={
+              ['Critical', 'Important', 'Moderate', 'Low', 'Unknown'].map((sev) => ({
+                key: sev,
+                value: sev,
+                hasCheckbox: true,
+                isSelected: severities.includes(sev),
+                children: <SeverityWithIcon severity={sev} />,
+              })) as SelectOptionProps[]
+            }
+            toggleValue='Filter by severity'
+          />
+        );
+
+      default:
+        return <></>;
+    }
+  }, [filterType, isLoading, search, types, severities]);
+
+  return (
+    <Flex direction={{ default: 'column' }}>
+      <FlexItem>
+        <InputGroup>
+          <InputGroupItem>
+            <FlexItem>
+              <DropdownSelect
+                key='filtertype'
+                toggleProps={{ isDisabled: isLoading, icon: <FilterIcon /> }}
+                ouiaId='filter_type'
+                options={filters.map((optionName) => ({
+                  key: optionName,
+                  value: optionName,
+                  children: optionName,
+                }))}
+                selected={filterType}
+                onSelect={(_, val) => {
+                  setFilterType(val as Filters);
+                }}
+                toggleValue={filterType}
+              />
+            </FlexItem>
+          </InputGroupItem>
+          <InputGroupItem>
+            <FlexItem>{Filter}</FlexItem>
+          </InputGroupItem>
+        </InputGroup>
+      </FlexItem>
+      <Hide hide={!(search !== '' || !isEmpty(types) || !isEmpty(severities))}>
+        <FlexItem className={classes.chipsContainer}>
+          {search !== '' && (
+            <ChipGroup categoryName='Name/Synopsis'>
+              <Chip key='search_chip' onClick={() => setSearch('')}>
+                {search}
+              </Chip>
+            </ChipGroup>
+          )}
+          {!isEmpty(types) && (
+            <ChipGroup categoryName='Type'>
+              {severities.map((type) => (
+                <Chip key='type_chip' onClick={() => addOrRemoveTypes(type)}>
+                  {type}
+                </Chip>
+              ))}
+            </ChipGroup>
+          )}
+          {!isEmpty(severities) && (
+            <ChipGroup categoryName='Severity'>
+              {severities.map((severity) => (
+                <Chip key='severity_chip' onClick={() => addOrRemoveSeverity(severity)}>
+                  {severity}
+                </Chip>
+              ))}
+            </ChipGroup>
+          )}
+          {(debouncedSearch !== '' && search !== '') || !isEmpty(types) || !isEmpty(severities) ? (
+            <Button className={classes.clearFilters} onClick={clearFilters} variant='link' isInline>
+              Clear filters
+            </Button>
+          ) : (
+            ''
+          )}
+        </FlexItem>
+      </Hide>
+    </Flex>
+  );
+}

--- a/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataFilters.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataFilters.tsx
@@ -101,7 +101,7 @@ export default function SnapshotErrataFilters({ isLoading, setFilterData, filter
               isDisabled={isLoading}
               id='search'
               ouiaId='filter_search'
-              placeholder='Filter by Name/Synopsis'
+              placeholder='Filter by name/synopsis'
               value={search}
               onChange={(_event, value) => setSearch(value)}
             />
@@ -123,7 +123,7 @@ export default function SnapshotErrataFilters({ isLoading, setFilterData, filter
                 children: type,
               })) as SelectOptionProps[]
             }
-            toggleValue='Filter by Type'
+            toggleValue='Filter by type'
           />
         );
       case 'Severity':
@@ -139,7 +139,7 @@ export default function SnapshotErrataFilters({ isLoading, setFilterData, filter
                 children: <SeverityWithIcon severity={sev} />,
               })) as SelectOptionProps[]
             }
-            toggleValue='Filter by Severity'
+            toggleValue='Filter by severity'
           />
         );
 

--- a/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataFilters.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataFilters.tsx
@@ -123,7 +123,7 @@ export default function SnapshotErrataFilters({ isLoading, setFilterData, filter
                 children: type,
               })) as SelectOptionProps[]
             }
-            toggleValue='Filter by type'
+            toggleValue='Filter by Type'
           />
         );
       case 'Severity':
@@ -139,7 +139,7 @@ export default function SnapshotErrataFilters({ isLoading, setFilterData, filter
                 children: <SeverityWithIcon severity={sev} />,
               })) as SelectOptionProps[]
             }
-            toggleValue='Filter by severity'
+            toggleValue='Filter by Severity'
           />
         );
 
@@ -187,7 +187,7 @@ export default function SnapshotErrataFilters({ isLoading, setFilterData, filter
           )}
           {!isEmpty(types) && (
             <ChipGroup categoryName='Type'>
-              {severities.map((type) => (
+              {types.map((type) => (
                 <Chip key='type_chip' onClick={() => addOrRemoveTypes(type)}>
                   {type}
                 </Chip>

--- a/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataTab.test.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataTab.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render } from '@testing-library/react';
+import { ContentOrigin, ErrataItem } from '../../../../../services/Content/ContentApi';
+import { useGetSnapshotErrataQuery } from '../../../../../services/Content/ContentQueries';
+import { SnapshotErrataTab } from './SnapshotErrataTab';
+
+const errataItem: ErrataItem = {
+  id: 'id',
+  errata_id: 'errata id',
+  title: 'errata title',
+  summary: 'bugfix update',
+  description: 'description',
+  issued_date: '20 Aug 2014',
+  updated_date: '25 Sep 2014',
+  type: 'Bugfix',
+  severity: 'important',
+  reboot_suggested: false,
+};
+
+jest.mock('../../../../../Hooks/useDebounce', () => (value) => value);
+
+jest.mock('../../../../../Hooks/useRootPath', () => () => 'someUrl');
+
+jest.mock('../../../../../services/Content/ContentQueries', () => ({
+  useGetSnapshotErrataQuery: jest.fn(),
+}));
+
+jest.mock('../../../../../Hooks/useDebounce', () => (value) => value);
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+  useParams: () => ({
+    repoUUID: 'some-uuid',
+  }),
+}));
+
+jest.mock('../../../../../middleware/AppContext', () => ({
+  useAppContext: () => ({
+    contentOrigin: ContentOrigin.EXTERNAL,
+  }),
+}));
+
+it('Render 1 item in errata list', () => {
+  (useGetSnapshotErrataQuery as jest.Mock).mockImplementation(() => ({
+    isLoading: false,
+    data: {
+      data: [errataItem],
+      meta: { count: 1, limit: 20, offset: 0 },
+    },
+  }));
+
+  const { queryByText } = render(<SnapshotErrataTab />);
+
+  const expandableButton = document.getElementById('expandable-0');
+  fireEvent.click(expandableButton as HTMLElement);
+
+  expect(queryByText(errataItem.errata_id)).toBeInTheDocument();
+  expect(queryByText(errataItem.summary)).toBeInTheDocument();
+  expect(queryByText(errataItem.type)).toBeInTheDocument();
+  expect(queryByText(errataItem.severity)).toBeInTheDocument();
+  expect(queryByText(errataItem.description)).toBeInTheDocument();
+  expect(queryByText(errataItem.issued_date)).toBeInTheDocument();
+  expect(queryByText(errataItem.updated_date)).toBeInTheDocument();
+  expect(queryByText('Reboot is not required')).toBeInTheDocument();
+});

--- a/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataTab.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataTab.tsx
@@ -1,26 +1,22 @@
 import {
   Grid,
   InputGroup,
-  InputGroupItem,
-  TextInput,
-  InputGroupText,
   Pagination,
   Flex,
   FlexItem,
   PaginationVariant,
 } from '@patternfly/react-core';
-import { SearchIcon } from '@patternfly/react-icons';
 import Hide from '../../../../../components/Hide/Hide';
 import { ContentOrigin } from '../../../../../services/Content/ContentApi';
 import { createUseStyles } from 'react-jss';
 import { global_BackgroundColor_100, global_Color_200 } from '@patternfly/react-tokens';
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import useDebounce from '../../../../../Hooks/useDebounce';
 import useRootPath from '../../../../../Hooks/useRootPath';
 import { useAppContext } from '../../../../../middleware/AppContext';
-import { useGetSnapshotPackagesQuery } from '../../../../../services/Content/ContentQueries';
-import PackagesTable from '../../../../../components/SharedTables/PackagesTable';
+import { useGetSnapshotErrataQuery } from '../../../../../services/Content/ContentQueries';
+import AdvisoriesTable from '../../../../../components/SharedTables/AdvisoriesTable';
+import SnapshotErrataFilters from './SnapshotErrataFilters';
 
 const useStyles = createUseStyles({
   description: {
@@ -43,11 +39,15 @@ const useStyles = createUseStyles({
     justifyContent: 'space-between',
     height: 'fit-content',
   },
+  alignTop: {
+    alignItems: 'baseline',
+  },
 });
 
-const perPageKey = 'snapshotPackagePerPage';
+const perPageKey = 'snapshotErrataPerPage';
+const defaultFilterState = { search: '', type: [] as string[], severity: [] as string[] };
 
-export function SnapshotPackagesTab() {
+export function SnapshotErrataTab() {
   const classes = useStyles();
   const { contentOrigin } = useAppContext();
 
@@ -57,20 +57,25 @@ export function SnapshotPackagesTab() {
   const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(storedPerPage);
-  const [searchQuery, setSearchQuery] = useState('');
-
-  const debouncedSearchQuery = useDebounce(searchQuery, !searchQuery ? 0 : 500);
+  const [filterData, setFilterData] = useState(defaultFilterState);
 
   useEffect(() => {
     setPage(1);
-  }, [debouncedSearchQuery]);
+  }, [filterData]);
 
   const {
     isLoading,
     isFetching,
     isError,
     data = { data: [], meta: { count: 0, limit: 20, offset: 0 } },
-  } = useGetSnapshotPackagesQuery(snapshotUUID, page, perPage, debouncedSearchQuery);
+  } = useGetSnapshotErrataQuery(
+    snapshotUUID,
+    page,
+    perPage,
+    filterData.search,
+    filterData.type,
+    filterData.severity,
+  );
 
   useEffect(() => {
     if (isError) {
@@ -90,7 +95,7 @@ export function SnapshotPackagesTab() {
     navigate(rootPath + (contentOrigin === ContentOrigin.REDHAT ? `?origin=${contentOrigin}` : ''));
 
   const {
-    data: packagesList = [],
+    data: errataList = [],
     meta: { count = 0 },
   } = data;
 
@@ -100,20 +105,14 @@ export function SnapshotPackagesTab() {
   return (
     <Grid className={classes.mainContainer}>
       <InputGroup className={classes.topContainer}>
-        <InputGroupItem>
-          <TextInput
-            id='search'
-            ouiaId='name_search'
-            placeholder='Filter by name'
-            value={searchQuery}
-            onChange={(_event, value) => setSearchQuery(value)}
-          />
-          <InputGroupText id='search-icon'>
-            <SearchIcon />
-          </InputGroupText>
-        </InputGroupItem>
+        <SnapshotErrataFilters
+          isLoading={isLoading}
+          filterData={filterData}
+          setFilterData={setFilterData}
+        />
         <Hide hide={isLoading}>
           <Pagination
+            className={classes.alignTop}
             id='top-pagination-id'
             widgetId='topPaginationWidgetId'
             itemCount={count}
@@ -125,11 +124,11 @@ export function SnapshotPackagesTab() {
           />
         </Hide>
       </InputGroup>
-      <PackagesTable
-        packagesList={packagesList}
+      <AdvisoriesTable
+        errataList={errataList}
         isFetchingOrLoading={fetchingOrLoading}
         isLoadingOrZeroCount={loadingOrZeroCount}
-        clearSearch={() => setSearchQuery('')}
+        clearSearch={() => setFilterData(defaultFilterState)}
         perPage={perPage}
       />
       <Flex className={classes.bottomContainer}>

--- a/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotPackagesTab.test.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotPackagesTab.test.tsx
@@ -16,6 +16,8 @@ const packageItem: PackageItem = {
   uuid: '',
 };
 
+jest.mock('../../../../../Hooks/useDebounce', () => (value) => value);
+
 jest.mock('../../../../../Hooks/useRootPath', () => () => 'someUrl');
 
 jest.mock('../../../../../services/Content/ContentQueries', () => ({

--- a/src/Pages/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
+++ b/src/Pages/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
@@ -39,6 +39,8 @@ import { SearchIcon } from '@patternfly/react-icons';
 import { useAppContext } from '../../../../middleware/AppContext';
 import RepoConfig from './components/RepoConfig';
 import { REPOSITORIES_ROUTE } from '../../../../Routes/constants';
+import { SnapshotDetailTab } from '../SnapshotDetailsModal/SnapshotDetailsModal';
+import { formatDateDDMMMYYYY } from '../../../../helpers';
 
 const useStyles = createUseStyles({
   description: {
@@ -239,7 +241,7 @@ export default function SnapshotListModal() {
                     index: number,
                   ) => (
                     <Tr key={created_at + index} data-uuid={snap_uuid}>
-                      <Td>{new Date(created_at).toUTCString()}</Td>
+                      <Td>{formatDateDDMMMYYYY(created_at, true)}</Td>
                       <Td>
                         <ChangedArrows
                           addedCount={added_counts?.['rpm.package'] || 0}
@@ -250,6 +252,7 @@ export default function SnapshotListModal() {
                         <Button
                           variant='link'
                           isInline
+                          isDisabled={!content_counts?.['rpm.package']}
                           onClick={() =>
                             navigate(
                               `${rootPath}/${REPOSITORIES_ROUTE}/${uuid}/snapshots/${snap_uuid}`,
@@ -259,7 +262,20 @@ export default function SnapshotListModal() {
                           {content_counts?.['rpm.package'] || 0}
                         </Button>
                       </Td>
-                      <Td>{content_counts?.['rpm.advisory'] || 0}</Td>
+                      <Td>
+                        <Button
+                          variant='link'
+                          isInline
+                          isDisabled={!content_counts?.['rpm.advisory']}
+                          onClick={() =>
+                            navigate(
+                              `${rootPath}/${REPOSITORIES_ROUTE}/${uuid}/snapshots/${snap_uuid}?tab=${SnapshotDetailTab.ERRATA}`,
+                            )
+                          }
+                        >
+                          {content_counts?.['rpm.advisory'] || 0}
+                        </Button>
+                      </Td>
                       <Td>
                         <RepoConfig repoUUID={uuid} snapUUID={snap_uuid} />
                       </Td>

--- a/src/Pages/TemplatesTable/TemplatesTable.test.tsx
+++ b/src/Pages/TemplatesTable/TemplatesTable.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 import TemplatesTable from './TemplatesTable';
 import { useTemplateList } from '../../services/Templates/TemplateQueries';
 import { ReactQueryTestWrapper, defaultTemplateItem } from '../../testingHelpers';
-import { formatDateToHumanReadable } from '../../helpers';
+import { formatDateDDMMMYYYY } from '../../helpers';
 
 jest.mock('../../services/Templates/TemplateQueries', () => ({
   useTemplateList: jest.fn(),
@@ -49,5 +49,5 @@ it('expect TemplatesTable to render a single row', () => {
   );
 
   expect(queryByText(defaultTemplateItem.name)).toBeInTheDocument();
-  expect(queryByText(formatDateToHumanReadable(defaultTemplateItem.date))).toBeInTheDocument();
+  expect(queryByText(formatDateDDMMMYYYY(defaultTemplateItem.date))).toBeInTheDocument();
 });

--- a/src/Pages/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/TemplatesTable/TemplatesTable.tsx
@@ -35,7 +35,7 @@ import ConditionalTooltip from '../../components/ConditionalTooltip/ConditionalT
 import { useAppContext } from '../../middleware/AppContext';
 import { useRepositoryParams } from '../../services/Content/ContentQueries';
 import TemplateFilters from './components/TemplateFilters';
-import { formatDateToHumanReadable } from '../../helpers';
+import { formatDateDDMMMYYYY } from '../../helpers';
 import { useQueryClient } from 'react-query';
 
 const useStyles = createUseStyles({
@@ -270,7 +270,7 @@ const TemplatesTable = () => {
                     <Td>{description}</Td>
                     <Td>{archesDisplay(arch)}</Td>
                     <Td>{versionDisplay(version)}</Td>
-                    <Td>{formatDateToHumanReadable(date)}</Td>
+                    <Td>{formatDateDDMMMYYYY(date)}</Td>
                     <Td>
                       <ActionsColumn
                         items={[

--- a/src/Pages/TemplatesTable/components/AddTemplate/AddTemplate.tsx
+++ b/src/Pages/TemplatesTable/components/AddTemplate/AddTemplate.tsx
@@ -24,7 +24,7 @@ import DefineContentStep from './steps/DefineContentStep';
 import SetUpDateStep from './steps/SetUpDateStep';
 import DetailStep from './steps/DetailStep';
 import ReviewStep from './steps/ReviewStep';
-import { formatTemplateDate } from '../../../../helpers';
+import { formatDateDDMMMYYYY } from '../../../../helpers';
 import { isEmpty } from 'lodash';
 import { createUseStyles } from 'react-jss';
 
@@ -50,13 +50,13 @@ const AddTemplateBase = () => {
 
   const { mutateAsync: addTemplate, isLoading: isAdding } = useCreateTemplateQuery(queryClient, {
     ...(templateRequest as TemplateRequest),
-    date: formatTemplateDate(templateRequest.date || ''),
+    date: formatDateDDMMMYYYY(templateRequest.date || ''),
   });
 
   const { mutateAsync: editTemplate, isLoading: isEditing } = useEditTemplateQuery(queryClient, {
     uuid: editUUID as string,
     ...(templateRequest as TemplateRequest),
-    date: formatTemplateDate(templateRequest.date || ''),
+    date: formatDateDDMMMYYYY(templateRequest.date || ''),
   });
 
   const addEditAction = isEdit ? editTemplate : addTemplate;

--- a/src/Pages/TemplatesTable/components/AddTemplate/steps/ReviewStep.test.tsx
+++ b/src/Pages/TemplatesTable/components/AddTemplate/steps/ReviewStep.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import { useAddTemplateContext } from '../AddTemplateContext';
 import { defaultTemplateItem, testRepositoryParamsResponse } from '../../../../../testingHelpers';
 import ReviewStep from './ReviewStep';
+import { formatDateDDMMMYYYY } from '../../../../../helpers';
 
 jest.mock('../AddTemplateContext', () => ({
   useAddTemplateContext: jest.fn(),
@@ -23,6 +24,6 @@ it('expect Review step to render correctly', () => {
   expect(getByText('Create')).toBeInTheDocument();
   expect(getByText(defaultTemplateItem.arch)).toBeInTheDocument();
   expect(getByText('el' + defaultTemplateItem.version)).toBeInTheDocument();
-  expect(getByText(defaultTemplateItem.date)).toBeInTheDocument();
+  expect(getByText(formatDateDDMMMYYYY(defaultTemplateItem.date))).toBeInTheDocument();
   expect(getByText(defaultTemplateItem.name)).toBeInTheDocument();
 });

--- a/src/Pages/TemplatesTable/components/AddTemplate/steps/ReviewStep.tsx
+++ b/src/Pages/TemplatesTable/components/AddTemplate/steps/ReviewStep.tsx
@@ -1,6 +1,7 @@
 import { ExpandableSection, Flex, Grid, Text, TextVariants, Title } from '@patternfly/react-core';
 import { useAddTemplateContext } from '../AddTemplateContext';
 import { useMemo, useState } from 'react';
+import { formatDateDDMMMYYYY } from '../../../../../helpers';
 
 export default function ReviewStep() {
   const [expanded, setExpanded] = useState(new Set([0]));
@@ -34,7 +35,7 @@ export default function ReviewStep() {
         'Custom Repositories': selectedCustomRepos.size,
       },
       Date: {
-        Date: date,
+        Date: formatDateDDMMMYYYY(date || ''),
       },
       Details: {
         Name: name,

--- a/src/Pages/TemplatesTable/components/TemplateFilters.tsx
+++ b/src/Pages/TemplatesTable/components/TemplateFilters.tsx
@@ -11,7 +11,7 @@ import {
   InputGroupText,
 } from '@patternfly/react-core';
 import { SelectVariant } from '@patternfly/react-core/deprecated';
-import DropdownSelect from '../../../components/DropdownSelect/DropdownSelect';
+import DropdownSelect from '../../../components/DropdownSelect_Deprecated/DropdownSelect_Deprecated';
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import { global_BackgroundColor_100 } from '@patternfly/react-tokens';
 import Hide from '../../../components/Hide/Hide';

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -7,7 +7,7 @@ import {
   MenuToggleProps,
 } from '@patternfly/react-core';
 import { createUseStyles } from 'react-jss';
-import { useState } from 'react';
+import { ReactElement, useState } from 'react';
 
 const useStyles = createUseStyles({
   menuToggle: {
@@ -17,7 +17,7 @@ const useStyles = createUseStyles({
 
 export interface DropDownMenuProps {
   menuValue: string;
-  dropDownItems?: { value: string; label: string }[];
+  dropDownItems?: { value: string; label: string | ReactElement }[];
   onSelect?: (value?: string | number | undefined) => void;
   isDisabled?: boolean;
   menuToggleProps?: Partial<MenuToggleProps>;
@@ -64,7 +64,7 @@ export default function DropdownMenu({
     >
       <DropdownList>
         {dropDownItems.map(({ value, label }, index) => (
-          <DropdownItem key={value + label + index} value={value}>
+          <DropdownItem key={value + index} value={value}>
             {label}
           </DropdownItem>
         ))}

--- a/src/components/DropdownSelect/DropdownSelect.tsx
+++ b/src/components/DropdownSelect/DropdownSelect.tsx
@@ -1,76 +1,44 @@
+import React from 'react';
 import {
   Select,
   SelectOption,
+  SelectList,
+  MenuToggle,
+  MenuToggleElement,
+  SelectOptionProps,
+  MenuToggleProps,
   SelectProps,
-  SelectVariant,
-} from '@patternfly/react-core/deprecated';
+} from '@patternfly/react-core';
 
-import React, { Dispatch, SetStateAction, useState } from 'react';
-
-interface DropdownSelectProps extends Partial<SelectProps> {
-  options: Array<string>;
-  variant: SelectVariant.single | SelectVariant.checkbox | SelectVariant.typeaheadMulti;
-  selectedProp: any; // eslint-disable-line
-  setSelected: Dispatch<SetStateAction<any>>; // eslint-disable-line
-  toggleIcon?: React.ReactElement;
-  placeholderText?: string | React.ReactNode;
-  isDisabled?: boolean;
+interface Props extends Omit<SelectProps, 'toggle'> {
+  toggleValue: string;
+  toggleProps?: Partial<MenuToggleProps>;
+  options: Partial<SelectOptionProps>[];
 }
 
-const DropdownSelect = ({
-  options,
-  variant,
-  selectedProp,
-  setSelected,
-  toggleIcon,
-  placeholderText,
-  isDisabled,
-  ...rest
-}: DropdownSelectProps) => {
-  const selected = Array.isArray(selectedProp) ? selectedProp : [selectedProp];
-  const [isOpen, setIsOpen] = useState(false);
+export default function DropdownSelect({ toggleValue, options, toggleProps = {}, ...rest }: Props) {
+  const [isOpen, setIsOpen] = React.useState(false);
 
-  const selectFrom = options.map((option, index) => (
-    <SelectOption key={option + index} id={option} value={option} />
-  ));
-
-  const onSelect = (_event, selection) => {
-    switch (variant) {
-      case SelectVariant.single:
-        setSelected(selection);
-        setIsOpen(false);
-        break;
-      case SelectVariant.typeaheadMulti:
-      case SelectVariant.checkbox:
-        if (Array.isArray(selectedProp)) {
-          if (selected.includes(selection)) {
-            const remaining = selected.filter((item) => item !== selection);
-            setSelected(remaining);
-            break;
-          }
-          setSelected([...selected, selection]);
-          break;
-        }
-        break;
-    }
+  const onToggleClick = () => {
+    setIsOpen(!isOpen);
   };
 
   return (
     <Select
-      isDisabled={isDisabled}
-      variant={variant}
-      onSelect={onSelect}
-      selections={selected}
       isOpen={isOpen}
-      onToggle={(_event, isOpen) => setIsOpen(isOpen)}
-      placeholderText={placeholderText}
-      isCheckboxSelectionBadgeHidden
-      toggleIcon={toggleIcon}
+      onOpenChange={(nextOpen: boolean) => setIsOpen(nextOpen)}
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen} {...toggleProps}>
+          {toggleValue}
+        </MenuToggle>
+      )}
       {...rest}
     >
-      {selectFrom}
+      <SelectList>
+        {options.map((option, index) => (
+          <SelectOption key={index} {...option} />
+        ))}
+      </SelectList>
     </Select>
   );
-};
-
-export default DropdownSelect;
+}

--- a/src/components/DropdownSelect_Deprecated/DropdownSelect_Deprecated.test.tsx
+++ b/src/components/DropdownSelect_Deprecated/DropdownSelect_Deprecated.test.tsx
@@ -1,6 +1,6 @@
 import { SelectVariant } from '@patternfly/react-core/deprecated';
 import { fireEvent, render, waitFor } from '@testing-library/react';
-import DropDownSelect from './DropdownSelect';
+import DropDownSelect from './DropdownSelect_Deprecated';
 
 it('Render with SelectVariant.single', async () => {
   const { queryByText } = render(

--- a/src/components/DropdownSelect_Deprecated/DropdownSelect_Deprecated.tsx
+++ b/src/components/DropdownSelect_Deprecated/DropdownSelect_Deprecated.tsx
@@ -1,0 +1,76 @@
+import {
+  Select,
+  SelectOption,
+  SelectProps,
+  SelectVariant,
+} from '@patternfly/react-core/deprecated';
+
+import React, { Dispatch, SetStateAction, useState } from 'react';
+
+interface DropdownSelectProps extends Partial<SelectProps> {
+  options: Array<string>;
+  variant: SelectVariant.single | SelectVariant.checkbox | SelectVariant.typeaheadMulti;
+  selectedProp: any; // eslint-disable-line
+  setSelected: Dispatch<SetStateAction<any>>; // eslint-disable-line
+  toggleIcon?: React.ReactElement;
+  placeholderText?: string | React.ReactNode;
+  isDisabled?: boolean;
+}
+
+const DropdownSelect_Deprecated = ({
+  options,
+  variant,
+  selectedProp,
+  setSelected,
+  toggleIcon,
+  placeholderText,
+  isDisabled,
+  ...rest
+}: DropdownSelectProps) => {
+  const selected = Array.isArray(selectedProp) ? selectedProp : [selectedProp];
+  const [isOpen, setIsOpen] = useState(false);
+
+  const selectFrom = options.map((option, index) => (
+    <SelectOption key={option + index} id={option} value={option} />
+  ));
+
+  const onSelect = (_event, selection) => {
+    switch (variant) {
+      case SelectVariant.single:
+        setSelected(selection);
+        setIsOpen(false);
+        break;
+      case SelectVariant.typeaheadMulti:
+      case SelectVariant.checkbox:
+        if (Array.isArray(selectedProp)) {
+          if (selected.includes(selection)) {
+            const remaining = selected.filter((item) => item !== selection);
+            setSelected(remaining);
+            break;
+          }
+          setSelected([...selected, selection]);
+          break;
+        }
+        break;
+    }
+  };
+
+  return (
+    <Select
+      isDisabled={isDisabled}
+      variant={variant}
+      onSelect={onSelect}
+      selections={selected}
+      isOpen={isOpen}
+      onToggle={(_event, isOpen) => setIsOpen(isOpen)}
+      placeholderText={placeholderText}
+      isCheckboxSelectionBadgeHidden
+      toggleIcon={toggleIcon}
+      {...rest}
+    >
+      {selectFrom}
+    </Select>
+  );
+};
+
+export default DropdownSelect_Deprecated;

--- a/src/components/ErrataTypeIcon/ErrataTypeIcon.tsx
+++ b/src/components/ErrataTypeIcon/ErrataTypeIcon.tsx
@@ -1,0 +1,33 @@
+import {
+  BugIcon,
+  EnhancementIcon,
+  PackageIcon,
+  SecurityIcon,
+  UnknownIcon,
+} from '@patternfly/react-icons';
+import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
+import { useMemo } from 'react';
+
+interface Props {
+  type: string;
+  iconProps?: SVGIconProps;
+}
+
+export default function ErrataTypeIcon({ type, iconProps }: Props) {
+  const Icon = useMemo(() => {
+    switch (type?.toLowerCase()) {
+      case 'bugfix':
+        return BugIcon;
+      case 'newpackage':
+        return PackageIcon;
+      case 'enhancement':
+        return EnhancementIcon;
+      case 'security':
+        return SecurityIcon;
+      default:
+        return UnknownIcon;
+    }
+  }, [type]);
+
+  return <Icon {...iconProps} />;
+}

--- a/src/components/SeverityWithIcon/SeverityWithIcon.tsx
+++ b/src/components/SeverityWithIcon/SeverityWithIcon.tsx
@@ -1,0 +1,60 @@
+import { Grid } from '@patternfly/react-core';
+import { SecurityIcon } from '@patternfly/react-icons';
+import {
+  global_danger_color_100,
+  global_palette_orange_300,
+  global_warning_color_100,
+  global_Color_200,
+} from '@patternfly/react-tokens';
+
+import { createUseStyles } from 'react-jss';
+
+const useStyles = (color: string) => {
+  let finalColor = 'initial';
+  switch (color) {
+    case 'critical':
+      finalColor = global_danger_color_100.value;
+      break;
+    case 'important':
+      finalColor = global_palette_orange_300.value;
+      break;
+    case 'moderate':
+      finalColor = global_warning_color_100.value;
+      break;
+    case 'low':
+      finalColor = global_Color_200.value;
+      break;
+    default:
+      break;
+  }
+
+  return createUseStyles({
+    iconColor: {
+      fill: finalColor,
+      marginRight: '4px',
+    },
+    wrapper: {
+      display: 'inline-flex',
+      alignItems: 'center',
+    },
+  });
+};
+
+interface Props {
+  severity: string;
+}
+
+const severityTypes = new Set(['critical', 'important', 'moderate', 'low']);
+
+export default function SeverityWithIcon({ severity }: Props) {
+  const loweredSeverity = severity?.toLowerCase();
+  const classes = useStyles(loweredSeverity)();
+
+  const isOther = !severityTypes.has(loweredSeverity);
+
+  return (
+    <Grid className={classes.wrapper}>
+      {isOther ? '' : <SecurityIcon className={classes.iconColor} />} {severity}
+    </Grid>
+  );
+}

--- a/src/components/SharedTables/AdvisoriesTable/index.tsx
+++ b/src/components/SharedTables/AdvisoriesTable/index.tsx
@@ -45,6 +45,7 @@ const useStyles = createUseStyles({
   rightMargin: { marginRight: '6px' },
   red: { extend: 'rightMargin', color: red },
   green: { extend: 'rightMargin', color: green },
+  retainSpaces: { whiteSpace: 'pre-line' },
 });
 
 interface Props {
@@ -159,7 +160,7 @@ export default function AdvisoriesTable({
                             </Flex>
                             <Grid>
                               <strong>Description</strong>
-                              <Text>{description}</Text>
+                              <Text className={classes.retainSpaces}>{description}</Text>
                             </Grid>
                             <Grid>
                               <strong>Reboot</strong>

--- a/src/components/SharedTables/AdvisoriesTable/index.tsx
+++ b/src/components/SharedTables/AdvisoriesTable/index.tsx
@@ -64,10 +64,11 @@ export default function AdvisoriesTable({
 }: Props) {
   const classes = useStyles();
   const columnHeaders = [
-    { name: 'Name' },
+    { name: 'Name', width: 15 },
     { name: 'Synopsis' },
     { name: 'Type', width: 15 },
     { name: 'Severity', width: 10 },
+    { name: 'Publish date', width: 15},
   ];
   const [expandState, setExpandState] = useState({});
 
@@ -140,6 +141,7 @@ export default function AdvisoriesTable({
                     <Td>
                       <SeverityWithIcon severity={severity} />
                     </Td>
+                    <Td>{formatDateDDMMMYYYY(issued_date)}</Td>
                   </Tr>
                   <Hide hide={!expandState[rowIndex]}>
                     <Tr>
@@ -148,10 +150,6 @@ export default function AdvisoriesTable({
                         <ExpandableRowContent key={rowIndex + '-expandablecontent'}>
                           <Stack hasGutter className={classes.expansionBox}>
                             <Flex direction={{ default: 'row' }}>
-                              <FlexItem>
-                                <strong>Issued date</strong>
-                                <Text>{formatDateDDMMMYYYY(issued_date)}</Text>
-                              </FlexItem>
                               <FlexItem>
                                 <strong>Updated date</strong>
                                 <Text>

--- a/src/components/SharedTables/AdvisoriesTable/index.tsx
+++ b/src/components/SharedTables/AdvisoriesTable/index.tsx
@@ -155,7 +155,7 @@ export default function AdvisoriesTable({
                               </FlexItem>
                               <FlexItem>
                                 <strong>Updated date</strong>
-                                <Text>{formatDateDDMMMYYYY(updated_date)}</Text>
+                                <Text>{updated_date ? formatDateDDMMMYYYY(updated_date) : 'N/A'}</Text>
                               </FlexItem>
                             </Flex>
                             <Grid>

--- a/src/components/SharedTables/AdvisoriesTable/index.tsx
+++ b/src/components/SharedTables/AdvisoriesTable/index.tsx
@@ -27,6 +27,7 @@ import { OffIcon, OnIcon } from '@patternfly/react-icons';
 import { formatDateDDMMMYYYY, reduceStringToCharsWithEllipsis } from '../../../helpers';
 import ErrataTypeIcon from '../../ErrataTypeIcon/ErrataTypeIcon';
 import SeverityWithIcon from '../../SeverityWithIcon/SeverityWithIcon';
+import UrlWithExternalIcon from '../../UrlWithLinkIcon/UrlWithLinkIcon';
 
 const red = global_danger_color_200.value;
 const green = global_success_color_200.value;
@@ -155,7 +156,9 @@ export default function AdvisoriesTable({
                               </FlexItem>
                               <FlexItem>
                                 <strong>Updated date</strong>
-                                <Text>{updated_date ? formatDateDDMMMYYYY(updated_date) : 'N/A'}</Text>
+                                <Text>
+                                  {updated_date ? formatDateDDMMMYYYY(updated_date) : 'N/A'}
+                                </Text>
                               </FlexItem>
                             </Flex>
                             <Grid>
@@ -171,6 +174,18 @@ export default function AdvisoriesTable({
                                   <OnIcon className={classes.green} />
                                 )}
                                 {`Reboot is ${reboot_suggested ? '' : 'not '}required`}
+                              </div>
+                            </Grid>
+                            <Grid>
+                              <div>
+                                {errata_id.startsWith('RH') ? (
+                                  <UrlWithExternalIcon
+                                    href={`https://access.redhat.com/errata/${errata_id}`}
+                                    customText={'View packages and errata at access.redhat.com'}
+                                  />
+                                ) : (
+                                  ''
+                                )}
                               </div>
                             </Grid>
                           </Stack>

--- a/src/components/SharedTables/AdvisoriesTable/index.tsx
+++ b/src/components/SharedTables/AdvisoriesTable/index.tsx
@@ -24,7 +24,7 @@ import useDeepCompareEffect from '../../../Hooks/useDeepCompareEffect';
 import React, { useState } from 'react';
 import { capitalize, isEmpty } from 'lodash';
 import { OffIcon, OnIcon } from '@patternfly/react-icons';
-import { formatDateDDMMMYYYY, reduceStringToCharsWithEllipsis } from '../../../helpers';
+import { formatDateDDMMMYYYY, formatDescription, reduceStringToCharsWithEllipsis } from '../../../helpers';
 import ErrataTypeIcon from '../../ErrataTypeIcon/ErrataTypeIcon';
 import SeverityWithIcon from '../../SeverityWithIcon/SeverityWithIcon';
 import UrlWithExternalIcon from '../../UrlWithLinkIcon/UrlWithLinkIcon';
@@ -160,7 +160,7 @@ export default function AdvisoriesTable({
                             </Flex>
                             <Grid>
                               <strong>Description</strong>
-                              <Text className={classes.retainSpaces}>{description}</Text>
+                              <Text className={classes.retainSpaces}>{formatDescription(description)}</Text>
                             </Grid>
                             <Grid>
                               <strong>Reboot</strong>

--- a/src/components/SharedTables/AdvisoriesTable/index.tsx
+++ b/src/components/SharedTables/AdvisoriesTable/index.tsx
@@ -1,0 +1,192 @@
+import {
+  BaseCellProps,
+  ExpandableRowContent,
+  Table,
+  TableVariant,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from '@patternfly/react-table';
+import EmptyPackageState from '../../../Pages/ContentListTable/components/PackageModal/components/EmptyPackageState';
+import { ErrataItem } from '../../../services/Content/ContentApi';
+import Hide from '../../Hide/Hide';
+import { Flex, FlexItem, Grid, Stack, Text } from '@patternfly/react-core';
+import { SkeletonTable } from '@patternfly/react-component-groups';
+import {
+  global_BackgroundColor_100,
+  global_danger_color_200,
+  global_success_color_200,
+} from '@patternfly/react-tokens';
+import { createUseStyles } from 'react-jss';
+import useDeepCompareEffect from '../../../Hooks/useDeepCompareEffect';
+import React, { useState } from 'react';
+import { capitalize, isEmpty } from 'lodash';
+import { OffIcon, OnIcon } from '@patternfly/react-icons';
+import { formatDateDDMMMYYYY, reduceStringToCharsWithEllipsis } from '../../../helpers';
+import ErrataTypeIcon from '../../ErrataTypeIcon/ErrataTypeIcon';
+import SeverityWithIcon from '../../SeverityWithIcon/SeverityWithIcon';
+
+const red = global_danger_color_200.value;
+const green = global_success_color_200.value;
+
+const useStyles = createUseStyles({
+  mainContainer: {
+    backgroundColor: global_BackgroundColor_100.value,
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+  },
+  expansionBox: {
+    padding: '16px 0',
+  },
+  rightMargin: { marginRight: '6px' },
+  red: { extend: 'rightMargin', color: red },
+  green: { extend: 'rightMargin', color: green },
+});
+
+interface Props {
+  isFetchingOrLoading: boolean;
+  isLoadingOrZeroCount: boolean;
+  errataList: ErrataItem[];
+  clearSearch: () => void;
+  perPage: number;
+}
+
+export default function AdvisoriesTable({
+  isFetchingOrLoading,
+  isLoadingOrZeroCount,
+  errataList,
+  clearSearch,
+  perPage,
+}: Props) {
+  const classes = useStyles();
+  const columnHeaders = [
+    { name: 'Name' },
+    { name: 'Synopsis' },
+    { name: 'Type', width: 15 },
+    { name: 'Severity', width: 10 },
+  ];
+  const [expandState, setExpandState] = useState({});
+
+  useDeepCompareEffect(() => {
+    if (!isEmpty(expandState)) setExpandState({});
+  }, [errataList]);
+
+  return (
+    <>
+      <Hide hide={!isFetchingOrLoading}>
+        <Grid className={classes.mainContainer}>
+          <SkeletonTable
+            rows={perPage}
+            numberOfColumns={columnHeaders.length}
+            variant={TableVariant.compact}
+          />
+        </Grid>
+      </Hide>
+      <Hide hide={isFetchingOrLoading}>
+        <Table aria-label='errata table' ouiaId='errata_table' variant='compact'>
+          <Hide hide={isLoadingOrZeroCount}>
+            <Thead>
+              <Tr>
+                <Th />
+                {columnHeaders.map(({ name, width }, index) => (
+                  <Th width={width as BaseCellProps['width']} key={index + name + '_header'}>
+                    {name}
+                  </Th>
+                ))}
+              </Tr>
+            </Thead>
+          </Hide>
+          <Tbody>
+            {errataList.map(
+              (
+                {
+                  //   id,
+                  errata_id,
+                  //   title,
+                  summary,
+                  description,
+                  issued_date,
+                  updated_date,
+                  type,
+                  severity,
+                  reboot_suggested,
+                }: ErrataItem,
+                rowIndex,
+              ) => (
+                <React.Fragment key={errata_id + rowIndex + '-column'}>
+                  <Tr>
+                    <Td
+                      expand={{
+                        rowIndex,
+                        isExpanded: !!expandState[rowIndex],
+                        onToggle: () =>
+                          setExpandState((prev) => ({ ...prev, [rowIndex]: !prev[rowIndex] })),
+                        expandId: 'expandable-',
+                      }}
+                    />
+                    <Td>{errata_id}</Td>
+                    <Td>{reduceStringToCharsWithEllipsis(summary, 70)}</Td>
+                    <Td>
+                      <div>
+                        <ErrataTypeIcon
+                          type={type}
+                          iconProps={{ className: classes.rightMargin }}
+                        />
+                        {capitalize(type)}
+                      </div>
+                    </Td>
+                    <Td>
+                      <SeverityWithIcon severity={severity} />
+                    </Td>
+                  </Tr>
+                  <Hide hide={!expandState[rowIndex]}>
+                    <Tr>
+                      <Td />
+                      <Td dataLabel={rowIndex + '-content-label'} colSpan={3}>
+                        <ExpandableRowContent key={rowIndex + '-expandablecontent'}>
+                          <Stack hasGutter className={classes.expansionBox}>
+                            <Flex direction={{ default: 'row' }}>
+                              <FlexItem>
+                                <strong>Issued date</strong>
+                                <Text>{formatDateDDMMMYYYY(issued_date)}</Text>
+                              </FlexItem>
+                              <FlexItem>
+                                <strong>Updated date</strong>
+                                <Text>{formatDateDDMMMYYYY(updated_date)}</Text>
+                              </FlexItem>
+                            </Flex>
+                            <Grid>
+                              <strong>Description</strong>
+                              <Text>{description}</Text>
+                            </Grid>
+                            <Grid>
+                              <strong>Reboot</strong>
+                              <div>
+                                {reboot_suggested ? (
+                                  <OffIcon className={classes.red} />
+                                ) : (
+                                  <OnIcon className={classes.green} />
+                                )}
+                                {`Reboot is ${reboot_suggested ? '' : 'not '}required`}
+                              </div>
+                            </Grid>
+                          </Stack>
+                        </ExpandableRowContent>
+                      </Td>
+                    </Tr>
+                  </Hide>
+                </React.Fragment>
+              ),
+            )}
+            <Hide hide={!isLoadingOrZeroCount}>
+              <EmptyPackageState clearSearch={clearSearch} />
+            </Hide>
+          </Tbody>
+        </Table>
+      </Hide>
+    </>
+  );
+}

--- a/src/components/SharedTables/AdvisoriesTable/index.tsx
+++ b/src/components/SharedTables/AdvisoriesTable/index.tsx
@@ -45,7 +45,6 @@ const useStyles = createUseStyles({
   rightMargin: { marginRight: '6px' },
   red: { extend: 'rightMargin', color: red },
   green: { extend: 'rightMargin', color: green },
-  retainSpaces: { whiteSpace: 'pre-line' },
 });
 
 interface Props {
@@ -162,7 +161,7 @@ export default function AdvisoriesTable({
                             </Flex>
                             <Grid>
                               <strong>Description</strong>
-                              <Text className={classes.retainSpaces}>{description}</Text>
+                              <Text>{description}</Text>
                             </Grid>
                             <Grid>
                               <strong>Reboot</strong>

--- a/src/components/SharedTables/AdvisoriesTable/index.tsx
+++ b/src/components/SharedTables/AdvisoriesTable/index.tsx
@@ -45,6 +45,7 @@ const useStyles = createUseStyles({
   rightMargin: { marginRight: '6px' },
   red: { extend: 'rightMargin', color: red },
   green: { extend: 'rightMargin', color: green },
+  retainSpaces: { whiteSpace: 'pre-line' },
 });
 
 interface Props {
@@ -104,9 +105,7 @@ export default function AdvisoriesTable({
             {errataList.map(
               (
                 {
-                  //   id,
                   errata_id,
-                  //   title,
                   summary,
                   description,
                   issued_date,
@@ -163,7 +162,7 @@ export default function AdvisoriesTable({
                             </Flex>
                             <Grid>
                               <strong>Description</strong>
-                              <Text>{description}</Text>
+                              <Text className={classes.retainSpaces}>{description}</Text>
                             </Grid>
                             <Grid>
                               <strong>Reboot</strong>
@@ -181,7 +180,7 @@ export default function AdvisoriesTable({
                                 {errata_id.startsWith('RH') ? (
                                   <UrlWithExternalIcon
                                     href={`https://access.redhat.com/errata/${errata_id}`}
-                                    customText={'View packages and errata at access.redhat.com'}
+                                    customText='View packages and errata at access.redhat.com'
                                   />
                                 ) : (
                                   ''

--- a/src/components/SharedTables/PackagesTable/index.tsx
+++ b/src/components/SharedTables/PackagesTable/index.tsx
@@ -1,0 +1,76 @@
+import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import EmptyPackageState from '../../../Pages/ContentListTable/components/PackageModal/components/EmptyPackageState';
+import { PackageItem } from '../../../services/Content/ContentApi';
+import Hide from '../../Hide/Hide';
+import { Grid } from '@patternfly/react-core';
+import { SkeletonTable } from '@patternfly/react-component-groups';
+import { global_BackgroundColor_100 } from '@patternfly/react-tokens';
+import { createUseStyles } from 'react-jss';
+
+const useStyles = createUseStyles({
+  mainContainer: {
+    backgroundColor: global_BackgroundColor_100.value,
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+  },
+});
+
+interface Props {
+  isFetchingOrLoading: boolean;
+  isLoadingOrZeroCount: boolean;
+  packagesList: PackageItem[];
+  clearSearch: () => void;
+  perPage: number;
+}
+
+export default function PackagesTable({
+  isFetchingOrLoading,
+  isLoadingOrZeroCount,
+  packagesList,
+  clearSearch,
+  perPage,
+}: Props) {
+  const classes = useStyles();
+  const columnHeaders = ['Name', 'Version', 'Release', 'Arch'];
+
+  return (
+    <>
+      <Hide hide={!isFetchingOrLoading}>
+        <Grid className={classes.mainContainer}>
+          <SkeletonTable
+            rows={perPage}
+            numberOfColumns={columnHeaders.length}
+            variant={TableVariant.compact}
+          />
+        </Grid>
+      </Hide>
+      <Hide hide={isFetchingOrLoading}>
+        <Table aria-label='packages table' ouiaId='packages_table' variant='compact'>
+          <Hide hide={isLoadingOrZeroCount}>
+            <Thead>
+              <Tr>
+                {columnHeaders.map((columnHeader) => (
+                  <Th key={columnHeader + '_column'}>{columnHeader}</Th>
+                ))}
+              </Tr>
+            </Thead>
+          </Hide>
+          <Tbody>
+            {packagesList.map(({ name, version, release, arch }: PackageItem, index: number) => (
+              <Tr key={name + index}>
+                <Td>{name}</Td>
+                <Td>{version}</Td>
+                <Td>{release}</Td>
+                <Td>{arch}</Td>
+              </Tr>
+            ))}
+            <Hide hide={!isLoadingOrZeroCount}>
+              <EmptyPackageState clearSearch={clearSearch} />
+            </Hide>
+          </Tbody>
+        </Table>
+      </Hide>
+    </>
+  );
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 // Removes null values and builds url params from a given object.
 export const objectToUrlParams = (obj: { [key: string]: string | undefined }): string => {
   const keyList = Object.keys(obj).filter((key) => !!obj[key]);
-  // Check each item for falsey value and
+  // Check each item for falsey value and filter
 
   if (!keyList.length) return '';
 
@@ -14,11 +14,8 @@ export const objectToUrlParams = (obj: { [key: string]: string | undefined }): s
   return items;
 };
 
-export const formatDateToHumanReadable = (date: string): string =>
-  dayjs(date).format('DD MMM YYYY HH:mm UTCZ');
-
-export const formatTemplateDate = (date: string): string =>
-  dayjs(date).format('YYYY-MM-DDTHH:mm:ssZ');
+export const formatDateDDMMMYYYY = (date: string, withTime?: boolean): string =>
+  dayjs(date).format(`DD MMM YYYY${withTime ? ' - HH:mm:ss' : ''}`);
 
 export const reduceStringToCharsWithEllipsis = (str: string, maxLength: number = 50) =>
   str.length > maxLength ? str.split('').slice(0, maxLength).join('') + '...' : str;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -20,7 +20,6 @@ export const formatDateDDMMMYYYY = (date: string, withTime?: boolean): string =>
 export const reduceStringToCharsWithEllipsis = (str: string, maxLength: number = 50) =>
   str.length > maxLength ? str.split('').slice(0, maxLength).join('') + '...' : str;
 
-// Removes unnecessary newlines before or after spaces
+// Removes any cases of 3+ line breaks and replaces them with 2 
 export const formatDescription = (description: string): string => 
-  description.replace(/(?<! )\n\s*\n(?![ ])/g, '\n');
-
+  description.replace(/\n{3,}/g, '\n\n');

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -19,3 +19,8 @@ export const formatDateDDMMMYYYY = (date: string, withTime?: boolean): string =>
 
 export const reduceStringToCharsWithEllipsis = (str: string, maxLength: number = 50) =>
   str.length > maxLength ? str.split('').slice(0, maxLength).join('') + '...' : str;
+
+// Removes unnecessary newlines before or after spaces
+export const formatDescription = (description: string): string => 
+  description.replace(/(?<! )\n\s*\n(?![ ])/g, '\n');
+

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -166,7 +166,7 @@ export interface ErrataItem {
   updated_date: string;
   type: string;
   severity: string;
-  reboot_suggested: string;
+  reboot_suggested: boolean;
 }
 
 export type PackagesResponse = {

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -156,8 +156,27 @@ export interface PackageItem {
   version: string;
 }
 
+export interface ErrataItem {
+  id: string;
+  errata_id: string;
+  title: string;
+  summary: string;
+  description: string;
+  issued_date: string;
+  updated_date: string;
+  type: string;
+  severity: string;
+  reboot_suggested: string;
+}
+
 export type PackagesResponse = {
   data: PackageItem[];
+  links: Links;
+  meta: Meta;
+};
+
+export type ErrataResponse = {
+  data: ErrataItem[];
   links: Links;
   meta: Meta;
 };
@@ -339,13 +358,13 @@ export const getPackages: (
   page: number,
   limit: number,
   search: string,
-  sortBy: string,
+  sortBy?: string,
 ) => Promise<PackagesResponse> = async (
   uuid: string,
   page: number,
   limit: number,
   search: string,
-  sortBy: string,
+  sortBy?: string,
 ) => {
   const { data } = await axios.get(
     `/api/content-sources/v1.0/repositories/${uuid}/rpms?${objectToUrlParams({
@@ -376,7 +395,7 @@ export const getSnapshotList: (
       offset: ((page - 1) * limit).toString(),
       limit: limit?.toString(),
       search,
-      sortBy,
+      sort_by: sortBy,
     })}`,
   );
   return data;
@@ -423,9 +442,38 @@ export const getSnapshotPackages: (
   searchQuery: string,
 ) => {
   const { data } = await axios.get(
-    `/api/content-sources/v1/snapshots/${snap_uuid}/rpms?offset=${
-      (page - 1) * limit
-    }&limit=${limit}&search=${searchQuery}`,
+    `/api/content-sources/v1/snapshots/${snap_uuid}/rpms?${objectToUrlParams({
+      offset: ((page - 1) * limit).toString(),
+      limit: limit?.toString(),
+      search: searchQuery,
+    })}`,
+  );
+  return data;
+};
+
+export const getSnapshotErrata: (
+  snap_uuid: string,
+  page: number,
+  limit: number,
+  search: string,
+  type: string[],
+  severity: string[],
+) => Promise<ErrataResponse> = async (
+  snap_uuid: string,
+  page: number,
+  limit: number,
+  search: string,
+  type: string[],
+  severity: string[],
+) => {
+  const { data } = await axios.get(
+    `/api/content-sources/v1/snapshots/${snap_uuid}/errata?${objectToUrlParams({
+      offset: ((page - 1) * limit).toString(),
+      limit: limit?.toString(),
+      search,
+      type: type.join(',').toLowerCase(),
+      severity: severity.join(','),
+    })}`,
   );
   return data;
 };

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -35,6 +35,8 @@ import {
   triggerSnapshot,
   getSnapshotsByDate,
   getSnapshotPackages,
+  getSnapshotErrata,
+  ErrataResponse,
 } from './ContentApi';
 import { ADMIN_TASK_LIST_KEY } from '../AdminTasks/AdminTaskQueries';
 import useErrorNotification from '../../Hooks/useErrorNotification';
@@ -45,7 +47,9 @@ export const POPULAR_REPOSITORIES_LIST_KEY = 'POPULAR_REPOSITORIES_LIST_KEY';
 export const REPOSITORY_PARAMS_KEY = 'REPOSITORY_PARAMS_KEY';
 export const CREATE_PARAMS_KEY = 'CREATE_PARAMS_KEY';
 export const PACKAGES_KEY = 'PACKAGES_KEY';
-export const LIST_SNAPSHOTS_KEY = 'PACKAGES_KEY';
+export const SNAPSHOT_PACKAGES_KEY = 'SNAPSHOT_PACKAGES_KEY';
+export const SNAPSHOT_ERRATA_KEY = 'SNAPSHOT_ERRATA_KEY';
+export const LIST_SNAPSHOTS_KEY = 'LIST_SNAPSHOTS_KEY';
 export const CONTENT_ITEM_KEY = 'CONTENT_ITEM_KEY';
 export const REPO_CONFIG_FILE_KEY = 'REPO_CONFIG_FILE_KEY';
 
@@ -586,7 +590,7 @@ export const useGetPackagesQuery = (
   page: number,
   limit: number,
   searchQuery: string,
-  sortBy: string,
+  sortBy?: string,
 ) => {
   const errorNotifier = useErrorNotification();
   return useQuery<PackagesResponse>(
@@ -617,7 +621,7 @@ export const useGetSnapshotPackagesQuery = (
 ) => {
   const errorNotifier = useErrorNotification();
   return useQuery<PackagesResponse>(
-    [PACKAGES_KEY, snap_uuid, page, limit, searchQuery],
+    [SNAPSHOT_PACKAGES_KEY, snap_uuid, page, limit, searchQuery],
     () => getSnapshotPackages(snap_uuid, page, limit, searchQuery),
     {
       keepPreviousData: true,
@@ -630,6 +634,35 @@ export const useGetSnapshotPackagesQuery = (
           'An error occurred',
           err,
           'snapshot-package-list-error',
+        );
+      },
+    },
+  );
+};
+
+export const useGetSnapshotErrataQuery = (
+  snap_uuid: string,
+  page: number,
+  limit: number,
+  search: string,
+  type: string[],
+  severity: string[],
+) => {
+  const errorNotifier = useErrorNotification();
+  return useQuery<ErrataResponse>(
+    [SNAPSHOT_ERRATA_KEY, snap_uuid, page, limit, search, type, severity],
+    () => getSnapshotErrata(snap_uuid, page, limit, search, type, severity),
+    {
+      keepPreviousData: true,
+      optimisticResults: true,
+      staleTime: 60000,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      onError: (err: any) => {
+        errorNotifier(
+          'Unable to find errata with the given UUID.',
+          'An error occurred',
+          err,
+          'snapshot-errata-list-error',
         );
       },
     },


### PR DESCRIPTION
## Summary

- Adds a query to retrieve snapshot errata
- Adds an Errata tab to SnapshotDetails modal to list snapshot errata
- Supports filtering by name / synopsis, type, and severity
- Dependent on these PRs: [backend](https://github.com/content-services/content-sources-backend/pull/608), [tang](https://github.com/content-services/tang/pull/6)

## Testing steps

- Add a repository with package errata and let it snapshot 
- Click View all snapshots from the kebab on the Repositories page
- Click the Errata count to route to the Errata (Advisories) tab in the SnapshotDetails modal
- You should see all the errata for this snapshot displayed, with additional info for each errata displayed when clicking the expandable icon 
- Filtering on name / synopsis, type, severity should only display errata with those filters 
