### PR TITLE
Fixes 4009: snapshot errata should be sortable

### DIFF
--- a/src/components/SharedTables/AdvisoriesTable/index.tsx
+++ b/src/components/SharedTables/AdvisoriesTable/index.tsx
@@ -6,6 +6,7 @@ import {
   Tbody,
   Td,
   Th,
+  ThProps,
   Thead,
   Tr,
 } from '@patternfly/react-table';
@@ -54,6 +55,7 @@ interface Props {
   errataList: ErrataItem[];
   clearSearch: () => void;
   perPage: number;
+  sortParams: (columnIndex: number) => ThProps['sort'];
 }
 
 export default function AdvisoriesTable({
@@ -62,6 +64,7 @@ export default function AdvisoriesTable({
   errataList,
   clearSearch,
   perPage,
+  sortParams
 }: Props) {
   const classes = useStyles();
   const columnHeaders = [
@@ -95,9 +98,13 @@ export default function AdvisoriesTable({
               <Tr>
                 <Th />
                 {columnHeaders.map(({ name, width }, index) => (
+                  name === 'Name' || name === 'Synopsis' ?  
                   <Th width={width as BaseCellProps['width']} key={index + name + '_header'}>
                     {name}
-                  </Th>
+                  </Th> :
+                  <Th width={width as BaseCellProps['width']} key={index + name + '_header'} sort={sortParams(index)}>
+                  {name}
+                </Th>
                 ))}
               </Tr>
             </Thead>

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -466,6 +466,7 @@ export const getSnapshotErrata: (
   search: string,
   type: string[],
   severity: string[],
+  sortBy: string,
 ) => Promise<ErrataResponse> = async (
   snap_uuid: string,
   page: number,
@@ -473,6 +474,7 @@ export const getSnapshotErrata: (
   search: string,
   type: string[],
   severity: string[],
+  sortBy: string,
 ) => {
   const { data } = await axios.get(
     `/api/content-sources/v1/snapshots/${snap_uuid}/errata?${objectToUrlParams({
@@ -481,6 +483,7 @@ export const getSnapshotErrata: (
       search,
       type: type.join(',').toLowerCase(),
       severity: severity.join(','),
+      sort_by: sortBy,
     })}`,
   );
   return data;

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -625,11 +625,12 @@ export const useGetSnapshotErrataQuery = (
   search: string,
   type: string[],
   severity: string[],
+  sortBy: string,
 ) => {
   const errorNotifier = useErrorNotification();
   return useQuery<ErrataResponse>(
-    [SNAPSHOT_ERRATA_KEY, snap_uuid, page, limit, search, type, severity],
-    () => getSnapshotErrata(snap_uuid, page, limit, search, type, severity),
+    [SNAPSHOT_ERRATA_KEY, snap_uuid, page, limit, search, type, severity, sortBy],
+    () => getSnapshotErrata(snap_uuid, page, limit, search, type, severity, sortBy),
     {
       keepPreviousData: true,
       optimisticResults: true,


### PR DESCRIPTION
## Summary

- Enables sorting on snapshot errata by issued_date, type, and severity
- Dependent on these PRs: https://github.com/content-services/tang/pull/9, https://github.com/content-services/content-sources-backend/pull/673

## Testing steps

- Create a repository and let it snapshot
- View the snapshot errata by clicking View all snapshots in the kebab and then on the Errata count on the snapshot details page
- The Type, Severity, and Publish date (issued date) columns should be sortable
- Should default to sorting by Publish date descending
