### PR TITLE
Refs 3832: fix date format in snapshots/for_date

### DIFF
--- a/src/Pages/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.test.tsx
+++ b/src/Pages/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.test.tsx
@@ -6,7 +6,6 @@ import {
 import SetUpDateStep from './SetUpDateStep';
 import { useAddTemplateContext } from '../AddTemplateContext';
 import { defaultContentItem, defaultSnapshotsByDateResponse } from '../../../../../testingHelpers';
-import { formatTemplateDate } from '../../../../../helpers';
 
 jest.mock('../../../../../services/Content/ContentQueries', () => ({
   useGetSnapshotsByDates: jest.fn(),

--- a/src/Pages/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.test.tsx
+++ b/src/Pages/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.test.tsx
@@ -6,6 +6,7 @@ import {
 import SetUpDateStep from './SetUpDateStep';
 import { useAddTemplateContext } from '../AddTemplateContext';
 import { defaultContentItem, defaultSnapshotsByDateResponse } from '../../../../../testingHelpers';
+import { formatTemplateDate } from '../../../../../helpers';
 
 jest.mock('../../../../../services/Content/ContentQueries', () => ({
   useGetSnapshotsByDates: jest.fn(),
@@ -26,6 +27,7 @@ jest.mock('react-router-dom', () => ({
 jest.mock('dayjs', () =>
   jest.fn(() => ({
     fromNow: () => '2024-01-22',
+    format: () => '2024-04-28T00:00:00-04:00'
   })),
 );
 

--- a/src/Pages/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
+++ b/src/Pages/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
@@ -26,7 +26,7 @@ import { ContentItem, ContentOrigin } from '../../../../../services/Content/Cont
 import { SkeletonTable } from '@patternfly/react-component-groups';
 import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import ConditionalTooltip from '../../../../../components/ConditionalTooltip/ConditionalTooltip';
-import { reduceStringToCharsWithEllipsis } from '../../../../../helpers';
+import { formatTemplateDate, reduceStringToCharsWithEllipsis } from '../../../../../helpers';
 import UrlWithExternalIcon from '../../../../../components/UrlWithLinkIcon/UrlWithLinkIcon';
 import PackageCount from '../../../../ContentListTable/components/PackageCount';
 import { REPOSITORIES_ROUTE } from '../../../../../Routes/constants';
@@ -53,7 +53,7 @@ export default function SetUpDateStep() {
 
   const { data, mutateAsync } = useGetSnapshotsByDates(
     [...selectedRedhatRepos, ...selectedCustomRepos],
-    templateRequest?.date || '',
+    formatTemplateDate(templateRequest?.date || ''),
   );
 
   const dateValidators = [

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -18,7 +18,7 @@ export const formatDateDDMMMYYYY = (date: string, withTime?: boolean): string =>
   dayjs(date).format(`DD MMM YYYY${withTime ? ' - HH:mm:ss' : ''}`);
 
 export const formatTemplateDate = (date: string): string =>
-    dayjs(date).format('YYYY-MM-DDTHH:mm:ssZ');
+  dayjs(date).format('YYYY-MM-DDTHH:mm:ssZ');
 
 export const reduceStringToCharsWithEllipsis = (str: string, maxLength: number = 50) =>
   str.length > maxLength ? str.split('').slice(0, maxLength).join('') + '...' : str;


### PR DESCRIPTION
## Summary

- Adjusts date format in request to /snapshots/for_date to ensure wrong formats are rejected and wrong results aren't returned
- Wait to merge until the backend only allows RFC3339 date formats

## Testing steps

- Deploy this PR with the [backend PR](https://github.com/content-services/content-sources-backend/pull/659)
- Creating / updating a template in the UI should work as expected
