### PR TITLE
Fixes 3898: add glitchtip error component

### DIFF
--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -24,6 +24,7 @@ import TemplatesTable from 'Pages/Templates/TemplatesTable/TemplatesTable';
 import { NoPermissionsPage } from 'components/NoPermissionsPage/NoPermissionsPage';
 import TemplatePackageTab from 'Pages/Templates/TemplateDetails/components/TemplatePackageDetails';
 import TemplateErrataDetails from 'Pages/Templates/TemplateDetails/components/TemplateErrataDetails';
+import GlitchtipError from '../components/Error/GlitchtipError';
 
 export default function RepositoriesRoutes() {
   const key = useMemo(() => Math.random(), []);
@@ -32,55 +33,57 @@ export default function RepositoriesRoutes() {
 
   return (
     <ErrorPage>
-      <Routes key={key}>
-        {zeroState ? <Route path={REPOSITORIES_ROUTE} element={<ZeroState />} /> : <></>}
+      <GlitchtipError>
+        <Routes key={key}>
+          {zeroState ? <Route path={REPOSITORIES_ROUTE} element={<ZeroState />} /> : <></>}
 
-        <Route element={<RepositoryLayout tabs={repositoryRoutes} />}>
-          {repositoryRoutes.map(({ route, Element, ChildRoutes }, key) => (
-            <Route key={key.toString()} path={route} element={<Element />}>
-              {ChildRoutes?.map(({ path, Element: ChildRouteElement }, childRouteKey) => (
-                <Route key={childRouteKey} path={path} element={<ChildRouteElement />} />
-              ))}
-            </Route>
-          ))}
-        </Route>
-        {!rbac?.templateRead ? (
-          <Route path={TEMPLATES_ROUTE} element={<NoPermissionsPage />} />
-        ) : (
-          ''
-        )}
-        <Route
-          path={`${TEMPLATES_ROUTE}/:templateUUID/${DETAILS_ROUTE}`}
-          element={<TemplateDetails />}
-        >
-          <Route path='' element={<Navigate to={`${CONTENT_ROUTE}/${PACKAGES_ROUTE}`} replace />} />
-          <Route path={CONTENT_ROUTE}>
-            <Route path='' element={<Navigate to={PACKAGES_ROUTE} replace />} />
-            <Route path={PACKAGES_ROUTE} element={<TemplatePackageTab />} />
-            <Route path={ADVISORIES_ROUTE} element={<TemplateErrataDetails />} />
-            <Route path='*' element={<Navigate to={PACKAGES_ROUTE} replace />} />
+          <Route element={<RepositoryLayout tabs={repositoryRoutes} />}>
+            {repositoryRoutes.map(({ route, Element, ChildRoutes }, key) => (
+              <Route key={key.toString()} path={route} element={<Element />}>
+                {ChildRoutes?.map(({ path, Element: ChildRouteElement }, childRouteKey) => (
+                  <Route key={childRouteKey} path={path} element={<ChildRouteElement />} />
+                ))}
+              </Route>
+            ))}
           </Route>
+          {!rbac?.templateRead ? (
+            <Route path={TEMPLATES_ROUTE} element={<NoPermissionsPage />} />
+          ) : (
+            ''
+          )}
+          <Route
+            path={`${TEMPLATES_ROUTE}/:templateUUID/${DETAILS_ROUTE}`}
+            element={<TemplateDetails />}
+          >
+            <Route path='' element={<Navigate to={`${CONTENT_ROUTE}/${PACKAGES_ROUTE}`} replace />} />
+            <Route path={CONTENT_ROUTE}>
+              <Route path='' element={<Navigate to={PACKAGES_ROUTE} replace />} />
+              <Route path={PACKAGES_ROUTE} element={<TemplatePackageTab />} />
+              <Route path={ADVISORIES_ROUTE} element={<TemplateErrataDetails />} />
+              <Route path='*' element={<Navigate to={PACKAGES_ROUTE} replace />} />
+            </Route>
 
-          {/*
-           // TODO: Uncomment this for SYSTEMS support
-          <Route path={SYSTEMS_ROUTE}>
-            <Route path='' element={<Navigate to='other' replace />} />
-            <Route path='other' element={<>other</>} />
-            <Route path='thing' element={<>thing</>} />
-            <Route path='*' element={<Navigate to='other' replace />} />
-          </Route> */}
-          <Route path='*' element={<Navigate to='content' replace />} />
-        </Route>
-        <Route path={TEMPLATES_ROUTE} element={<TemplatesTable />}>
-          {...rbac?.templateWrite
-            ? [
-                <Route key='1' path={ADD_ROUTE} element={<AddTemplate />} />,
-                <Route key='2' path={`:templateUUID/${EDIT_ROUTE}`} element={<AddTemplate />} />,
-              ]
-            : []}
-        </Route>
-        <Route path='*' element={<Navigate to={REPOSITORIES_ROUTE} replace />} />
-      </Routes>
+            {/*
+             // TODO: Uncomment this for SYSTEMS support
+            <Route path={SYSTEMS_ROUTE}>
+              <Route path='' element={<Navigate to='other' replace />} />
+              <Route path='other' element={<>other</>} />
+              <Route path='thing' element={<>thing</>} />
+              <Route path='*' element={<Navigate to='other' replace />} />
+            </Route> */}
+            <Route path='*' element={<Navigate to='content' replace />} />
+          </Route>
+          <Route path={TEMPLATES_ROUTE} element={<TemplatesTable />}>
+            {...rbac?.templateWrite
+              ? [
+                  <Route key='1' path={ADD_ROUTE} element={<AddTemplate />} />,
+                  <Route key='2' path={`:templateUUID/${EDIT_ROUTE}`} element={<AddTemplate />} />,
+                ]
+              : []}
+          </Route>
+          <Route path='*' element={<Navigate to={REPOSITORIES_ROUTE} replace />} />
+        </Routes>
+      </GlitchtipError>
     </ErrorPage>
   );
 }

--- a/src/components/Error/GlitchtipError.tsx
+++ b/src/components/Error/GlitchtipError.tsx
@@ -1,0 +1,40 @@
+import { Component, ReactNode } from 'react';
+import axios from 'axios';
+
+interface Props {
+    children?: ReactNode;
+    fallback?: ReactNode;
+}
+
+interface State {
+    hasError: boolean;
+}
+
+class GlitchtipError extends Component<Props, State> {
+    state: State = {
+        hasError: false
+    };
+
+    static getDerivedStateFromError(): State {
+        // Update state so the next render will show the fallback UI.
+        return { hasError: true };
+    }
+
+    componentDidCatch(error: Error) {
+        axios.post('/api/content-sources/v1.0/log_error/', {
+            error_title: 'UI error',
+            error_details: error.stack,
+        })
+        throw error
+    }
+
+    public render() {
+        if (this.state.hasError) {
+            return this.props.fallback
+        }
+
+        return this.props.children;
+    }
+}
+
+export default GlitchtipError;


### PR DESCRIPTION
## Summary
Adds an error boundary component that, sends an error message to the backend API. The backend API will log the error so we get a glitchtip notification for it.

## Testing steps
1. Checkout https://github.com/content-services/content-sources-backend/pull/730
2. Replace the AddContent modal with something like `return <button onClick={methodDoesNotExist}> Ahhhh </button>`.
3. The frontend UI should show a dropdown with the error (same behavior as main)
4. The backend should have a log for the error message you see in the UI
