### PR TITLE
Fixes 4392,4444: improve recovery from failed snapshot

### DIFF
--- a/src/Pages/Repositories/ContentListTable/ContentListTable.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.test.tsx
@@ -86,7 +86,7 @@ it('Render with a single row', async () => {
     },
   }));
 
-  const { queryByText, getByRole } = render(
+  const { queryByText, getByRole, queryByRole } = render(
     <ReactQueryTestWrapper>
       <ContentListTable />
     </ReactQueryTestWrapper>,
@@ -109,6 +109,6 @@ it('Render with a single row', async () => {
 
   await waitFor(() => expect(getByRole('menuitem', { name: 'Edit' })).toBeInTheDocument());
   expect(getByRole('menuitem', { name: 'Trigger snapshot' })).toBeInTheDocument();
-  expect(getByRole('menuitem', { name: 'Introspect now' })).toBeInTheDocument();
+  expect(queryByRole('menuitem', { name: 'Introspect now' })).not.toBeInTheDocument();
   expect(getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
 });

--- a/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
@@ -227,9 +227,10 @@ const ContentListTable = () => {
     sortString,
   );
 
-  const triggerIntrospectionAndSnapshot = (repoUuid) => {
-    introspectRepoForUuid(repoUuid).then(clearCheckedRepositories);
-    triggerSnapshot(repoUuid);
+  const triggerIntrospectionAndSnapshot = async (repoUuid: string): Promise<void> => {
+    clearCheckedRepositories();
+    await introspectRepoForUuid(repoUuid)
+    await triggerSnapshot(repoUuid);
   }
 
   // Other update actions will be added to this later.
@@ -320,10 +321,9 @@ const ContentListTable = () => {
                   {
                     isDisabled:
                       actionTakingPlace ||
-                      !rowData.snapshot ||
-                      !(rowData.snapshot && rowData.last_snapshot_uuid),
+                      !rowData.last_snapshot_uuid,
                     title:
-                      rowData.snapshot && rowData.last_snapshot_uuid
+                      rowData.last_snapshot_uuid
                         ? 'View all snapshots'
                         : 'No snapshots yet',
                     onClick: () => {

--- a/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
@@ -227,6 +227,11 @@ const ContentListTable = () => {
     sortString,
   );
 
+  const triggerIntrospectionAndSnapshot = (repoUuid) => {
+    introspectRepoForUuid(repoUuid).then(clearCheckedRepositories);
+    triggerSnapshot(repoUuid);
+  }
+
   // Other update actions will be added to this later.
   const actionTakingPlace =
     isFetching || repositoryParamsLoading || isIntrospecting || isDeletingItems;
@@ -335,7 +340,7 @@ const ContentListTable = () => {
                       actionTakingPlace || rowData?.status === 'Pending' || !rowData.snapshot,
                     title: 'Trigger snapshot',
                     onClick: () => {
-                      triggerSnapshot(rowData.uuid);
+                        triggerIntrospectionAndSnapshot(rowData?.uuid);
                     },
                     tooltipProps: !rowData.snapshot
                       ? {
@@ -348,11 +353,16 @@ const ContentListTable = () => {
                   },
                 ]
               : []),
-            {
-              isDisabled: actionTakingPlace || rowData?.status == 'Pending',
-              title: 'Introspect now',
-              onClick: () => introspectRepoForUuid(rowData?.uuid).then(clearCheckedRepositories),
-            },
+            ...(!rowData?.snapshot
+              ? [
+                  {
+                    isDisabled: actionTakingPlace || rowData?.status == 'Pending',
+                    title: 'Introspect now',
+                    onClick: () =>
+                      introspectRepoForUuid(rowData?.uuid).then(clearCheckedRepositories),
+                  },
+                ]
+              : []),
             { isSeparator: true },
             {
               title: 'Delete',

--- a/src/Pages/Repositories/ContentListTable/components/StatusIcon.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/StatusIcon.test.tsx
@@ -36,7 +36,7 @@ it('Render with Unavailable status', async () => {
 
   await waitFor(() => {
     expect(queryByText('Retry')).toBeInTheDocument();
-    expect(queryByText('snapshot failed')).toBeInTheDocument();
+    expect(queryByText('A snapshot error occurred: snapshot failed')).toBeInTheDocument();
   });
 });
 
@@ -53,6 +53,6 @@ it('Render with Invalid status', async () => {
 
   await waitFor(() => {
     expect(queryByText('Retry')).toBeInTheDocument();
-    expect(queryByText('snapshot failed')).toBeInTheDocument();
+    expect(queryByText('A snapshot error occurred: snapshot failed')).toBeInTheDocument();
   });
 });

--- a/src/Pages/Repositories/ContentListTable/components/StatusIcon.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/StatusIcon.tsx
@@ -108,9 +108,9 @@ const StatusIcon = ({
     if (!snapshotError && !introspectError) {
       return 'An unknown error occurred';
     } else if (snapshotError) {
-      return snapshotError;
+      return `A snapshot error occurred: ${snapshotError}`;
     } else if (introspectError) {
-      return introspectError;
+      return `An introspection error occurred: ${introspectError}`;
     }
   };
 

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -686,6 +686,7 @@ export const useIntrospectRepositoryMutate = (
   ];
   const errorNotifier = useErrorNotification();
   const { notify } = useNotification();
+  let hasSnapshottingEnabled: boolean | undefined = false;
   return useMutation(introspectRepository, {
     onMutate: async (item: IntrospectRepositoryRequestItem) => {
       // Cancel any outgoing refetches (so they don't overwrite our optimistic update)
@@ -706,15 +707,19 @@ export const useIntrospectRepositoryMutate = (
       queryClient.setQueryData(contentListKeyArray, () => ({
         ...newData,
       }));
+
+      hasSnapshottingEnabled = newData.data?.at(0)?.snapshot;
       // Return a context object with the snapshotted value
       return { previousData, queryClient };
     },
     onSuccess: () => {
-      notify({
-        variant: AlertVariant.success,
-        title: 'Repository introspection in progress',
-        id: 'introspect-repository-success',
-      });
+      if (!hasSnapshottingEnabled) {
+        notify({
+          variant: AlertVariant.success,
+          title: 'Repository introspection in progress',
+          id: 'introspect-repository-success',
+        });
+      }
       queryClient.invalidateQueries(ADMIN_TASK_LIST_KEY);
     },
     // If the mutation fails, use the context returned from onMutate to roll back


### PR DESCRIPTION
## Summary

- Changes Trigger snapshot action to kick off both introspection and snapshot tasks
- Only shows the Introspect now action if a repo doesn't have snapshotting enabled
- Errors are labeled as coming from either introspection or snapshot
- Adds fix to allow users to see their previous snapshots if they exist even if the repo has snapshotting disabled

## Testing steps

- Create 2 repositories, one with snapshotting enabled and one with it disabled. You should still see Introspect now as an action in the kebab for the snapshot-disabled repo, but should not see it for the snapshot-enabled repo
- Clicking Trigger snapshot for the snapshot-enabled repo should kick off both introspection and snapshotting. You can verify this in the backend logs or wait to see the Last Introspection time change in the UI
- If there is an error with snapshotting or introspection, these should be labeled as either `A snapshot error occurred: <error message>` or `An introspection error occurred: <error message>` when clicking on the repository status