### PR TITLE
Refs 4297: fix zero date format, add UTC tooltip

### DIFF
--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateErrataTab.test.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateErrataTab.test.tsx
@@ -13,7 +13,11 @@ jest.mock('react-router-dom', () => ({
   Outlet: () => <></>,
 }));
 
-jest.mock('dayjs', () => (value) => ({ fromNow: () => value, format: () => value, isBefore: () => value }));
+jest.mock('dayjs', () => (value) => ({
+  fromNow: () => value,
+  format: () => value,
+  isBefore: () => value,
+}));
 
 jest.mock('Hooks/useRootPath', () => () => 'someUrl');
 

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateErrataTab.test.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateErrataTab.test.tsx
@@ -13,7 +13,7 @@ jest.mock('react-router-dom', () => ({
   Outlet: () => <></>,
 }));
 
-jest.mock('dayjs', () => (value) => ({ fromNow: () => value, format: () => value }));
+jest.mock('dayjs', () => (value) => ({ fromNow: () => value, format: () => value, isBefore: () => value }));
 
 jest.mock('Hooks/useRootPath', () => () => 'someUrl');
 

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -7,6 +7,7 @@ import {
   Pagination,
   PaginationVariant,
   Spinner,
+  Tooltip,
 } from '@patternfly/react-core';
 import {
   ActionsColumn,
@@ -32,7 +33,7 @@ import { useDeleteTemplateItemMutate, useTemplateList } from 'services/Templates
 import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip';
 import { useAppContext } from 'middleware/AppContext';
 import TemplateFilters from './components/TemplateFilters';
-import { formatDateDDMMMYYYY } from 'helpers';
+import {formatDateDDMMMYYYY, formatDateUTC} from 'helpers';
 import { useQueryClient } from 'react-query';
 import Header from 'components/Header/Header';
 import useRootPath from 'Hooks/useRootPath';
@@ -286,7 +287,11 @@ const TemplatesTable = () => {
                       <Td>{description}</Td>
                       <Td>{archesDisplay(arch)}</Td>
                       <Td>{versionDisplay(version)}</Td>
-                      <Td>{use_latest ? 'Use latest' : formatDateDDMMMYYYY(date)}</Td>
+                      <Td>
+                        <Tooltip content={formatDateUTC(date)} position='top-start' enableFlip>
+                          <p>{use_latest ? 'Use latest' : formatDateDDMMMYYYY(date)}</p>
+                        </Tooltip>
+                      </Td>
                       <Td>
                         <ConditionalTooltip
                           content='You do not have the required permissions to perform this action.'

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -7,7 +7,6 @@ import {
   Pagination,
   PaginationVariant,
   Spinner,
-  Tooltip,
 } from '@patternfly/react-core';
 import {
   ActionsColumn,
@@ -33,7 +32,7 @@ import { useDeleteTemplateItemMutate, useTemplateList } from 'services/Templates
 import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip';
 import { useAppContext } from 'middleware/AppContext';
 import TemplateFilters from './components/TemplateFilters';
-import {formatDateDDMMMYYYY, formatDateUTC} from 'helpers';
+import { formatDateDDMMMYYYY, formatDateUTC } from 'helpers';
 import { useQueryClient } from 'react-query';
 import Header from 'components/Header/Header';
 import useRootPath from 'Hooks/useRootPath';
@@ -288,9 +287,14 @@ const TemplatesTable = () => {
                       <Td>{archesDisplay(arch)}</Td>
                       <Td>{versionDisplay(version)}</Td>
                       <Td>
-                        <Tooltip content={formatDateUTC(date)} position='top-start' enableFlip>
+                        <ConditionalTooltip
+                          show={!use_latest}
+                          content={formatDateUTC(date)}
+                          position='top-start'
+                          enableFlip
+                        >
                           <p>{use_latest ? 'Use latest' : formatDateDDMMMYYYY(date)}</p>
-                        </Tooltip>
+                        </ConditionalTooltip>
                       </Td>
                       <Td>
                         <ConditionalTooltip

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/AddTemplateContext.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/AddTemplateContext.tsx
@@ -11,7 +11,7 @@ import { TemplateRequest } from 'services/Templates/TemplateApi';
 import { QueryClient, useQueryClient } from 'react-query';
 import { useContentListQuery, useRepositoryParams } from 'services/Content/ContentQueries';
 import { ContentOrigin, NameLabel } from 'services/Content/ContentApi';
-import { formatApiTemplateTime, hardcodeRedHatReposByArchAndVersion } from '../templateHelpers';
+import { hardcodeRedHatReposByArchAndVersion } from '../templateHelpers';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useFetchTemplate } from 'services/Templates/TemplateQueries';
 import useRootPath from 'Hooks/useRootPath';
@@ -124,7 +124,6 @@ export const AddTemplateContextProvider = ({ children }: { children: ReactNode }
     if (uuid && !!editTemplateData && !isLoading && !!existingRepositoryInformation) {
       const startingState = {
         ...editTemplateData,
-        date: formatApiTemplateTime(editTemplateData.date),
       };
 
       setTemplateRequest(startingState);

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.test.tsx
@@ -20,11 +20,11 @@ jest.mock('react-router-dom', () => ({
 }));
 
 // dayJs is an absolute pain, just mock it.
-jest.mock('dayjs', () =>
-  jest.fn(() => ({
-    fromNow: () => '2024-01-22',
-  })),
-);
+jest.mock('dayjs', () => () => ({
+  fromNow: () => '2024-01-22',
+  format: () => '2024-01-22',
+  isBefore: () => false,
+}));
 
 it('expect Set snapshot date step to render dates', () => {
   (useGetSnapshotsByDates as jest.Mock).mockImplementation(() => ({

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
@@ -24,7 +24,7 @@ import { ContentItem, ContentOrigin } from 'services/Content/ContentApi';
 import { SkeletonTable } from '@patternfly/react-component-groups';
 import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip';
-import { reduceStringToCharsWithEllipsis } from 'helpers';
+import { formatDateForPicker, reduceStringToCharsWithEllipsis } from 'helpers';
 import UrlWithExternalIcon from 'components/UrlWithLinkIcon/UrlWithLinkIcon';
 import PackageCount from 'Pages/Repositories/ContentListTable/components/PackageCount';
 import { REPOSITORIES_ROUTE } from 'Routes/constants';
@@ -152,7 +152,7 @@ export default function SetUpDateStep() {
         </GridItem>
         <FormGroup label='Include repository changes up to this date' required>
           <DatePicker
-            value={templateRequest.date || ''}
+            value={formatDateForPicker(templateRequest.date)}
             required
             requiredDateOptions={{ isRequired: true }}
             validators={dateValidators}

--- a/src/Pages/Templates/TemplatesTable/components/templateHelpers.test.ts
+++ b/src/Pages/Templates/TemplatesTable/components/templateHelpers.test.ts
@@ -1,4 +1,4 @@
-import { formatApiTemplateTime, hardcodeRedHatReposByArchAndVersion } from './templateHelpers';
+import { hardcodeRedHatReposByArchAndVersion } from './templateHelpers';
 
 it('Test hardcodeRedHatReposByArchAndVersion', () => {
   let result = hardcodeRedHatReposByArchAndVersion('x86_64', '8') as string[];
@@ -11,10 +11,4 @@ it('Test hardcodeRedHatReposByArchAndVersion', () => {
 
   result = hardcodeRedHatReposByArchAndVersion('stuff', '12') as string[];
   expect(result).toBeUndefined();
-});
-
-it('formatApiTemplateTime', () => {
-  const result = formatApiTemplateTime('2021-22-01T-things-weDontWantzzzzz');
-  expect(result).toHaveLength(10);
-  expect(result).toEqual('2021-22-01');
 });

--- a/src/Pages/Templates/TemplatesTable/components/templateHelpers.ts
+++ b/src/Pages/Templates/TemplatesTable/components/templateHelpers.ts
@@ -36,5 +36,3 @@ export const TemplateValidationSchema = Yup.object().shape({
   name: Yup.string().max(255, 'Too Long!').required('Required'),
   description: Yup.string().max(255, 'Too Long!'),
 });
-
-export const formatApiTemplateTime = (time: string) => time.split('T')[0];

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -14,11 +14,28 @@ export const objectToUrlParams = (obj: { [key: string]: string | undefined }): s
   return items;
 };
 
-export const formatDateDDMMMYYYY = (date: string, withTime?: boolean): string =>
-  dayjs(date).format(`DD MMM YYYY${withTime ? ' - HH:mm:ss' : ''}`);
+export const formatDateDDMMMYYYY = (date: string, withTime?: boolean): string => {
+  const d = dayjs(date)
+  if (d.isBefore(dayjs('0001-01-02'))) {
+    return `01 Jan 0001${withTime ? ' - 00:00:00' : ''}`
+  }
+
+  return d.format(`DD MMM YYYY${withTime ? ' - HH:mm:ss' : ''}`);
+}
 
 export const formatTemplateDate = (date: string): string =>
   dayjs(date).format('YYYY-MM-DDTHH:mm:ssZ');
+
+export const formatDateUTC = (date: string): string => {
+  const d = dayjs(date)
+  if (d.isBefore(dayjs('0001-01-02'))) {
+    return '01 Jan 0001 - 00:00:00 (UTC)'
+  }
+
+  const offset = d.utcOffset()
+  const utc = d.subtract(offset, 'minutes');
+  return utc.format('DD MMM YYYY - HH:mm:ss [(UTC)]');
+}
 
 export const reduceStringToCharsWithEllipsis = (str: string, maxLength: number = 50) =>
   str.length > maxLength ? str.split('').slice(0, maxLength).join('') + '...' : str;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -26,6 +26,19 @@ export const formatDateDDMMMYYYY = (date: string, withTime?: boolean): string =>
 export const formatTemplateDate = (date: string): string =>
   dayjs(date).format('YYYY-MM-DDTHH:mm:ssZ');
 
+export const formatDateForPicker = (date: string | null | undefined): string => {
+  if (typeof date !== 'string') {
+    return '';
+  }
+
+  const d = dayjs(date);
+  if (d.isBefore(dayjs('0001-01-02'))) {
+    return '0001-01-01';
+  }
+
+  return d.format('YYYY-MM-DD');
+};
+
 export const formatDateUTC = (date: string): string => {
   const d = dayjs(date);
   if (d.isBefore(dayjs('0001-01-02'))) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -27,7 +27,7 @@ export const formatTemplateDate = (date: string): string =>
   dayjs(date).format('YYYY-MM-DDTHH:mm:ssZ');
 
 export const formatDateForPicker = (date: string | null | undefined): string => {
-  if (typeof date !== 'string') {
+  if (typeof date !== 'string' || date === '') {
     return '';
   }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -15,27 +15,27 @@ export const objectToUrlParams = (obj: { [key: string]: string | undefined }): s
 };
 
 export const formatDateDDMMMYYYY = (date: string, withTime?: boolean): string => {
-  const d = dayjs(date)
+  const d = dayjs(date);
   if (d.isBefore(dayjs('0001-01-02'))) {
-    return `01 Jan 0001${withTime ? ' - 00:00:00' : ''}`
+    return `01 Jan 0001${withTime ? ' - 00:00:00' : ''}`;
   }
 
   return d.format(`DD MMM YYYY${withTime ? ' - HH:mm:ss' : ''}`);
-}
+};
 
 export const formatTemplateDate = (date: string): string =>
   dayjs(date).format('YYYY-MM-DDTHH:mm:ssZ');
 
 export const formatDateUTC = (date: string): string => {
-  const d = dayjs(date)
+  const d = dayjs(date);
   if (d.isBefore(dayjs('0001-01-02'))) {
-    return '01 Jan 0001 - 00:00:00 (UTC)'
+    return '01 Jan 0001 - 00:00:00 (UTC)';
   }
 
-  const offset = d.utcOffset()
+  const offset = d.utcOffset();
   const utc = d.subtract(offset, 'minutes');
   return utc.format('DD MMM YYYY - HH:mm:ss [(UTC)]');
-}
+};
 
 export const reduceStringToCharsWithEllipsis = (str: string, maxLength: number = 50) =>
   str.length > maxLength ? str.split('').slice(0, maxLength).join('') + '...' : str;


### PR DESCRIPTION
## Summary
This PR fixes the zero date format issues in the `TemplateTable` found [here](https://issues.redhat.com/browse/HMS-4297). Also adds a tooltip displaying the snapshot date in the UTC format (not converted to local, which the date in the table is) as @swadeley suggested.
Also has a [sibling back-end PR](https://github.com/content-services/content-sources-backend/pull/785) which makes the template API output all dates as UTC.

![image](https://github.com/user-attachments/assets/618cf98a-17ea-4698-9879-02c5e6ed949a)

## Testing steps
Create a template with the zeroed date and `use_latest=false`.
```bash
http :8000/api/content-sources/v1.0/templates/ "$( ./scripts/header.sh 18064594 1111)" arch='x86_64' version='9' repository_uuids:='[]' name='test zero' use_latest:=false
```
Verify the date in the table is displayed correctly as `01 Jan 0001` and doesn't change even when changing timezones of the system.