### PR TITLE
Fixes 4524: Fix menu routing for popular repos

### DIFF
--- a/src/Pages/Repositories/AdminTaskTable/components/ViewPayloadModal/ViewPayloadModal.tsx
+++ b/src/Pages/Repositories/AdminTaskTable/components/ViewPayloadModal/ViewPayloadModal.tsx
@@ -17,7 +17,7 @@ import Hide from 'components/Hide/Hide';
 import { useFetchAdminTaskQuery } from 'services/AdminTasks/AdminTaskQueries';
 import { useNavigate, useParams } from 'react-router-dom';
 import useRootPath from 'Hooks/useRootPath';
-import { ADMIN_TASKS_ROUTE } from 'Routes/constants';
+import { ADMIN_TASKS_ROUTE, REPOSITORIES_ROUTE } from 'Routes/constants';
 
 const useStyles = createUseStyles({
   jsonView: {
@@ -37,7 +37,7 @@ const ViewPayloadModal = () => {
   const navigate = useNavigate();
   const rootPath = useRootPath();
 
-  const onClose = () => navigate(`${rootPath}/${ADMIN_TASKS_ROUTE}`);
+  const onClose = () => navigate(`${rootPath}/${REPOSITORIES_ROUTE}/${ADMIN_TASKS_ROUTE}`);
 
   const [activeTabKey, setActiveTabKey] = useState<string | number>(0);
   const detailRef = createRef<HTMLElement>();

--- a/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
@@ -108,7 +108,7 @@ export default function DeleteContentModal() {
 
   const onClose = () =>
     navigate(
-      `${rootPath}/${REPOSITORIES_ROUTE}${checkedPopularRepos ? `/${POPULAR_REPOSITORIES_ROUTE}` : ''}`,
+      `${rootPath}/${REPOSITORIES_ROUTE}${checkedPopularRepos.length ? `/${POPULAR_REPOSITORIES_ROUTE}` : ''}`,
     );
 
   const onSave = async () => {

--- a/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
@@ -31,7 +31,7 @@ import { usePopularListOutletContext } from '../../../PopularRepositoriesTable/P
 import useRootPath from 'Hooks/useRootPath';
 import { GET_TEMPLATES_KEY, useTemplateList } from 'services/Templates/TemplateQueries';
 import { TemplateFilterData, TemplateItem } from 'services/Templates/TemplateApi';
-import { REPOSITORIES_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
+import { POPULAR_REPOSITORIES_ROUTE, REPOSITORIES_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
 import { ContentItem, FilterData } from 'services/Content/ContentApi';
 import { isEmpty } from 'lodash';
 import useDeepCompareEffect from 'Hooks/useDeepCompareEffect';
@@ -106,7 +106,11 @@ export default function DeleteContentModal() {
     sortString,
   );
 
-  const onClose = () => navigate(`${rootPath}/${REPOSITORIES_ROUTE}`);
+  const onClose = () =>
+    navigate(
+      `${rootPath}/${REPOSITORIES_ROUTE}${checkedPopularRepos ? `/${POPULAR_REPOSITORIES_ROUTE}` : ''}`,
+    );
+
   const onSave = async () => {
     deleteItems(reposToDelete).then(() => {
       onClose();

--- a/src/Pages/Repositories/RepositoryLayout.tsx
+++ b/src/Pages/Repositories/RepositoryLayout.tsx
@@ -7,7 +7,12 @@ import { createUseStyles } from 'react-jss';
 import { last } from 'lodash';
 import Header from 'components/Header/Header';
 import RepositoryQuickStart from 'components/QuickStart/RepositoryQuickStart';
-import { TabbedRouteItem } from '../../Routes/constants';
+import {
+  ADMIN_TASKS_ROUTE,
+  POPULAR_REPOSITORIES_ROUTE,
+  REPOSITORIES_ROUTE,
+} from '../../Routes/constants';
+import { useAppContext } from 'middleware/AppContext';
 
 const useStyles = createUseStyles({
   tabs: {
@@ -31,10 +36,32 @@ const useStyles = createUseStyles({
   },
 });
 
-export default function RepositoryLayout({ tabs }: { tabs: TabbedRouteItem[] }) {
+export default function RepositoryLayout() {
   const { pathname } = useLocation();
+  const { features } = useAppContext();
   const classes = useStyles();
   const currentRoute = useMemo(() => last(pathname.split('/')), [pathname]);
+
+  const tabs = useMemo(
+    () => [
+      { title: 'Your repositories', route: '', key: REPOSITORIES_ROUTE },
+      {
+        title: 'Popular repositories',
+        route: POPULAR_REPOSITORIES_ROUTE,
+        key: POPULAR_REPOSITORIES_ROUTE,
+      },
+      ...(features?.admintasks?.enabled && features.admintasks?.accessible
+        ? [
+            {
+              title: 'Admin tasks',
+              route: ADMIN_TASKS_ROUTE,
+              key: ADMIN_TASKS_ROUTE,
+            },
+          ]
+        : []),
+    ],
+    [features],
+  );
 
   return (
     <>
@@ -44,17 +71,17 @@ export default function RepositoryLayout({ tabs }: { tabs: TabbedRouteItem[] }) 
         paragraph='View all repositories within your organization.'
       />
       <Tabs className={classes.tabs} ouiaId='routed-tabs' activeKey={currentRoute}>
-        {tabs.map(({ title, route }) => (
+        {tabs.map(({ title, route, key }) => (
           <Tab
             className={classes.tab}
             keyParams={route}
-            key={route}
+            key={key}
             tabIndex={-1} // This prevents the tab from being targetable by accessibility features.
-            eventKey={route}
+            eventKey={key}
             aria-label={title}
             ouiaId={title}
             title={
-              <Link className={classes.link} accessKey={route} key={route} to={route}>
+              <Link className={classes.link} accessKey={key} key={key} to={route}>
                 <TabTitleText>{title}</TabTitleText>
               </Link>
             }

--- a/src/Routes/constants.ts
+++ b/src/Routes/constants.ts
@@ -1,8 +1,9 @@
 export const REPOSITORIES_ROUTE = 'repositories';
-export const POPULAR_REPOSITORIES_ROUTE = 'popular-repositories';
+export const POPULAR_REPOSITORIES_ROUTE = 'popular';
 export const ADMIN_TASKS_ROUTE = 'admin-tasks';
 export const TEMPLATES_ROUTE = 'templates';
 export const CONTENT_ROUTE = 'content';
+export const SNAPSHOTS_ROUTE = 'snapshots';
 export const SYSTEMS_ROUTE = 'systems';
 export const DETAILS_ROUTE = 'details';
 export const PACKAGES_ROUTE = 'packages';

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -4,15 +4,17 @@ import { useMemo } from 'react';
 import { ErrorPage } from 'components/Error/ErrorPage';
 import RepositoryLayout from '../Pages/Repositories/RepositoryLayout';
 import { ZeroState } from 'components/ZeroState/ZeroState';
-import useRepositoryRoutes from './Repositories/useRepositoryRoutes';
 import {
   ADD_ROUTE,
   ADVISORIES_ROUTE,
   CONTENT_ROUTE,
+  DELETE_ROUTE,
   DETAILS_ROUTE,
   EDIT_ROUTE,
   PACKAGES_ROUTE,
+  POPULAR_REPOSITORIES_ROUTE,
   REPOSITORIES_ROUTE,
+  SNAPSHOTS_ROUTE,
   SYSTEMS_ROUTE,
   TEMPLATES_ROUTE,
 } from './constants';
@@ -25,25 +27,62 @@ import AddSystemModal from 'Pages/Templates/TemplateDetails/components/AddSystem
 import TemplateErrataTab from 'Pages/Templates/TemplateDetails/components/Tabs/TemplateErrataTab';
 import TemplateSystemsTab from 'Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab';
 import TemplatePackageTab from 'Pages/Templates/TemplateDetails/components/Tabs/TemplatePackageTab';
+import ContentListTable from 'Pages/Repositories/ContentListTable/ContentListTable';
+import EditContentModal from 'Pages/Repositories/ContentListTable/components/EditContentModal/EditContentModal';
+import AddContent from 'Pages/Repositories/ContentListTable/components/AddContent/AddContent';
+import DeleteContentModal from 'Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal';
+import SnapshotListModal from 'Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal';
+import SnapshotDetailsModal from 'Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal';
+import PackageModal from 'Pages/Repositories/ContentListTable/components/PackageModal/PackageModal';
+import PopularRepositoriesTable from 'Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable';
 
 export default function RepositoriesRoutes() {
   const key = useMemo(() => Math.random(), []);
-  const repositoryRoutes = useRepositoryRoutes();
-  const { zeroState, rbac } = useAppContext();
-
+  const { zeroState, features, rbac } = useAppContext();
   return (
     <ErrorPage>
       <Routes key={key}>
         {zeroState ? <Route path={REPOSITORIES_ROUTE} element={<ZeroState />} /> : <></>}
-        <Route element={<RepositoryLayout tabs={repositoryRoutes} />}>
-          {repositoryRoutes.map(({ route, Element, ChildRoutes }, key) => (
-            <Route key={key.toString()} path={route} element={<Element />}>
-              {ChildRoutes?.map(({ path, Element: ChildRouteElement }, childRouteKey) => (
-                <Route key={childRouteKey} path={path} element={<ChildRouteElement />} />
-              ))}
-            </Route>
-          ))}
-          <Route path='*' element={<Navigate to={REPOSITORIES_ROUTE} replace />} />
+        <Route path={REPOSITORIES_ROUTE} element={<RepositoryLayout />}>
+          <Route path='' element={<ContentListTable />}>
+            {rbac?.repoWrite ? (
+              <>
+                <Route key={EDIT_ROUTE} path={EDIT_ROUTE} element={<EditContentModal />} />
+                <Route key={ADD_ROUTE} path={ADD_ROUTE} element={<AddContent />} />
+                <Route key={DELETE_ROUTE} path={DELETE_ROUTE} element={<DeleteContentModal />} />
+              </>
+            ) : (
+              ''
+            )}
+            {features?.snapshots?.enabled && features.snapshots?.accessible ? (
+              <>
+                <Route
+                  key={`:repoUUID/${SNAPSHOTS_ROUTE}`}
+                  path={`:repoUUID/${SNAPSHOTS_ROUTE}`}
+                  element={<SnapshotListModal />}
+                />
+                <Route
+                  key={`:repoUUID/${SNAPSHOTS_ROUTE}/:snapshotUUID`}
+                  path={`:repoUUID/${SNAPSHOTS_ROUTE}/:snapshotUUID`}
+                  element={<SnapshotDetailsModal />}
+                />
+              </>
+            ) : (
+              ''
+            )}
+            <Route
+              key={`:repoUUID/${PACKAGES_ROUTE}`}
+              path={`:repoUUID/${PACKAGES_ROUTE}`}
+              element={<PackageModal />}
+            />
+          </Route>
+          <Route path={POPULAR_REPOSITORIES_ROUTE} element={<PopularRepositoriesTable />}>
+            {rbac?.repoWrite ? (
+              <Route key={DELETE_ROUTE} path={DELETE_ROUTE} element={<DeleteContentModal />} />
+            ) : (
+              ''
+            )}
+          </Route>
         </Route>
         {!rbac?.templateRead ? (
           <Route path={TEMPLATES_ROUTE} element={<NoPermissionsPage />} />
@@ -67,14 +106,17 @@ export default function RepositoriesRoutes() {
           <Route path='*' element={<Navigate to={TEMPLATES_ROUTE} replace />} />
         </Route>
         <Route path={TEMPLATES_ROUTE} element={<TemplatesTable />}>
-          {...rbac?.templateWrite
-            ? [
-                <Route key='1' path={ADD_ROUTE} element={<AddTemplate />} />,
-                <Route key='2' path={`:templateUUID/${EDIT_ROUTE}`} element={<AddTemplate />} />,
-              ]
-            : []}
+          {rbac?.templateWrite ? (
+            <>
+              <Route key='1' path={ADD_ROUTE} element={<AddTemplate />} />
+              <Route key='2' path={`:templateUUID/${EDIT_ROUTE}`} element={<AddTemplate />} />
+            </>
+          ) : (
+            ''
+          )}
           <Route path='*' element={<Navigate to='' replace />} />
         </Route>
+        <Route path='*' element={<Navigate to={REPOSITORIES_ROUTE} replace />} />
       </Routes>
     </ErrorPage>
   );

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -6,6 +6,7 @@ import RepositoryLayout from '../Pages/Repositories/RepositoryLayout';
 import { ZeroState } from 'components/ZeroState/ZeroState';
 import {
   ADD_ROUTE,
+  ADMIN_TASKS_ROUTE,
   ADVISORIES_ROUTE,
   CONTENT_ROUTE,
   DELETE_ROUTE,
@@ -35,6 +36,8 @@ import SnapshotListModal from 'Pages/Repositories/ContentListTable/components/Sn
 import SnapshotDetailsModal from 'Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal';
 import PackageModal from 'Pages/Repositories/ContentListTable/components/PackageModal/PackageModal';
 import PopularRepositoriesTable from 'Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable';
+import AdminTaskTable from 'Pages/Repositories/AdminTaskTable/AdminTaskTable';
+import ViewPayloadModal from 'Pages/Repositories/AdminTaskTable/components/ViewPayloadModal/ViewPayloadModal';
 
 export default function RepositoriesRoutes() {
   const key = useMemo(() => Math.random(), []);
@@ -83,6 +86,13 @@ export default function RepositoriesRoutes() {
               ''
             )}
           </Route>
+          {features?.admintasks?.enabled && features.admintasks?.accessible ? (
+            <Route path={ADMIN_TASKS_ROUTE} element={<AdminTaskTable />}>
+              <Route key=':taskUUID' path=':taskUUID' element={<ViewPayloadModal />} />
+            </Route>
+          ) : (
+            ''
+          )}
         </Route>
         {!rbac?.templateRead ? (
           <Route path={TEMPLATES_ROUTE} element={<NoPermissionsPage />} />


### PR DESCRIPTION
## Summary

- Rewrote the routing for the repositories app, will hopefully be much easier for others to work on/add to.

- Changed "content/popular-repositories" to "content/repositories/popular".

## Testing steps

- Ensure all routing still works as expected for the repositories app. 
- Make sure all redirects are working as expected (/content/asdf or /content/repositories/asdf, etc..)
