### PR TITLE
Fixes 3953: modularity filtering option is not clear

### DIFF
--- a/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
@@ -488,7 +488,7 @@ const AddContent = () => {
               gpgLoading,
               metadataVerification,
               snapshot,
-              moduleHotfixesEnabled,
+              modularityFilteringEnabled,
             },
             index,
           ) => (
@@ -664,14 +664,14 @@ const AddContent = () => {
                       <Switch
                         label='Modularity filtering enabled'
                         labelOff='Modularity filtering disabled'
-                        ouiaId={`module_hotfixes_switch_${!moduleHotfixesEnabled ? 'on' : 'off'}`}
+                        ouiaId={`module_hotfixes_switch_${modularityFilteringEnabled ? 'on' : 'off'}`}
                         aria-label='enable_module_hotfixes'
                         hasCheckIcon
                         id={'module-hotfixes-switch' + index}
                         name='module-hotfixes-switch'
-                        isChecked={!moduleHotfixesEnabled}
+                        isChecked={modularityFilteringEnabled}
                         onChange={() => {
-                          updateVariable(index, { moduleHotfixesEnabled: !moduleHotfixesEnabled });
+                          updateVariable(index, { modularityFilteringEnabled: !modularityFilteringEnabled });
                         }}
                       />
                       <Tooltip content='Optional: Selecting this will set the module_hotfixes flag on the clients, allowing the repository to not be filtered by modularity'>

--- a/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
@@ -674,7 +674,7 @@ const AddContent = () => {
                           updateVariable(index, { modularityFilteringEnabled: !modularityFilteringEnabled });
                         }}
                       />
-                      <Tooltip content='When enabled, modularity filtering prevents updates for packages contained within a module in this repository'>
+                      <Tooltip content='When enabled, modularity filtering prevents updates to packages contained within an enabled module'>
                         <OutlinedQuestionCircleIcon
                           className='pf-u-ml-xs'
                           color={global_Color_200.value}

--- a/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
@@ -674,7 +674,7 @@ const AddContent = () => {
                           updateVariable(index, { modularityFilteringEnabled: !modularityFilteringEnabled });
                         }}
                       />
-                      <Tooltip content='Optional: Selecting this will set the module_hotfixes flag on the clients, allowing the repository to not be filtered by modularity'>
+                      <Tooltip content='When enabled, modularity filtering prevents updates for packages contained within a module in this repository'>
                         <OutlinedQuestionCircleIcon
                           className='pf-u-ml-xs'
                           color={global_Color_200.value}

