### PR TITLE
Fixes 3794,4173,4210: delete confirmation modal for repos

### DIFF
--- a/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
@@ -217,7 +217,7 @@ const ContentListTable = () => {
     triggerSnapshotMutation(uuid);
   };
 
-  const { mutateAsync: deleteItems, isLoading: isDeletingItems } = useBulkDeleteContentItemMutate(
+  const { isLoading: isDeletingItems } = useBulkDeleteContentItemMutate(
     queryClient,
     checkedRepositories,
     page,
@@ -356,7 +356,7 @@ const ContentListTable = () => {
             { isSeparator: true },
             {
               title: 'Delete',
-              onClick: () => navigate(`${DELETE_ROUTE}?repoUUIDS=${rowData.uuid}`),
+              onClick: () => navigate(`${DELETE_ROUTE}?repoUUID=${rowData.uuid}`),
             },
           ],
     [actionTakingPlace, checkedRepositories, isRedHatRepository],
@@ -403,15 +403,6 @@ const ContentListTable = () => {
     setCheckedRepositories(newSet);
   };
 
-  const deleteCheckedRepos = () =>
-    deleteItems(checkedRepositories).then(() => {
-      const newMaxPage = Math.ceil((count - checkedRepositories.size) / perPage);
-      if (page > 1 && newMaxPage < page) {
-        setPage(newMaxPage);
-      }
-      clearCheckedRepositories();
-    });
-
   const itemName =
     contentOrigin === ContentOrigin.EXTERNAL ? 'custom repositories' : 'Red Hat repositories';
   const notFilteredBody = 'To get started, create a custom repository';
@@ -442,7 +433,14 @@ const ContentListTable = () => {
       <Outlet
         context={{
           clearCheckedRepositories,
-          deletionContext: { page, perPage, filterData, contentOrigin, sortString: sortString },
+          deletionContext: {
+            page,
+            perPage,
+            filterData,
+            contentOrigin,
+            sortString: sortString,
+            checkedRepositories,
+          },
         }}
       />
       <Grid
@@ -462,7 +460,6 @@ const ContentListTable = () => {
             filterData={filterData}
             atLeastOneRepoChecked={atLeastOneRepoChecked}
             numberOfReposChecked={checkedRepositories.size}
-            deleteCheckedRepos={deleteCheckedRepos}
           />
           <FlexItem>
             <Pagination
@@ -688,6 +685,7 @@ export const useContentListOutletContext = () =>
       filterData: FilterData;
       contentOrigin: ContentOrigin;
       sortString: string;
+      checkedRepositories: Set<string>;
     };
   }>();
 

--- a/src/Pages/Repositories/ContentListTable/components/ContentListFilters.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/ContentListFilters.test.tsx
@@ -41,7 +41,6 @@ it('Render loading state (disabled)', () => {
       }}
       atLeastOneRepoChecked={false}
       numberOfReposChecked={0}
-      deleteCheckedRepos={() => null}
     />,
   );
 
@@ -63,7 +62,6 @@ it('Select a filter of each type and ensure chips are present', () => {
       }}
       atLeastOneRepoChecked={false}
       numberOfReposChecked={0}
-      deleteCheckedRepos={() => null}
     />,
   );
 

--- a/src/Pages/Repositories/ContentListTable/components/ContentListFilters.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/ContentListFilters.tsx
@@ -35,7 +35,6 @@ interface Props {
   filterData: FilterData;
   atLeastOneRepoChecked: boolean;
   numberOfReposChecked: number;
-  deleteCheckedRepos: () => void;
   setContentOrigin: (origin: ContentOrigin) => void;
   contentOrigin: ContentOrigin;
 }
