### PR TITLE
Fixes 4223: Ensure modals do not cause redirect on close

### DIFF
--- a/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
@@ -229,9 +229,9 @@ const ContentListTable = () => {
 
   const triggerIntrospectionAndSnapshot = async (repoUuid: string): Promise<void> => {
     clearCheckedRepositories();
-    await introspectRepoForUuid(repoUuid)
+    await introspectRepoForUuid(repoUuid);
     await triggerSnapshot(repoUuid);
-  }
+  };
 
   // Other update actions will be added to this later.
   const actionTakingPlace =
@@ -319,13 +319,8 @@ const ContentListTable = () => {
             ...(features?.snapshots?.accessible
               ? [
                   {
-                    isDisabled:
-                      actionTakingPlace ||
-                      !rowData.last_snapshot_uuid,
-                    title:
-                      rowData.last_snapshot_uuid
-                        ? 'View all snapshots'
-                        : 'No snapshots yet',
+                    isDisabled: actionTakingPlace || !rowData.last_snapshot_uuid,
+                    title: rowData.last_snapshot_uuid ? 'View all snapshots' : 'No snapshots yet',
                     onClick: () => {
                       navigate(`${rowData.uuid}/snapshots`);
                     },
@@ -340,7 +335,7 @@ const ContentListTable = () => {
                       actionTakingPlace || rowData?.status === 'Pending' || !rowData.snapshot,
                     title: 'Trigger snapshot',
                     onClick: () => {
-                        triggerIntrospectionAndSnapshot(rowData?.uuid);
+                      triggerIntrospectionAndSnapshot(rowData?.uuid);
                     },
                     tooltipProps: !rowData.snapshot
                       ? {

--- a/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
@@ -58,6 +58,7 @@ import useRootPath from 'Hooks/useRootPath';
 import { useAppContext } from 'middleware/AppContext';
 import CustomHelperText from 'components/CustomHelperText/CustomHelperText';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import { REPOSITORIES_ROUTE } from 'Routes/constants';
 
 const useStyles = createUseStyles({
   description: {
@@ -219,7 +220,7 @@ const AddContent = () => {
     return { distributionArches, distributionVersions };
   }, [distArches, distVersions]);
 
-  const onClose = () => navigate(rootPath);
+  const onClose = () => navigate(`${rootPath}/${REPOSITORIES_ROUTE}`);
 
   const { mutateAsync: addContent, isLoading: isAdding } = useAddContentQuery(
     queryClient,

--- a/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
@@ -29,7 +29,7 @@ import { useContentListOutletContext } from '../../ContentListTable';
 import useRootPath from 'Hooks/useRootPath';
 import { GET_TEMPLATES_KEY, useTemplateList } from 'services/Templates/TemplateQueries';
 import { TemplateFilterData, TemplateItem } from 'services/Templates/TemplateApi';
-import { TEMPLATES_ROUTE } from 'Routes/constants';
+import { REPOSITORIES_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
 import { ContentItem, FilterData } from 'services/Content/ContentApi';
 import { isEmpty } from 'lodash';
 import useDeepCompareEffect from 'Hooks/useDeepCompareEffect';
@@ -89,7 +89,7 @@ export default function DeleteContentModal() {
     sortString,
   );
 
-  const onClose = () => navigate(rootPath);
+  const onClose = () => navigate(`${rootPath}/${REPOSITORIES_ROUTE}`);
   const onSave = async () => {
     deleteItems(reposToDelete).then(() => {
       onClose();

--- a/src/Pages/Repositories/ContentListTable/components/EditContentModal/EditContentModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/EditContentModal/EditContentModal.tsx
@@ -26,6 +26,7 @@ import { isEqual } from 'lodash';
 import { mapToContentItemsToEditContentRequest } from './helpers';
 import { useContentListOutletContext } from '../../ContentListTable';
 import useRootPath from 'Hooks/useRootPath';
+import { REPOSITORIES_ROUTE } from 'Routes/constants';
 
 const useStyles = createUseStyles({
   description: {
@@ -57,7 +58,7 @@ const EditContentModal = () => {
     updatedValues,
   );
 
-  const onClose = () => navigate(rootPath);
+  const onClose = () => navigate(`${rootPath}/${REPOSITORIES_ROUTE}`);
   const onSave = async () =>
     editContent().then(() => {
       onClose();

--- a/src/Pages/Repositories/ContentListTable/components/PackageModal/PackageModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/PackageModal/PackageModal.tsx
@@ -25,6 +25,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import useRootPath from 'Hooks/useRootPath';
 import { useAppContext } from 'middleware/AppContext';
 import PackagesTable from 'components/SharedTables/PackagesTable';
+import { REPOSITORIES_ROUTE } from 'Routes/constants';
 
 const useStyles = createUseStyles({
   description: {
@@ -91,7 +92,10 @@ export default function PackageModal() {
   };
 
   const onClose = () =>
-    navigate(rootPath + (contentOrigin === ContentOrigin.REDHAT ? `?origin=${contentOrigin}` : ''));
+    navigate(
+      `${rootPath}/${REPOSITORIES_ROUTE}` +
+        (contentOrigin === ContentOrigin.REDHAT ? `?origin=${contentOrigin}` : ''),
+    );
 
   const {
     data: packagesList = [],

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.tsx
@@ -60,7 +60,10 @@ export default function SnapshotDetailsModal() {
   };
 
   const onClose = () =>
-    navigate(rootPath + (contentOrigin === ContentOrigin.REDHAT ? `?origin=${contentOrigin}` : ''));
+    navigate(
+      `${rootPath}/${REPOSITORIES_ROUTE}` +
+        (contentOrigin === ContentOrigin.REDHAT ? `?origin=${contentOrigin}` : ''),
+    );
 
   const onBackClick = () => navigate(rootPath + `/${REPOSITORIES_ROUTE}/${repoUUID}/snapshots`);
 

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
@@ -136,7 +136,10 @@ export default function SnapshotListModal() {
   };
 
   const onClose = () =>
-    navigate(rootPath + (contentOrigin === ContentOrigin.REDHAT ? `?origin=${contentOrigin}` : ''));
+    navigate(
+      `${rootPath}/${REPOSITORIES_ROUTE}` +
+        (contentOrigin === ContentOrigin.REDHAT ? `?origin=${contentOrigin}` : ''),
+    );
 
   const {
     data: snapshotsList = [],

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/AddTemplate.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/AddTemplate.tsx
@@ -61,7 +61,7 @@ const AddTemplateBase = () => {
   }, []);
 
   const { queryClient } = useAddTemplateContext();
-  const onClose = () => navigate(rootPath + '/' + TEMPLATES_ROUTE);
+  const onClose = () => navigate(`${rootPath}/${TEMPLATES_ROUTE}`);
 
   const { mutateAsync: addTemplate, isLoading: isAdding } = useCreateTemplateQuery(queryClient, {
     ...(templateRequest as TemplateRequest),


### PR DESCRIPTION
## Summary

- Fixes an issue where modals were redirecting on close, causing a rerender of the root node > clearing filters and component state.

## Testing steps

- Set a filter on the repositories page, open and close any modal, the filter should remain.
