### PR TITLE
Fixes 3812: sorting snapshots by date appears broken

### DIFF
--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -384,7 +384,7 @@ export const getSnapshotList: (
       offset: ((page - 1) * limit).toString(),
       limit: limit?.toString(),
       search,
-      sortBy,
+      sort_by: sortBy,
     })}`,
   );
   return data;


### PR DESCRIPTION
## Summary

Fixes sorting by date in SnapshotList modal

## Testing steps

- Create a repo and snapshot it a couple times, then go to SnapshotList modal (click View all snapshots)
- Sorting on the date column should work, defaults to descending order