### PR TITLE
Fixes 4242: attempting to edit a template changes the date

### DIFF
--- a/src/services/Templates/TemplateQueries.ts
+++ b/src/services/Templates/TemplateQueries.ts
@@ -31,6 +31,7 @@ export const useEditTemplateQuery = (queryClient: QueryClient, request: EditTemp
       });
 
       queryClient.invalidateQueries(GET_TEMPLATES_KEY);
+      queryClient.invalidateQueries(FETCH_TEMPLATE_KEY);
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onError: (err: any) => {


### PR DESCRIPTION
## Summary

Adds an invalidation of the template fetched to the edit template query to always pull in the latest template data to the edit modal

## Testing steps

- Add a repo, let it snapshot, and create a template with that repo's snapshot
- Edit the template date in the edit modal and save it
- Open the edit modal again and the date should be correct
- The template name should be editable once this [PR](https://github.com/content-services/content-sources-backend/pull/694) is merged in
