### PR TITLE
Fixes 4105: Polling, css, console warn bugfix

### DIFF
--- a/src/AppEntry.tsx
+++ b/src/AppEntry.tsx
@@ -4,6 +4,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import * as Redux from 'redux';
 
 import App from './App';
+import 'index.scss';
 import { ContextProvider } from './middleware/AppContext';
 import { createStore, restoreStore } from './store';
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,0 +1,4 @@
+// This file can be removed when patternfly fixes the pagination component.
+.pf-v5-c-menu-toggle.pf-m-plain.pf-m-text {
+    display: flex
+}


### PR DESCRIPTION
## Summary
- Fixes a bug found with polling when navigating: When navigating to other pages/tabs and returning, polling would stop.  Now polling will continue regardless of page refresh, tab change, etc.. in cases where polling is needed (if there are pending states being returned).
- Patternfly has a known bug with their bottom-navigation Pagination component, I have applied css to temporarily fix this until it's patched
- Fixed a couple recurring console warns around the Th requiring an aria-label

## Testing steps
- Try before, try after.