### PR TITLE
Fixes 4046: template date formatted incorrectly

### DIFF
--- a/src/Pages/TemplatesTable/components/AddTemplate/AddTemplate.tsx
+++ b/src/Pages/TemplatesTable/components/AddTemplate/AddTemplate.tsx
@@ -24,7 +24,7 @@ import DefineContentStep from './steps/DefineContentStep';
 import SetUpDateStep from './steps/SetUpDateStep';
 import DetailStep from './steps/DetailStep';
 import ReviewStep from './steps/ReviewStep';
-import { formatDateDDMMMYYYY } from '../../../../helpers';
+import { formatTemplateDate } from '../../../../helpers';
 import { isEmpty } from 'lodash';
 import { createUseStyles } from 'react-jss';
 
@@ -50,13 +50,13 @@ const AddTemplateBase = () => {
 
   const { mutateAsync: addTemplate, isLoading: isAdding } = useCreateTemplateQuery(queryClient, {
     ...(templateRequest as TemplateRequest),
-    date: formatDateDDMMMYYYY(templateRequest.date || ''),
+    date: formatTemplateDate(templateRequest.date || ''),
   });
 
   const { mutateAsync: editTemplate, isLoading: isEditing } = useEditTemplateQuery(queryClient, {
     uuid: editUUID as string,
     ...(templateRequest as TemplateRequest),
-    date: formatDateDDMMMYYYY(templateRequest.date || ''),
+    date: formatTemplateDate(templateRequest.date || ''),
   });
 
   const addEditAction = isEdit ? editTemplate : addTemplate;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -17,6 +17,9 @@ export const objectToUrlParams = (obj: { [key: string]: string | undefined }): s
 export const formatDateDDMMMYYYY = (date: string, withTime?: boolean): string =>
   dayjs(date).format(`DD MMM YYYY${withTime ? ' - HH:mm:ss' : ''}`);
 
+export const formatTemplateDate = (date: string): string =>
+    dayjs(date).format('YYYY-MM-DDTHH:mm:ssZ');
+
 export const reduceStringToCharsWithEllipsis = (str: string, maxLength: number = 50) =>
   str.length > maxLength ? str.split('').slice(0, maxLength).join('') + '...' : str;
 


### PR DESCRIPTION
## Summary

Fixes the template date format sent in the create / edit template requests. This was inadvertently updated in the last commit.

## Testing steps

- Creating and editing a template should not fail
