### PR TITLE
Refs 3902: Use new format for snapshot by date

### DIFF
--- a/src/Pages/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.test.tsx
+++ b/src/Pages/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.test.tsx
@@ -31,7 +31,7 @@ jest.mock('dayjs', () =>
 
 it('expect Set up date step to render correctly', () => {
   (useGetSnapshotsByDates as jest.Mock).mockImplementation(() => ({
-    data: [defaultSnapshotsByDateResponse],
+    data: defaultSnapshotsByDateResponse,
     mutateAsync: () => undefined,
   }));
 

--- a/src/Pages/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
+++ b/src/Pages/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
@@ -84,9 +84,6 @@ export default function SetUpDateStep() {
   const columnHeaders = ['Name', /* 'Label',*/ 'Advisories', 'Packages'];
 
   const itemsAfterDate = useMemo(() => data?.data?.filter(({ is_after }) => is_after) || [], [data?.data]);
-  console.log("AFTER")
-  console.log(itemsAfterDate)
-  console.log(data?.data)
   const hasIsAfter = itemsAfterDate.length > 0;
 
   const { isLoading, data: contentData = { data: [], meta: { count: 0, limit: 20, offset: 0 } } } =

--- a/src/Pages/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
+++ b/src/Pages/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
@@ -83,7 +83,10 @@ export default function SetUpDateStep() {
 
   const columnHeaders = ['Name', /* 'Label',*/ 'Advisories', 'Packages'];
 
-  const itemsAfterDate = useMemo(() => data?.filter(({ is_after }) => is_after) || [], [data]);
+  const itemsAfterDate = useMemo(() => data?.data?.filter(({ is_after }) => is_after) || [], [data?.data]);
+  console.log("AFTER")
+  console.log(itemsAfterDate)
+  console.log(data?.data)
   const hasIsAfter = itemsAfterDate.length > 0;
 
   const { isLoading, data: contentData = { data: [], meta: { count: 0, limit: 20, offset: 0 } } } =

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -182,7 +182,12 @@ export interface SnapshotItem {
   removed_counts: ContentCounts;
 }
 
+
 export type SnapshotByDateResponse = {
+  data: SnapshotForDate[];
+};
+
+export type SnapshotForDate = {
   repository_uuid: string;
   is_after: boolean;
   match?: {
@@ -286,7 +291,7 @@ export const deleteContentListItems: (uuids: string[]) => Promise<void> = async 
 export const getSnapshotsByDate = async (
   uuids: string[],
   date: string,
-): Promise<SnapshotByDateResponse[]> => {
+): Promise<SnapshotByDateResponse> => {
   const { data } = await axios.post('/api/content-sources/v1/snapshots/for_date/', {
     repository_uuids: uuids,
     date,

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -6,6 +6,7 @@ import {
   PopularRepository,
   RepositoryParamsResponse,
   SnapshotByDateResponse,
+  SnapshotForDate,
   SnapshotItem,
   ValidationResponse,
 } from './services/Content/ContentApi';
@@ -254,7 +255,7 @@ export const defaultTemplateItem: TemplateItem = {
   ],
 };
 
-export const defaultSnapshotsByDateResponse: SnapshotByDateResponse = {
+export const defaultSnapshotForDateItem: SnapshotForDate =   {
   repository_uuid: defaultContentItem.uuid,
   is_after: true,
   match: {
@@ -285,4 +286,10 @@ export const defaultSnapshotsByDateResponse: SnapshotByDateResponse = {
     removed_counts: {},
     url: '',
   },
+}
+
+export const defaultSnapshotsByDateResponse: SnapshotByDateResponse = {
+  data: [
+    defaultSnapshotForDateItem
+  ]
 };


### PR DESCRIPTION
## Summary

Adapts frontend for https://github.com/content-services/content-sources-backend/pull/625

## Testing steps

1. make repos-import
2. create a repo with snapshotting (something like  https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/)
3. navigate to /insights/content/templates/    
4. create a template and set the date to yesterday
5. you should see a warning pop up saying something about no snapshot availalbe
6. select todays date, the warning should go away
