### PR TITLE
Fixes 4475,4438: routing issues when deleting popular repos

### DIFF
--- a/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContent.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContent.test.tsx
@@ -38,6 +38,14 @@ jest.mock('../../ContentListTable', () => ({
   }),
 }));
 
+jest.mock('../../../PopularRepositoriesTable/PopularRepositoriesTable', () => ({
+    usePopularListOutletContext: () => ({
+      deletionContext: {
+        checkedRepositoriesToDelete: new Set<string>('some-uuid'),
+      },
+    }),
+  }));
+
 jest.mock('Hooks/useRootPath', () => () => 'someUrl');
 
 jest.mock('services/Content/ContentQueries', () => ({

--- a/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
@@ -3,6 +3,7 @@ import {
   Bullseye,
   Button,
   ExpandableSection,
+  ExpandableSectionToggle,
   List,
   ListItem,
   Modal,
@@ -55,6 +56,9 @@ const useStyles = createUseStyles({
   templateColumnMinWidth: {
     minWidth: '200px!important',
   },
+  expandableSectionMargin: {
+    marginTop: '8px'
+  }
 });
 
 export default function DeleteContentModal() {
@@ -230,15 +234,11 @@ export default function DeleteContentModal() {
                           ))}
                         <Hide hide={templatesWithRepos.length <= maxTemplatesToShow}>
                           <ExpandableSection
-                            toggleText={
-                              expandState[index]
-                                ? 'Show less'
-                                : `and ${templatesWithRepos.length - maxTemplatesToShow} more`
-                            }
-                            onToggle={() =>
-                              setExpandState((prev) => ({ ...prev, [index]: !prev[index] }))
-                            }
-                            isExpanded={!!expandState[index]}
+                            isExpanded={expandState[index]}
+                            isDetached
+                            toggleId='detached-expandable-section-toggle'
+                            contentId='detached-expandable-section-content'
+                            className={classes.expandableSectionMargin}
                           >
                             {templatesWithRepos
                               .slice(maxTemplatesToShow, templatesWithRepos.length)
@@ -259,6 +259,20 @@ export default function DeleteContentModal() {
                                 </ListItem>
                               ))}
                           </ExpandableSection>
+                          <ExpandableSectionToggle
+                            isExpanded={expandState[index]}
+                            onToggle={() =>
+                                setExpandState((prev) => ({ ...prev, [index]: !prev[index] }))
+                                }
+                            toggleId='detached-expandable-section-toggle'
+                            contentId='detached-expandable-section-content'
+                            direction='up'
+                          >
+                            {expandState[index]
+                                ? 'Show less'
+                                : `and ${templatesWithRepos.length - maxTemplatesToShow} more`
+                            }
+                          </ExpandableSectionToggle>
                         </Hide>
                       </List>
                     ) : (

--- a/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
@@ -26,6 +26,7 @@ import {
 import { useQueryClient } from 'react-query';
 import { useHref, useLocation, useNavigate } from 'react-router-dom';
 import { useContentListOutletContext } from '../../ContentListTable';
+import { usePopularListOutletContext } from '../../../PopularRepositoriesTable/PopularRepositoriesTable';
 import useRootPath from 'Hooks/useRootPath';
 import { GET_TEMPLATES_KEY, useTemplateList } from 'services/Templates/TemplateQueries';
 import { TemplateFilterData, TemplateItem } from 'services/Templates/TemplateApi';
@@ -72,10 +73,18 @@ export default function DeleteContentModal() {
     clearCheckedRepositories,
     deletionContext: { page, perPage, filterData, contentOrigin, sortString, checkedRepositories },
   } = useContentListOutletContext();
+  const {
+    deletionContext: { checkedRepositoriesToDelete },
+  } = usePopularListOutletContext();
 
-  const uuids =
-    new URLSearchParams(search).get('repoUUID')?.split(',') ||
-    Array.from(checkedRepositories) ||
+  const repoUUIDFromPath = new URLSearchParams(search).get('repoUUID')?.split(',');
+  const checkedCustomRepos = checkedRepositories ? Array.from(checkedRepositories) : [];
+  const checkedPopularRepos =  checkedRepositoriesToDelete ? Array.from(checkedRepositoriesToDelete) : [];
+
+  const uuids = 
+    repoUUIDFromPath?.length ? repoUUIDFromPath : 
+    checkedCustomRepos.length ? checkedCustomRepos :
+    checkedPopularRepos.length? checkedPopularRepos :
     [];
   const reposToDelete = new Set(uuids);
 

--- a/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
@@ -236,8 +236,8 @@ export default function DeleteContentModal() {
                           <ExpandableSection
                             isExpanded={expandState[index]}
                             isDetached
-                            toggleId='detached-expandable-section-toggle'
-                            contentId='detached-expandable-section-content'
+                            toggleId={expandState[index] ? 'detached-expandable-section-toggle-open' : 'detached-expandable-section-toggle'}
+                            contentId={expandState[index] ? 'detached-expandable-section-content-open' : 'detached-expandable-section-content'}
                             className={classes.expandableSectionMargin}
                           >
                             {templatesWithRepos
@@ -264,8 +264,8 @@ export default function DeleteContentModal() {
                             onToggle={() =>
                                 setExpandState((prev) => ({ ...prev, [index]: !prev[index] }))
                                 }
-                            toggleId='detached-expandable-section-toggle'
-                            contentId='detached-expandable-section-content'
+                            toggleId={expandState[index] ? 'detached-expandable-section-toggle-open' : 'detached-expandable-section-toggle'}
+                            contentId={expandState[index] ? 'detached-expandable-section-content-open' : 'detached-expandable-section-content'}
                             direction='up'
                           >
                             {expandState[index]

--- a/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
@@ -225,7 +225,7 @@ export default function DeleteContentModal() {
                                 className={classes.link}
                                 variant='link'
                                 component='a'
-                                href={pathname + '/' + TEMPLATES_ROUTE + `/${template.uuid}/edit`}
+                                href={pathname + '/' + TEMPLATES_ROUTE + `/${template.uuid}/edit?tab=custom_repositories`}
                                 target='_blank'
                               >
                                 {template.name}
@@ -250,7 +250,7 @@ export default function DeleteContentModal() {
                                     variant='link'
                                     component='a'
                                     href={
-                                      pathname + '/' + TEMPLATES_ROUTE + `/${template.uuid}/edit`
+                                      pathname + '/' + TEMPLATES_ROUTE + `/${template.uuid}/edit?tab=custom_repositories`
                                     }
                                     target='_blank'
                                   >

--- a/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.test.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.test.tsx
@@ -32,6 +32,7 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 jest.mock('react-router-dom', () => ({
   useNavigate: jest.fn(),
   useHref: () => 'insights/content/repositories',
+  Outlet: () => <></>,
 }));
 
 it('expect PopularRepositoriesTable to render with add one item', () => {

--- a/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.tsx
@@ -63,8 +63,8 @@ import {
   DropdownToggleAction,
 } from '@patternfly/react-core/deprecated';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
-import { DELETE_ROUTE, REPOSITORIES_ROUTE } from 'Routes/constants';
-import { useHref, useNavigate } from 'react-router-dom';
+import { DELETE_ROUTE } from 'Routes/constants';
+import { Outlet, useNavigate, useOutletContext } from 'react-router-dom';
 
 const useStyles = createUseStyles({
   chipsContainer: {
@@ -127,8 +127,6 @@ const PopularRepositoriesTable = () => {
   const queryClient = useQueryClient();
   const { rbac, features } = useAppContext();
   const navigate = useNavigate();
-  const path = useHref('content');
-  const pathname = path.split('content')[0] + 'content';
   // Uses urls as map key because uuids don't exist on repositories that haven't been created
   const [checkedRepositoriesToAdd, setCheckedRepositoriesToAdd] = useState<
     Map<string, CreateContentRequestItem>
@@ -371,6 +369,14 @@ const PopularRepositoriesTable = () => {
   }, [isInProd, checkedRepositoriesToAdd.size]);
 
   return (
+    <>
+    <Outlet
+        context={{
+          deletionContext: {
+            checkedRepositoriesToDelete,
+          },
+        }}
+      />
     <Grid data-ouia-component-id='popular_repositories_page' className={classes.mainContainer}>
       <Flex className={classes.topContainer}>
         <FlexItem>
@@ -556,7 +562,7 @@ const PopularRepositoriesTable = () => {
             <Thead>
               <Tr>
                 <Hide hide={!rbac?.repoWrite}>
-                  <Th
+                  <Th screenReaderText='empty'
                     className={classes.checkboxMinWidth}
                     select={{
                       onSelect: selectAllRepos,
@@ -621,15 +627,7 @@ const PopularRepositoriesTable = () => {
                           <Button
                             isDisabled={uuid === selectedUUID || isAdding}
                             onClick={() =>
-                              navigate(
-                                pathname +
-                                  '/' +
-                                  REPOSITORIES_ROUTE +
-                                  '/' +
-                                  DELETE_ROUTE +
-                                  '?repoUUID=' +
-                                  uuid,
-                              )
+                              navigate(DELETE_ROUTE + '?repoUUID=' + uuid)
                             }
                             variant='danger'
                             ouiaId='remove_popular_repo'
@@ -681,7 +679,15 @@ const PopularRepositoriesTable = () => {
         />
       </Hide>
     </Grid>
+    </>
   );
 };
+
+export const usePopularListOutletContext = () =>
+    useOutletContext<{
+      deletionContext: {
+        checkedRepositoriesToDelete: Set<string>;
+      };
+    }>();
 
 export default PopularRepositoriesTable;

--- a/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.tsx
@@ -562,7 +562,8 @@ const PopularRepositoriesTable = () => {
             <Thead>
               <Tr>
                 <Hide hide={!rbac?.repoWrite}>
-                  <Th screenReaderText='empty'
+                  <Th
+                    aria-label='popular repositories selection column'
                     className={classes.checkboxMinWidth}
                     select={{
                       onSelect: selectAllRepos,

--- a/src/Routes/Repositories/useRepositoryRoutes.tsx
+++ b/src/Routes/Repositories/useRepositoryRoutes.tsx
@@ -53,6 +53,13 @@ export default function useRepositoryRoutes(): TabbedRouteItem[] {
         title: 'Popular repositories',
         route: POPULAR_REPOSITORIES_ROUTE,
         Element: PopularRepositoriesTable,
+        ChildRoutes: [
+            ...(hasWrite 
+              ? [
+                  { path: DELETE_ROUTE, Element: DeleteContentModal },
+                ]
+              : []),
+        ]
       },
       ...(features?.admintasks?.enabled && features.admintasks?.accessible
         ? [

--- a/src/Routes/Repositories/useRepositoryRoutes.tsx
+++ b/src/Routes/Repositories/useRepositoryRoutes.tsx
@@ -53,13 +53,12 @@ export default function useRepositoryRoutes(): TabbedRouteItem[] {
         title: 'Popular repositories',
         route: POPULAR_REPOSITORIES_ROUTE,
         Element: PopularRepositoriesTable,
-        ChildRoutes: [
-            ...(hasWrite 
-              ? [
-                  { path: DELETE_ROUTE, Element: DeleteContentModal },
-                ]
-              : []),
-        ]
+        ChildRoutes: 
+          hasWrite 
+            ? [
+              { path: DELETE_ROUTE, Element: DeleteContentModal },
+            ]
+            : [],
       },
       ...(features?.admintasks?.enabled && features.admintasks?.accessible
         ? [

--- a/src/components/DeleteKebab/DeleteKebab.tsx
+++ b/src/components/DeleteKebab/DeleteKebab.tsx
@@ -41,7 +41,7 @@ const DeleteKebab = ({
       show={!atLeastOneRepoChecked}
       setDisabled
     >
-      <DropdownItem onClick={() => navigate(`${DELETE_ROUTE}`)}>
+      <DropdownItem onClick={() => navigate(DELETE_ROUTE)}>
         {atLeastOneRepoChecked
           ? `Remove ${numberOfReposChecked} repositories`
           : 'Remove selected repositories'}


### PR DESCRIPTION
## Summary

This fixes the routing issues when trying to removing popular repos by adding a delete route specific to popular repos. 

## Testing steps

- When clicking Remove on one popular repository, this should route to the delete modal and show the selected repo. This is currently broken in stage preview and prod preview and returns a 404. Make sure to test this in preview environments (for devs, npm run local > stage > beta or npm run local > prod > beta)
- When trying to delete popular repos by bulk selecting, this should route to the delete modal and show the selected repos
- If a repo has associated templates, clicking on the template should route to the custom repos step in the template modal
- Also fixes the positioning of the expanded content (list of templates) in the delete modal if a repo is associated with more than 3 templates