### PR TITLE
Fixes 3846: fix admin tasks sort_by status

### DIFF
--- a/src/Pages/AdminTaskTable/AdminTaskTable.tsx
+++ b/src/Pages/AdminTaskTable/AdminTaskTable.tsx
@@ -82,8 +82,6 @@ const AdminTaskTable = () => {
     'account_id',
     'typename',
     'queued_at',
-    'started_at',
-    'finished_at',
     'status',
   ];
 


### PR DESCRIPTION
## Summary
When sorting by status, the frontend was actually requesting the API to sort by started_at
## Testing steps
1. Get a mix of task statuses by snapshotting a few repositories.
2. Go to the admin tasks tab and try the status filter