### PR TITLE
Fixes 4257: expose/disable snaps by default in prod stable

### DIFF
--- a/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.test.tsx
@@ -11,6 +11,7 @@ import {
   useFetchGpgKey,
   useValidateContentList,
 } from 'services/Content/ContentQueries';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 jest.mock('services/Content/ContentQueries', () => ({
   useAddContentQuery: jest.fn(),
@@ -53,6 +54,14 @@ jest.mock('../../ContentListTable', () => ({
   useContentListOutletContext: () => ({
     clearCheckedRepositories: () => undefined,
   }),
+}));
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: jest.fn(),
+}));
+
+(useChrome as jest.Mock).mockImplementation(() => ({
+  isProd: () => false,
 }));
 
 const passingValidationMetaDataSigNotPresent = [

--- a/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
@@ -57,6 +57,7 @@ import { useContentListOutletContext } from '../../ContentListTable';
 import useRootPath from 'Hooks/useRootPath';
 import { useAppContext } from 'middleware/AppContext';
 import CustomHelperText from 'components/CustomHelperText/CustomHelperText';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 const useStyles = createUseStyles({
   description: {
@@ -138,8 +139,15 @@ const AddContent = () => {
   );
   const classes = useStyles();
   const queryClient = useQueryClient();
+  const { isProd } = useChrome();
+  // temporarily disable snapshotting by default for custom repos
+  const handleDefaultSnapshotting = () => {
+    if (isProd()) {
+      return [getDefaultFormikValues({ snapshot: false })];
+    } else return [getDefaultFormikValues({ snapshot: snapshottingEnabled })];
+  };
   const formik = useFormik({
-    initialValues: [getDefaultFormikValues({ snapshot: snapshottingEnabled })],
+    initialValues: handleDefaultSnapshotting(),
     validateOnBlur: false,
     validateOnChange: false,
     validationSchema: makeValidationSchema(),
@@ -557,7 +565,7 @@ const AddContent = () => {
                           <FormAlert style={{ paddingTop: '20px' }}>
                             <Alert
                               variant='warning'
-                              title='Disabling snapshots might result in a higher risk of losing content or unintentionally modifying it irreversibly.'
+                              title='Enable snapshotting for this repository if you want to build images with historical snapshots.'
                               isInline
                             />
                           </FormAlert>

--- a/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.test.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.test.tsx
@@ -6,6 +6,7 @@ import {
 } from 'testingHelpers';
 import PopularRepositoriesTable from './PopularRepositoriesTable';
 import { usePopularRepositoriesQuery, useRepositoryParams } from 'services/Content/ContentQueries';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 jest.mock('services/Content/ContentQueries', () => ({
   useRepositoryParams: jest.fn(),
@@ -18,6 +19,14 @@ jest.mock('services/Content/ContentQueries', () => ({
 
 jest.mock('middleware/AppContext', () => ({
   useAppContext: () => ({}),
+}));
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: jest.fn(),
+}));
+
+(useChrome as jest.Mock).mockImplementation(() => ({
+  isProd: () => false,
 }));
 
 jest.mock('react-router-dom', () => ({

--- a/src/Pages/Repositories/PopularRepositoriesTable/components/AddRepo.test.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/components/AddRepo.test.tsx
@@ -1,9 +1,18 @@
 import { fireEvent, render } from '@testing-library/react';
 import { AddRepo } from './AddRepo';
 import { useAppContext } from 'middleware/AppContext';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 jest.mock('middleware/AppContext', () => ({
   useAppContext: jest.fn(),
+}));
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: jest.fn(),
+}));
+
+(useChrome as jest.Mock).mockImplementation(() => ({
+  isProd: () => false,
 }));
 
 it('Render enabled with snapshots enabled', () => {

--- a/src/middleware/AppContext.tsx
+++ b/src/middleware/AppContext.tsx
@@ -44,12 +44,6 @@ export const ContextProvider = ({ children }: { children: ReactNode }) => {
 
     (async () => {
       const fetchedFeatures = await fetchFeatures();
-      // Disable snapshotting in prod stable
-      if (chrome.isProd() && !chrome.isBeta() && fetchedFeatures?.snapshots?.accessible) {
-        if (fetchedFeatures !== null && fetchedFeatures.snapshots !== undefined) {
-          fetchedFeatures.snapshots.accessible = false;
-        }
-      }
       setFeatures(fetchedFeatures);
     })();
   }, [!!chrome]);


### PR DESCRIPTION
## Summary

- Exposes snapshotting in prod stable
- Temporarily disables snapshotting by default for custom and popular repos in prod stable

## Testing steps

When running the frontend on prod->stable:
- Snapshotting should be turned on
- When adding a custom repo, snapshot creation should default to disabled (see screenshot below)
![Screenshot 2024-06-21 at 1 56 05 PM](https://github.com/content-services/content-sources-frontend/assets/28575816/29bbdcfe-860c-425a-ac41-04759a155176)

- The top-level add / batch add button for popular repositories should add repositories with snapshotting disabled
- The hidden button in the add / batch add dropdown should show an option to "Add with snapshotting", which should add these repositories with snapshotting enabled (see screenshots below)
![Screenshot 2024-06-21 at 1 55 44 PM](https://github.com/content-services/content-sources-frontend/assets/28575816/21d1029e-1f5e-48bd-87ba-444117cb2a8f)
![Screenshot 2024-06-21 at 1 55 34 PM](https://github.com/content-services/content-sources-frontend/assets/28575816/49199d12-fb55-4287-986a-34c0d705694d)