@@ -64,7 +63,6 @@ const ContentListFilters = ({
   filterData,
   atLeastOneRepoChecked,
   numberOfReposChecked,
-  deleteCheckedRepos,
   setContentOrigin,
   contentOrigin,
 }: Props) => {
@@ -325,7 +323,6 @@ const ContentListFilters = ({
               isDisabled={!rbac?.repoWrite || isRedHatRepository}
               atLeastOneRepoChecked={atLeastOneRepoChecked}
               numberOfReposChecked={numberOfReposChecked}
-              deleteCheckedRepos={deleteCheckedRepos}
               toggleOuiaId='custom_repositories_kebab_toggle'
             />
           </ConditionalTooltip>

--- a/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.test.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.test.tsx
@@ -20,6 +20,11 @@ jest.mock('middleware/AppContext', () => ({
   useAppContext: () => ({}),
 }));
 
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+  useHref: () => 'insights/content/repositories',
+}));
+
 it('expect PopularRepositoriesTable to render with add one item', () => {
   (useRepositoryParams as jest.Mock).mockImplementation(() => ({ isLoading: false }));
   (usePopularRepositoriesQuery as jest.Mock).mockImplementation(() => ({

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -80,6 +80,7 @@ const TemplatesTable = () => {
     arch: '',
     version: '',
     search: '',
+    repository_uuids: '',
   };
 
   const [filterData, setFilterData] = useState<TemplateFilterData>(defaultValues);

--- a/src/Pages/Templates/TemplatesTable/components/TemplateFilters.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/TemplateFilters.test.tsx
@@ -29,6 +29,7 @@ it('Render loading state (disabled)', async () => {
         search: '',
         version: '',
         arch: '',
+        repository_uuids: '',
       }}
     />,
   );
@@ -45,6 +46,7 @@ it('Select a filter of each type and ensure chips are present', async () => {
         search: '',
         version: '',
         arch: '',
+        repository_uuids: '',
       }}
     />,
   );

--- a/src/Pages/Templates/TemplatesTable/components/TemplateFilters.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/TemplateFilters.tsx
@@ -70,7 +70,7 @@ const Filters = ({ isLoading, setFilterData, filterData }: Props) => {
     setSearchQuery('');
     setSelectedVersion('');
     setSelectedArch('');
-    setFilterData({ search: '', version: '', arch: '' });
+    setFilterData({ search: '', version: '', arch: '', repository_uuids: '' });
   };
 
   useEffect(() => {
@@ -104,6 +104,7 @@ const Filters = ({ isLoading, setFilterData, filterData }: Props) => {
       search: debouncedSearchQuery,
       version: getLabels('version', debouncedSelectedVersion),
       arch: getLabels('arch', debouncedSelectedArch),
+      repository_uuids: '',
     });
   }, [debouncedSearchQuery, debouncedSelectedVersion, debouncedSelectedArch]);
 

--- a/src/components/DeleteKebab/DeleteKebab.test.tsx
+++ b/src/components/DeleteKebab/DeleteKebab.test.tsx
@@ -5,13 +5,13 @@ jest.mock('middleware/AppContext', () => ({
   useAppContext: () => ({ rbac: { read: true, write: true } }),
 }));
 
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+}));
+
 it('Render no checked repos', () => {
   const { queryByText } = render(
-    <DeleteKebab
-      atLeastOneRepoChecked={false}
-      numberOfReposChecked={0}
-      deleteCheckedRepos={() => null}
-    />,
+    <DeleteKebab atLeastOneRepoChecked={false} numberOfReposChecked={0} />,
   );
 
   const kebab = document.getElementById('delete-kebab');
@@ -24,11 +24,7 @@ it('Render no checked repos', () => {
 it('Render with checked repos', () => {
   const repos = 100;
   const { queryByText } = render(
-    <DeleteKebab
-      atLeastOneRepoChecked={true}
-      numberOfReposChecked={repos}
-      deleteCheckedRepos={() => null}
-    />,
+    <DeleteKebab atLeastOneRepoChecked={true} numberOfReposChecked={repos} />,
   );
 
   const kebab = document.getElementById('delete-kebab');

--- a/src/components/DeleteKebab/DeleteKebab.tsx
+++ b/src/components/DeleteKebab/DeleteKebab.tsx
@@ -1,11 +1,12 @@
 import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core/deprecated';
 import { useState } from 'react';
 import ConditionalTooltip from '../ConditionalTooltip/ConditionalTooltip';
+import { useNavigate } from 'react-router-dom';
+import { DELETE_ROUTE } from 'Routes/constants';
 
 interface Props {
   atLeastOneRepoChecked: boolean;
   numberOfReposChecked: number;
-  deleteCheckedRepos: () => void;
   toggleOuiaId?: string;
   isDisabled?: boolean;
 }
@@ -13,10 +14,10 @@ interface Props {
 const DeleteKebab = ({
   atLeastOneRepoChecked,
   numberOfReposChecked,
-  deleteCheckedRepos,
   toggleOuiaId,
   isDisabled,
 }: Props) => {
+  const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
 
   const onToggle = (isOpen: boolean) => {
@@ -40,7 +41,7 @@ const DeleteKebab = ({
       show={!atLeastOneRepoChecked}
       setDisabled
     >
-      <DropdownItem onClick={deleteCheckedRepos}>
+      <DropdownItem onClick={() => navigate(`${DELETE_ROUTE}`)}>
         {atLeastOneRepoChecked
           ? `Remove ${numberOfReposChecked} repositories`
           : 'Remove selected repositories'}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -18,11 +18,11 @@ export const formatDateDDMMMYYYY = (date: string, withTime?: boolean): string =>
   dayjs(date).format(`DD MMM YYYY${withTime ? ' - HH:mm:ss' : ''}`);
 
 export const formatTemplateDate = (date: string): string =>
-    dayjs(date).format('YYYY-MM-DDTHH:mm:ssZ');
+  dayjs(date).format('YYYY-MM-DDTHH:mm:ssZ');
 
 export const reduceStringToCharsWithEllipsis = (str: string, maxLength: number = 50) =>
   str.length > maxLength ? str.split('').slice(0, maxLength).join('') + '...' : str;
 
-// Removes any cases of 3+ line breaks and replaces them with 2 
-export const formatDescription = (description: string): string => 
+// Removes any cases of 3+ line breaks and replaces them with 2
+export const formatDescription = (description: string): string =>
   description.replace(/\n{3,}/g, '\n\n');

--- a/src/services/Templates/TemplateApi.ts
+++ b/src/services/Templates/TemplateApi.ts
@@ -36,6 +36,7 @@ export type TemplateFilterData = {
   arch: string;
   version: string;
   search: string;
+  repository_uuids: string;
 };
 
 export const getTemplates: (
@@ -47,7 +48,7 @@ export const getTemplates: (
   page,
   limit,
   sortBy,
-  { search, arch, version },
+  { search, arch, version, repository_uuids },
 ) => {
   const { data } = await axios.get(
     `/api/content-sources/v1/templates/?${objectToUrlParams({
@@ -57,6 +58,7 @@ export const getTemplates: (
       arch,
       version,
       sort_by: sortBy,
+      repository_uuids: repository_uuids,
     })}`,
   );
   return data;

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -259,6 +259,21 @@ export const defaultTemplateItem: TemplateItem = {
   ],
 };
 
+// Template used for testing delete modal where repo is not in any templates
+export const defaultTemplateItem2: TemplateItem = {
+  uuid: '60412eda-7df5-4fac-8556-278f45e2ef9a',
+  name: 'Bettyboop!',
+  org_id: '16758779',
+  description: 'I am not associated with the default repo!',
+  arch: 'aarch64',
+  version: '9',
+  date: '2024-01-22T00:00:00-07:00',
+  repository_uuids: [
+    '31c06bb4-ef1b-42f5-8c91-0ff67e7d8a1b',
+    '28b8d2b1-e4d6-4d8a-be12-1104601fb96e',
+  ],
+};
+
 export const defaultSnapshotForDateItem: SnapshotForDate = {
   repository_uuid: defaultContentItem.uuid,
   is_after: true,


### PR DESCRIPTION
## Summary

- Adds a confirmation modal when deleting one or many repositories
- If a repo is associated with any templates, the modal shows a warning message and which templates are associated with it

## Testing steps

- Add a few custom and popular repositories, let them snapshot, and create some templates from those repositories' snapshots
- Deleting a custom or popular repository via the delete kebab or Popular Repositories tab should route to the confirmation modal. Clicking Remove in the modal should remove this repository
- Bulk deletion of repositories should route to the confirmation modal and show a table of the repositories selected to delete. Clicking Remove in the modal should remove each repository
- If a repository has associated templates, a warning message and the list of templates should be shown in the modal with a link to the template edit modal for each respective template (a future improvement would be to route directly to the Custom Repositories step in that modal, ticket filed [here](https://issues.redhat.com/browse/HMS-4305) to make each step in the template edit modal routable)
- If a repository is associated with more than 5 templates, you should see `...and X more` in the list of associated templates

Note: There is an API bug that lists duplicate templates if multiple repositories are included in a template. Ticket filed [here](https://issues.redhat.com/browse/HMS-4292) and PR [here](https://github.com/content-services/content-sources-backend/pull/711)