### PR TITLE
Fixes 4133: add types filter to admin tasks list

### DIFF
--- a/src/Pages/Repositories/AdminTaskTable/AdminTaskTable.tsx
+++ b/src/Pages/Repositories/AdminTaskTable/AdminTaskTable.tsx
@@ -70,12 +70,13 @@ const AdminTaskTable = () => {
     accountId: '',
     orgId: '',
     statuses: [],
+    typenames: [],
   });
 
-  const clearFilters = () => setFilterData({ statuses: [], accountId: '', orgId: '' });
+  const clearFilters = () => setFilterData({ statuses: [], accountId: '', orgId: '' , typenames: []});
 
   const notFiltered =
-    filterData.statuses?.length === 0 && filterData.accountId === '' && filterData.orgId === '';
+      filterData.typenames?.length === 0 && filterData.statuses?.length === 0 && filterData.accountId === '' && filterData.orgId === '';
 
   const columnSortAttributes = ['org_id', 'account_id', 'typename', 'queued_at', 'status'];
 

--- a/src/Pages/Repositories/AdminTaskTable/components/AdminTaskFilters.test.tsx
+++ b/src/Pages/Repositories/AdminTaskTable/components/AdminTaskFilters.test.tsx
@@ -17,6 +17,7 @@ it('Render loading state (disabled)', () => {
         statuses: [],
         accountId: '',
         orgId: '',
+        typenames: [],
       }}
     />,
   );
@@ -33,6 +34,7 @@ it('Select a filter of each type and ensure chips are present', () => {
         statuses: [],
         accountId: '',
         orgId: '',
+        typenames: [],
       }}
     />,
   );
@@ -72,8 +74,25 @@ it('Select a filter of each type and ensure chips are present', () => {
   // Click the optionsButton to make the statusMenu disappear
   fireEvent.click(optionMenu);
 
+    // Select a Type item
+    const typeOption = queryByText('Type') as Element;
+    expect(typeOption).toBeInTheDocument();
+    fireEvent.click(typeOption);
+
+    const typeSelector = getByLabelText('filter type') as Element;
+    expect(typeSelector).toBeInTheDocument();
+    fireEvent.click(typeSelector);
+
+    const typeItem = queryByText('introspect') as Element;
+    expect(typeItem).toBeInTheDocument();
+    fireEvent.click(typeItem);
+
+    // Click the optionsButton to make the typeMenu disappear
+    fireEvent.click(optionMenu);
+
   // Check all the chips are there
   expect(queryByText('11593016')).toBeInTheDocument();
   expect(queryByText('13446804')).toBeInTheDocument();
   expect(queryByText('Running')).toBeInTheDocument();
+  expect(queryByText('introspect')).toBeInTheDocument();
 });

--- a/src/services/AdminTasks/AdminTaskApi.ts
+++ b/src/services/AdminTasks/AdminTaskApi.ts
@@ -6,6 +6,7 @@ export interface AdminTaskFilterData {
   statuses: string[];
   accountId: string;
   orgId: string;
+  typenames: string[];
 }
 
 export interface PulpData {
@@ -45,6 +46,7 @@ export const getAdminTasks: (
   const accountIdParam = filterData.accountId;
   const orgIdParam = filterData.orgId;
   const statusParam = filterData?.statuses?.join(',').toLowerCase();
+  const typeParam = filterData?.typenames?.join(',').toLowerCase()
   const { data } = await axios.get(
     `/api/content-sources/v1/admin/tasks/?${objectToUrlParams({
       offset: ((page - 1) * limit).toString(),
@@ -52,6 +54,7 @@ export const getAdminTasks: (
       account_id: accountIdParam,
       org_id: orgIdParam,
       status: statusParam,
+      type: typeParam,
       sort_by: sortBy,
     })}`,
   );


### PR DESCRIPTION
## Summary
Adds a type filter to the admin tasks tab

## Testing steps
1. Checkout this backend PR: https://github.com/content-services/content-sources-backend/pull/710
2. Create or delete some repos or templates to create some tasks
3. Navigate to the admin tasks tab and use the Type filter