--- a/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/ContentListTable/components/AddContent/AddContent.tsx
@@ -662,14 +662,14 @@ const AddContent = () => {
                     </FormGroup>
                     <FormGroup fieldId='enable_module_hotfixes'>
                       <Switch
-                        label='Modularity filtering disabled'
-                        labelOff='Modularity filtering enabled'
-                        ouiaId={`module_hotfixes_switch_${moduleHotfixesEnabled ? 'on' : 'off'}`}
+                        label='Modularity filtering enabled'
+                        labelOff='Modularity filtering disabled'
+                        ouiaId={`module_hotfixes_switch_${!moduleHotfixesEnabled ? 'on' : 'off'}`}
                         aria-label='enable_module_hotfixes'
                         hasCheckIcon
                         id={'module-hotfixes-switch' + index}
                         name='module-hotfixes-switch'
-                        isChecked={moduleHotfixesEnabled}
+                        isChecked={!moduleHotfixesEnabled}
                         onChange={() => {
                           updateVariable(index, { moduleHotfixesEnabled: !moduleHotfixesEnabled });
                         }}

--- a/src/Pages/ContentListTable/components/AddContent/helpers.test.ts
+++ b/src/Pages/ContentListTable/components/AddContent/helpers.test.ts
@@ -35,7 +35,7 @@ it('mapFormikToAPIValues', () => {
       expanded: false,
       metadataVerification: false,
       snapshot: true,
-      moduleHotfixesEnabled: false,
+      modularityFilteringEnabled: true,
     },
   ];
 

--- a/src/Pages/ContentListTable/components/AddContent/helpers.ts
+++ b/src/Pages/ContentListTable/components/AddContent/helpers.ts
@@ -33,7 +33,7 @@ export interface FormikValues {
   metadataVerification: boolean;
   expanded: boolean;
   snapshot: boolean;
-  moduleHotfixesEnabled: boolean;
+  modularityFilteringEnabled: boolean;
 }
 
 export const getDefaultFormikValues = (overrides: Partial<FormikValues> = {}): FormikValues => ({
@@ -46,7 +46,7 @@ export const getDefaultFormikValues = (overrides: Partial<FormikValues> = {}): F
   expanded: true,
   metadataVerification: false,
   snapshot: false,
-  moduleHotfixesEnabled: false,
+  modularityFilteringEnabled: true,
   ...overrides,
 });
 
@@ -69,7 +69,7 @@ export const mapFormikToAPIValues = (formikValues: FormikValues[]) =>
       gpgKey,
       metadataVerification,
       snapshot,
-      moduleHotfixesEnabled,
+      modularityFilteringEnabled,
     }) => ({
       name,
       url,
@@ -78,7 +78,7 @@ export const mapFormikToAPIValues = (formikValues: FormikValues[]) =>
       gpg_key: gpgKey,
       snapshot,
       metadata_verification: metadataVerification,
-      module_hotfixes: moduleHotfixesEnabled,
+      module_hotfixes: !modularityFilteringEnabled,
     }),
   );
 

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
@@ -533,14 +533,14 @@ const EditContentForm = ({
                   </FormGroup>
                   <FormGroup fieldId='enable_module_hotfixes'>
                     <Switch
-                      label='Modularity filtering disabled'
-                      labelOff='Modularity filtering enabled'
-                      ouiaId={`module_hotfixes_switch_${moduleHotfixesEnabled ? 'on' : 'off'}`}
+                      label='Modularity filtering enabled'
+                      labelOff='Modularity filtering disabled'
+                      ouiaId={`module_hotfixes_switch_${!moduleHotfixesEnabled ? 'on' : 'off'}`}
                       aria-label='enable_module_hotfixes'
                       hasCheckIcon
                       id={'module-hotfixes-switch' + index}
                       name='module-hotfixes-switch'
-                      isChecked={moduleHotfixesEnabled}
+                      isChecked={!moduleHotfixesEnabled}
                       onChange={() => {
                         updateVariable(index, { moduleHotfixesEnabled: !moduleHotfixesEnabled });
                       }}

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
@@ -373,7 +373,7 @@ const EditContentForm = ({
             gpgLoading,
             metadataVerification,
             snapshot,
-            moduleHotfixesEnabled,
+            modularityFilteringEnabled,
           },
           index,
         ) => (
@@ -535,14 +535,14 @@ const EditContentForm = ({
                     <Switch
                       label='Modularity filtering enabled'
                       labelOff='Modularity filtering disabled'
-                      ouiaId={`module_hotfixes_switch_${!moduleHotfixesEnabled ? 'on' : 'off'}`}
+                      ouiaId={`module_hotfixes_switch_${modularityFilteringEnabled ? 'on' : 'off'}`}
                       aria-label='enable_module_hotfixes'
                       hasCheckIcon
                       id={'module-hotfixes-switch' + index}
                       name='module-hotfixes-switch'
-                      isChecked={!moduleHotfixesEnabled}
+                      isChecked={modularityFilteringEnabled}
                       onChange={() => {
-                        updateVariable(index, { moduleHotfixesEnabled: !moduleHotfixesEnabled });
+                        updateVariable(index, { modularityFilteringEnabled: !modularityFilteringEnabled });
                       }}
                     />
                     <Tooltip content='Optional: Selecting this will set the module_hotfixes flag on the clients, allowing the repository to not be filtered by modularity'>

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
@@ -545,7 +545,7 @@ const EditContentForm = ({
                         updateVariable(index, { modularityFilteringEnabled: !modularityFilteringEnabled });
                       }}
                     />
-                    <Tooltip content='Optional: Selecting this will set the module_hotfixes flag on the clients, allowing the repository to not be filtered by modularity'>
+                    <Tooltip content='When enabled, modularity filtering prevents updates for packages contained within a module in this repository'>
                       <OutlinedQuestionCircleIcon
                         className='pf-u-ml-xs'
                         color={global_Color_200.value}

--- a/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
+++ b/src/Pages/ContentListTable/components/EditContentModal/EditContentForm.tsx
@@ -545,7 +545,7 @@ const EditContentForm = ({
                         updateVariable(index, { modularityFilteringEnabled: !modularityFilteringEnabled });
                       }}
                     />
-                    <Tooltip content='When enabled, modularity filtering prevents updates for packages contained within a module in this repository'>
+                    <Tooltip content='When enabled, modularity filtering prevents updates to packages contained within an enabled module'>
                       <OutlinedQuestionCircleIcon
                         className='pf-u-ml-xs'
                         color={global_Color_200.value}

--- a/src/Pages/ContentListTable/components/EditContentModal/helpers.test.ts
+++ b/src/Pages/ContentListTable/components/EditContentModal/helpers.test.ts
@@ -14,7 +14,7 @@ it('mapFormikToEditAPIValues', () => {
       uuid: 'stuff',
       metadataVerification: false,
       snapshot: false,
-      moduleHotfixesEnabled: false,
+      modularityFilteringEnabled: true,
     },
   ];
 
@@ -69,7 +69,7 @@ it('mapToDefaultFormikValues', () => {
       metadataVerification: false,
       expanded: true,
       uuid: 'stuffAndThings',
-      moduleHotfixesEnabled: false,
+      modularityFilteringEnabled: true,
     },
   ];
 

--- a/src/Pages/ContentListTable/components/EditContentModal/helpers.ts
+++ b/src/Pages/ContentListTable/components/EditContentModal/helpers.ts
@@ -11,7 +11,7 @@ export interface FormikEditValues {
   expanded: boolean;
   uuid: string;
   snapshot: boolean;
-  moduleHotfixesEnabled: boolean;
+  modularityFilteringEnabled: boolean;
 }
 
 export const mapFormikToEditAPIValues = (formikValues: FormikEditValues[]): EditContentRequest =>
@@ -25,7 +25,7 @@ export const mapFormikToEditAPIValues = (formikValues: FormikEditValues[]): Edit
       metadataVerification,
       uuid,
       snapshot,
-      moduleHotfixesEnabled,
+      modularityFilteringEnabled,
     }) => ({
       uuid,
       name,
@@ -35,7 +35,7 @@ export const mapFormikToEditAPIValues = (formikValues: FormikEditValues[]): Edit
       gpg_key: gpgKey,
       metadata_verification: metadataVerification,
       snapshot,
-      module_hotfixes: moduleHotfixesEnabled,
+      module_hotfixes: !modularityFilteringEnabled,
     }),
   );
 
@@ -51,7 +51,7 @@ export const mapToDefaultFormikValues = (values: ContentItem[]): FormikEditValue
         gpg_key: gpgKey,
         metadata_verification: metadataVerification,
         snapshot,
-        module_hotfixes: moduleHotfixesEnabled,
+        module_hotfixes,
       },
       index,
     ) => ({
@@ -65,7 +65,7 @@ export const mapToDefaultFormikValues = (values: ContentItem[]): FormikEditValue
       expanded: index + 1 === values.length,
       uuid,
       snapshot,
-      moduleHotfixesEnabled,
+      modularityFilteringEnabled: !module_hotfixes,
     }),
   );
 


### PR DESCRIPTION
## Summary

Fixes the modularity filtering toggle to default to ON if modularity filtering is enabled (default behavior) in repo create / edit modals

## Testing steps

- Add a repo with default modularity filtering behavior (toggle should be ON, label text should display `Modularity filtering enabled`, and should set `module_hotfixes = false` on the repository)
- Edit the repo to disable modularity filtering by toggling to OFF (label text should display `Modularity filtering disabled` and set `module_hotfixes = true`)