### PR TITLE
Fixes 4474: fix snapshot behavior in prod-beta

### DIFF
--- a/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
@@ -139,10 +139,10 @@ const AddContent = () => {
   );
   const classes = useStyles();
   const queryClient = useQueryClient();
-  const { isProd } = useChrome();
+  const { isProd, isBeta } = useChrome();
   // temporarily disable snapshotting by default for custom repos
   const handleDefaultSnapshotting = () => {
-    if (isProd()) {
+    if (isProd() && !isBeta()) {
       return [getDefaultFormikValues({ snapshot: false })];
     } else return [getDefaultFormikValues({ snapshot: snapshottingEnabled })];
   };

--- a/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.test.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.test.tsx
@@ -27,6 +27,7 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 
 (useChrome as jest.Mock).mockImplementation(() => ({
   isProd: () => false,
+  isBeta: () => false,
 }));
 
 jest.mock('react-router-dom', () => ({

--- a/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.tsx
@@ -146,8 +146,9 @@ const PopularRepositoriesTable = () => {
   const debouncedSearchValue = useDebounce(searchValue);
   const [perPage, setPerPage] = useState(storedPerPage);
   const [isActionOpen, setIsActionOpen] = useState(false);
-  const { isProd } = useChrome();
+  const { isProd, isBeta } = useChrome();
   const isInProd = useMemo(() => isProd() === true, []);
+  const isInBeta = useMemo(() => isBeta() === true, []);
 
   const onDropdownToggle = (_, isActionOpen: boolean) => {
     setIsActionOpen(isActionOpen);
@@ -346,7 +347,7 @@ const PopularRepositoriesTable = () => {
   const countIsZero = !data?.data?.length;
 
   const dropdownItems = useMemo(() => {
-    if (isInProd) {
+    if (isInProd && !isInBeta) {
       return [
         <DropdownItem
           key='action'
@@ -368,7 +369,7 @@ const PopularRepositoriesTable = () => {
           {`Add ${checkedRepositoriesToAdd.size} repositories without snapshotting`}
         </DropdownItem>,
       ];
-  }, [isInProd, checkedRepositoriesToAdd.size]);
+  }, [isInProd, isInBeta, checkedRepositoriesToAdd.size]);
 
   return (
     <Grid data-ouia-component-id='popular_repositories_page' className={classes.mainContainer}>
@@ -409,7 +410,7 @@ const PopularRepositoriesTable = () => {
                     if (features?.snapshots?.enabled && features.snapshots.accessible) {
                       const className = isDisabled ? classes.disabledDropdownButton : undefined;
                       // temporarily disable snapshotting by default for popular repos
-                      if (isInProd) {
+                      if (isInProd && !isInBeta) {
                         return (
                           <Dropdown
                             onSelect={onDropdownSelect}

--- a/src/Pages/Repositories/PopularRepositoriesTable/components/AddRepo.test.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/components/AddRepo.test.tsx
@@ -13,6 +13,7 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 
 (useChrome as jest.Mock).mockImplementation(() => ({
   isProd: () => false,
+  isBeta: () => false,
 }));
 
 it('Render enabled with snapshots enabled', () => {

--- a/src/Pages/Repositories/PopularRepositoriesTable/components/AddRepo.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/components/AddRepo.tsx
@@ -28,8 +28,10 @@ export const AddRepo = ({ isDisabled, addRepo }: Props) => {
   const { features } = useAppContext();
   const classes = useStyles();
   const [isActionOpen, setIsActionOpen] = useState(false);
-  const { isProd } = useChrome();
+  const { isProd, isBeta } = useChrome();
   const isInProd = useMemo(() => isProd() === true, []);
+  const isInBeta = useMemo(() => isBeta() === true, []);
+
 
   const onActionToggle = (_, isActionOpen: boolean) => {
     setIsActionOpen(isActionOpen);
@@ -46,7 +48,7 @@ export const AddRepo = ({ isDisabled, addRepo }: Props) => {
   };
 
   const dropdownItems = useMemo(() => {
-    if (isInProd) {
+    if (isInProd && !isInBeta) {
       return [
         <DropdownItem
           data-ouia-component-id='add-popular_repo_with-snapshotting'
@@ -73,7 +75,7 @@ export const AddRepo = ({ isDisabled, addRepo }: Props) => {
   if (features?.snapshots?.enabled && features.snapshots.accessible) {
     const className = isDisabled ? classes.disabledButton : undefined;
     // temporarily disable snapshotting by default for popular repos
-    if (isInProd) {
+    if (isInProd && !isInBeta) {
       return (
         <Dropdown
           onSelect={onActionSelect}


### PR DESCRIPTION
## Summary

In prod-beta, snapshotting should not be disabled by default. This fixes that behavior 

## Testing steps
- In prod-beta, snapshotting should be turned on and enabled by default when adding a custom repository
- The button behavior for adding popular repositories should be the same as it is in stage (split button should be Add > Add without snapshotting instead of Add > Add with snapshotting)
