### PR TITLE
Fixes 4526: added subscription check in templates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import { REPOSITORIES_ROUTE } from './Routes/constants';
 import usePageSafe from 'Hooks/usePageSafe';
 
 export default function App() {
-  const { rbac, isFetchingFeatures, zeroState, setZeroState } = useAppContext();
+  const { rbac, isFetchingPermissions, zeroState, setZeroState } = useAppContext();
   const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
   const { pathname } = useLocation();
   const pageSafe = usePageSafe();
@@ -50,7 +50,7 @@ export default function App() {
     }
   }, [data.data.length]);
 
-  if (!rbac || isFetchingFeatures || isLoading) {
+  if (!rbac || isFetchingPermissions || isLoading) {
     return (
       <Bullseye>
         <div data-ouia-safe={false} />

--- a/src/Hooks/useIsEphemeralEnv.tsx
+++ b/src/Hooks/useIsEphemeralEnv.tsx
@@ -1,0 +1,6 @@
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+
+export default function useIsEphemeralEnv(): boolean {
+  const { getEnvironment } = useChrome();
+  return getEnvironment() === 'qa';
+}

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.test.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.test.tsx
@@ -26,7 +26,10 @@ jest.mock('services/Systems/SystemsQueries', () => ({
 
 jest.mock('middleware/AppContext');
 
-(useAppContext as jest.Mock).mockImplementation(() => ({ rbac: { templateWrite: true } }));
+(useAppContext as jest.Mock).mockImplementation(() => ({
+  rbac: { templateWrite: true },
+  subscriptions: { red_hat_enterprise_linux: true },
+}));
 
 (useListSystemsByTemplateId as jest.Mock).mockImplementation(() => ({
   isLoading: false,

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.tsx
@@ -69,7 +69,7 @@ export default function TemplateSystemsTab() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { templateUUID: uuid } = useParams();
-  const { rbac } = useAppContext();
+  const { rbac, subscriptions } = useAppContext();
 
   const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
   const [page, setPage] = useState(1);
@@ -183,6 +183,11 @@ export default function TemplateSystemsTab() {
         }
       : undefined;
 
+  const hasRHELSubscription = !!subscriptions?.red_hat_enterprise_linux;
+  const isMissingRequirements = !rbac?.templateWrite || !hasRHELSubscription;
+  const missingRequirements =
+    rbac?.templateWrite && !hasRHELSubscription ? 'subscription (RHEL)' : 'permission';
+
   if (isLoading) {
     return <Loader />;
   }
@@ -209,8 +214,8 @@ export default function TemplateSystemsTab() {
           </InputGroupItem>
           <FlexItem className={classes.ctions}>
             <ConditionalTooltip
-              content='You do not have the required permissions to perform this action.'
-              show={!rbac?.templateWrite}
+              content={`You do not have the required ${missingRequirements} to perform this action.`}
+              show={isMissingRequirements}
               setDisabled
             >
               <Button
@@ -225,8 +230,8 @@ export default function TemplateSystemsTab() {
             </ConditionalTooltip>
           </FlexItem>
           <ConditionalTooltip
-            content='You do not have the required permissions to perform this action.'
-            show={!rbac?.templateWrite}
+            content={`You do not have the required ${missingRequirements} to perform this action.`}
+            show={isMissingRequirements}
             setDisabled
           >
             <SystemsDeleteKebab
@@ -257,8 +262,8 @@ export default function TemplateSystemsTab() {
             notFilteredBody='To get started, add this template to a system.'
             notFilteredButton={
               <ConditionalTooltip
-                content='You do not have the required permissions to perform this action.'
-                show={!rbac?.templateWrite}
+                content={`You do not have the required ${missingRequirements} to perform this action.`}
+                show={isMissingRequirements}
                 setDisabled
               >
                 <Button
@@ -286,7 +291,7 @@ export default function TemplateSystemsTab() {
           systemsList={systemsList}
           sortParams={sortParams}
           selected={selectedList}
-          editAllowed={!!rbac?.templateWrite}
+          editAllowed={!isMissingRequirements}
           setSelected={(id) => handleSelectItem(id)}
         />
       </Hide>

--- a/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.test.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.test.tsx
@@ -14,7 +14,10 @@ jest.mock('services/Templates/TemplateQueries', () => ({
 }));
 
 jest.mock('middleware/AppContext', () => ({
-  useAppContext: () => ({ rbac: { templateWrite: true }, subscriptions: { RedHatEnterpriseLinux: true } }),
+  useAppContext: () => ({
+    rbac: { templateWrite: true },
+    subscriptions: { red_hat_enterprise_linux: true },
+  }),
 }));
 
 it('expect TemplateActionDropdown to render all buttons', async () => {

--- a/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.test.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.test.tsx
@@ -14,7 +14,7 @@ jest.mock('services/Templates/TemplateQueries', () => ({
 }));
 
 jest.mock('middleware/AppContext', () => ({
-  useAppContext: () => ({ rbac: { templateWrite: true } }),
+  useAppContext: () => ({ rbac: { templateWrite: true }, subscriptions: { RedHatEnterpriseLinux: true } }),
 }));
 
 it('expect TemplateActionDropdown to render all buttons', async () => {

--- a/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.tsx
@@ -40,7 +40,7 @@ export default function TemplateActionDropdown() {
     }
   };
 
-  const hasRHELSubscription = subscriptions?.RedHatEnterpriseLinux || false;
+  const hasRHELSubscription = subscriptions?.red_hat_enterprise_linux || false;
   const isMissingRequirements = !rbac?.templateWrite || !hasRHELSubscription;
   const missingRequirements: string = !rbac?.templateWrite
     ? 'permission'

--- a/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.tsx
@@ -40,13 +40,10 @@ export default function TemplateActionDropdown() {
     }
   };
 
-  const hasRHELSubscription = subscriptions?.red_hat_enterprise_linux || false;
+  const hasRHELSubscription = !!subscriptions?.red_hat_enterprise_linux;
   const isMissingRequirements = !rbac?.templateWrite || !hasRHELSubscription;
-  const missingRequirements: string = !rbac?.templateWrite
-    ? 'permission'
-    : !hasRHELSubscription
-      ? 'subscription (RHEL)'
-      : 'permission';
+  const missingRequirements =
+    rbac?.templateWrite && !hasRHELSubscription ? 'subscription (RHEL)' : 'permission';
 
   return (
     <Dropdown

--- a/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.tsx
@@ -18,7 +18,7 @@ export default function TemplateActionDropdown() {
   const baseRoute = mainRoute + `${TEMPLATES_ROUTE}`;
   const navigate = useNavigate();
   const { templateUUID: uuid } = useParams();
-  const { rbac } = useAppContext();
+  const { rbac, subscriptions } = useAppContext();
 
   const onToggleClick = () => {
     setIsOpen(!isOpen);
@@ -40,6 +40,14 @@ export default function TemplateActionDropdown() {
     }
   };
 
+  const hasRHELSubscription = subscriptions?.RedHatEnterpriseLinux || false;
+  const isMissingRequirements = !rbac?.templateWrite || !hasRHELSubscription;
+  const missingRequirements: string = !rbac?.templateWrite
+    ? 'permission'
+    : !hasRHELSubscription
+      ? 'subscription (RHEL)'
+      : 'permission';
+
   return (
     <Dropdown
       isOpen={isOpen}
@@ -47,8 +55,8 @@ export default function TemplateActionDropdown() {
       onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
         <ConditionalTooltip
-          content='You do not have the required permissions to perform this action.'
-          show={!rbac?.templateWrite}
+          content={`You do not have the required ${missingRequirements} to perform this action.`}
+          show={isMissingRequirements}
           setDisabled
         >
           <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>

--- a/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.tsx
@@ -5,13 +5,23 @@ import {
   DropdownList,
   MenuToggle,
   MenuToggleElement,
+  TooltipPosition,
 } from '@patternfly/react-core';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { DELETE_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
 import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip';
 import { useAppContext } from 'middleware/AppContext';
+import { createUseStyles } from 'react-jss';
+
+const useStyles = createUseStyles({
+  disabledButton: {
+    pointerEvents: 'auto',
+    cursor: 'default',
+  },
+});
 
 export default function TemplateActionDropdown() {
+  const classes = useStyles();
   const [isOpen, setIsOpen] = React.useState(false);
   const { pathname } = useLocation();
   const [mainRoute] = pathname?.split(`${TEMPLATES_ROUTE}/`) || [];
@@ -52,8 +62,8 @@ export default function TemplateActionDropdown() {
       onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
         <ConditionalTooltip
-          content={`You do not have the required ${missingRequirements} to perform this action.`}
-          show={isMissingRequirements}
+          content='You do not have the required permission to perform this action.'
+          show={!rbac?.templateWrite}
           setDisabled
         >
           <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
@@ -64,7 +74,22 @@ export default function TemplateActionDropdown() {
       ouiaId='template_actions'
     >
       <DropdownList>
-        <DropdownItem value='edit'>Edit</DropdownItem>
+        <DropdownItem
+          className={isMissingRequirements ? classes.disabledButton : ''}
+          value='edit'
+          isDisabled={isMissingRequirements}
+          tooltipProps={
+            isMissingRequirements
+              ? {
+                  isVisible: isMissingRequirements,
+                  content: `You do not have the required ${missingRequirements} to perform this action.`,
+                  position: TooltipPosition.left,
+                }
+              : undefined
+          }
+        >
+          Edit
+        </DropdownItem>
         <DropdownItem value='delete'>Delete</DropdownItem>
       </DropdownList>
     </Dropdown>

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -75,7 +75,7 @@ const TemplatesTable = () => {
   const classes = useStyles();
   const rootPath = useRootPath();
   const navigate = useNavigate();
-  const { rbac, subscriptions, isFetchingSubscriptions } = useAppContext();
+  const { rbac, subscriptions } = useAppContext();
   const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(storedPerPage);
@@ -165,13 +165,10 @@ const TemplatesTable = () => {
 
   const countIsZero = count === 0;
 
-  const hasRHELSubscription = subscriptions?.red_hat_enterprise_linux || false;
+  const hasRHELSubscription = !!subscriptions?.red_hat_enterprise_linux;
   const isMissingRequirements = !rbac?.templateWrite || !hasRHELSubscription;
-  const missingRequirements: string = !rbac?.templateWrite
-    ? 'permission'
-    : !hasRHELSubscription
-      ? 'subscription (RHEL)'
-      : 'permission';
+  const missingRequirements =
+    rbac?.templateWrite && !hasRHELSubscription ? 'subscription (RHEL)' : 'permission';
 
   if (countIsZero && notFiltered && !isLoading)
     return (

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -75,7 +75,7 @@ const TemplatesTable = () => {
   const classes = useStyles();
   const rootPath = useRootPath();
   const navigate = useNavigate();
-  const { rbac } = useAppContext();
+  const { rbac, subscriptions, isFetchingSubscriptions } = useAppContext();
   const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(storedPerPage);
@@ -165,6 +165,14 @@ const TemplatesTable = () => {
 
   const countIsZero = count === 0;
 
+  const hasRHELSubscription = subscriptions?.RedHatEnterpriseLinux || false;
+  const isMissingRequirements = !rbac?.templateWrite || !hasRHELSubscription;
+  const missingRequirements: string = !rbac?.templateWrite
+    ? 'permission'
+    : !hasRHELSubscription
+      ? 'subscription (RHEL)'
+      : 'permission';
+
   if (countIsZero && notFiltered && !isLoading)
     return (
       <Bullseye data-ouia-component-id='content_template_list_page'>
@@ -175,8 +183,8 @@ const TemplatesTable = () => {
           notFilteredBody={notFilteredBody}
           notFilteredButton={
             <ConditionalTooltip
-              content='You do not have the required permissions to perform this action.'
-              show={!rbac?.templateWrite}
+              content={`You do not have the required ${missingRequirements} to perform this action.`}
+              show={isMissingRequirements}
               setDisabled
             >
               <Button
@@ -293,8 +301,8 @@ const TemplatesTable = () => {
                       </Td>
                       <Td>
                         <ConditionalTooltip
-                          content='You do not have the required permissions to perform this action.'
-                          show={!rbac?.templateWrite}
+                          content={`You do not have the required ${missingRequirements} to perform this action.`}
+                          show={isMissingRequirements}
                           setDisabled
                         >
                           <ActionsColumn
@@ -342,8 +350,8 @@ const TemplatesTable = () => {
             notFilteredBody={notFilteredBody}
             notFilteredButton={
               <ConditionalTooltip
-                content='You do not have the required permissions to perform this action.'
-                show={!rbac?.templateWrite}
+                content={`You do not have the required ${missingRequirements} to perform this action.`}
+                show={isMissingRequirements}
                 setDisabled
               >
                 <Button

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -7,6 +7,7 @@ import {
   Pagination,
   PaginationVariant,
   Spinner,
+  TooltipPosition,
 } from '@patternfly/react-core';
 import {
   ActionsColumn,
@@ -66,6 +67,10 @@ const useStyles = createUseStyles({
   },
   leftPaddingZero: {
     paddingLeft: 0,
+  },
+  disabledButton: {
+    pointerEvents: 'auto',
+    cursor: 'default',
   },
 });
 
@@ -298,15 +303,28 @@ const TemplatesTable = () => {
                       </Td>
                       <Td>
                         <ConditionalTooltip
-                          content={`You do not have the required ${missingRequirements} to perform this action.`}
-                          show={isMissingRequirements}
+                          content='You do not have the required permission to perform this action.'
+                          show={!rbac?.templateWrite}
                           setDisabled
                         >
                           <ActionsColumn
                             items={[
                               {
+                                id: 'actions-column-edit',
+                                className: isMissingRequirements ? classes.disabledButton : '',
                                 title: 'Edit',
                                 onClick: () => navigate(`${uuid}/edit`),
+                                isDisabled: isMissingRequirements,
+                                tooltipProps: isMissingRequirements
+                                  ? {
+                                      isVisible: isMissingRequirements,
+                                      content: `You do not have the required ${missingRequirements} to perform this action.`,
+                                      position: TooltipPosition.left,
+                                      triggerRef: () =>
+                                        document.getElementById('actions-column-edit') ||
+                                        document.body,
+                                    }
+                                  : undefined,
                               },
                               { isSeparator: true },
                               {

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -165,7 +165,7 @@ const TemplatesTable = () => {
 
   const countIsZero = count === 0;
 
-  const hasRHELSubscription = subscriptions?.RedHatEnterpriseLinux || false;
+  const hasRHELSubscription = subscriptions?.red_hat_enterprise_linux || false;
   const isMissingRequirements = !rbac?.templateWrite || !hasRHELSubscription;
   const missingRequirements: string = !rbac?.templateWrite
     ? 'permission'

--- a/src/Pages/Templates/TemplatesTable/components/TemplateFilters.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/TemplateFilters.tsx
@@ -65,7 +65,7 @@ const Filters = ({ isLoading, setFilterData, filterData }: Props) => {
   const { distribution_arches = [], distribution_versions = [] } =
     queryClient.getQueryData<RepositoryParamsResponse>(REPOSITORY_PARAMS_KEY) || {};
 
-  const hasRHELSubscription = subscriptions?.RedHatEnterpriseLinux || false;
+  const hasRHELSubscription = subscriptions?.red_hat_enterprise_linux || false;
   const isMissingRequirements = !rbac?.templateWrite || !hasRHELSubscription;
   const missingRequirements: string = !rbac?.templateWrite
     ? 'permission'

--- a/src/Pages/Templates/TemplatesTable/components/TemplateFilters.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/TemplateFilters.tsx
@@ -65,13 +65,10 @@ const Filters = ({ isLoading, setFilterData, filterData }: Props) => {
   const { distribution_arches = [], distribution_versions = [] } =
     queryClient.getQueryData<RepositoryParamsResponse>(REPOSITORY_PARAMS_KEY) || {};
 
-  const hasRHELSubscription = subscriptions?.red_hat_enterprise_linux || false;
+  const hasRHELSubscription = !!subscriptions?.red_hat_enterprise_linux;
   const isMissingRequirements = !rbac?.templateWrite || !hasRHELSubscription;
-  const missingRequirements: string = !rbac?.templateWrite
-    ? 'permission'
-    : !hasRHELSubscription
-      ? 'subscription (RHEL)'
-      : 'permission';
+  const missingRequirements =
+    rbac?.templateWrite && !hasRHELSubscription ? 'subscription (RHEL)' : 'permission';
 
   const clearFilters = () => {
     setFilterType('Name');

--- a/src/Pages/Templates/TemplatesTable/components/TemplateFilters.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/TemplateFilters.tsx
@@ -51,7 +51,7 @@ export type Filters = 'Name' | 'Version' | 'Architecture';
 
 const Filters = ({ isLoading, setFilterData, filterData }: Props) => {
   const classes = useStyles();
-  const { rbac } = useAppContext();
+  const { rbac, subscriptions } = useAppContext();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const filters = ['Name', 'Version', 'Architecture'];
@@ -64,6 +64,14 @@ const Filters = ({ isLoading, setFilterData, filterData }: Props) => {
 
   const { distribution_arches = [], distribution_versions = [] } =
     queryClient.getQueryData<RepositoryParamsResponse>(REPOSITORY_PARAMS_KEY) || {};
+
+  const hasRHELSubscription = subscriptions?.RedHatEnterpriseLinux || false;
+  const isMissingRequirements = !rbac?.templateWrite || !hasRHELSubscription;
+  const missingRequirements: string = !rbac?.templateWrite
+    ? 'permission'
+    : !hasRHELSubscription
+      ? 'subscription (RHEL)'
+      : 'permission';
 
   const clearFilters = () => {
     setFilterType('Name');
@@ -210,8 +218,8 @@ const Filters = ({ isLoading, setFilterData, filterData }: Props) => {
         </FlexItem>
         <FlexItem className={classes.repositoryActions}>
           <ConditionalTooltip
-            content='You do not have the required permissions to perform this action.'
-            show={!rbac?.templateWrite}
+            content={`You do not have the required ${missingRequirements} to perform this action.`}
+            show={isMissingRequirements}
             setDisabled
           >
             <Button

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -130,6 +130,14 @@ export default function RepositoriesRoutes() {
                 element={<DeleteTemplateModal />}
               />
             </>
+          ) : rbac?.templateWrite ? (
+            <>
+              <Route
+                key='3'
+                path={`:templateUUID/${DELETE_ROUTE}`}
+                element={<DeleteTemplateModal />}
+              />
+            </>
           ) : (
             ''
           )}

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -117,7 +117,7 @@ export default function RepositoriesRoutes() {
           <Route path='*' element={<Navigate to={TEMPLATES_ROUTE} replace />} />
         </Route>
         <Route path={TEMPLATES_ROUTE} element={<TemplatesTable />}>
-          {rbac?.templateWrite && subscriptions?.RedHatEnterpriseLinux ? (
+          {rbac?.templateWrite && subscriptions?.red_hat_enterprise_linux ? (
             <>
               <Route key='1' path={ADD_ROUTE} element={<AddTemplate />} />
               <Route key='2' path={`:templateUUID/${EDIT_ROUTE}`} element={<AddTemplate />} />

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -112,9 +112,12 @@ export default function RepositoriesRoutes() {
             <Route path='*' element={<Navigate to={PACKAGES_ROUTE} replace />} />
           </Route>
           <Route path={SYSTEMS_ROUTE} element={<TemplateSystemsTab />}>
-            {rbac?.templateWrite ? <Route path={ADD_ROUTE} element={<AddSystemModal />} /> : ''}
+            {rbac?.templateWrite && subscriptions?.red_hat_enterprise_linux ? (
+              <Route path={ADD_ROUTE} element={<AddSystemModal />} />
+            ) : (
+              ''
+            )}
           </Route>
-          <Route path='*' element={<Navigate to={TEMPLATES_ROUTE} replace />} />
         </Route>
         <Route path={TEMPLATES_ROUTE} element={<TemplatesTable />}>
           {rbac?.templateWrite && subscriptions?.red_hat_enterprise_linux ? (

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -42,7 +42,7 @@ import DeleteTemplateModal from 'Pages/Templates/TemplatesTable/components/Delet
 
 export default function RepositoriesRoutes() {
   const key = useMemo(() => Math.random(), []);
-  const { zeroState, features, rbac } = useAppContext();
+  const { zeroState, features, rbac, subscriptions } = useAppContext();
   return (
     <ErrorPage>
       <Routes key={key}>
@@ -117,7 +117,7 @@ export default function RepositoriesRoutes() {
           <Route path='*' element={<Navigate to={TEMPLATES_ROUTE} replace />} />
         </Route>
         <Route path={TEMPLATES_ROUTE} element={<TemplatesTable />}>
-          {rbac?.templateWrite ? (
+          {rbac?.templateWrite && subscriptions?.RedHatEnterpriseLinux ? (
             <>
               <Route key='1' path={ADD_ROUTE} element={<AddTemplate />} />
               <Route key='2' path={`:templateUUID/${EDIT_ROUTE}`} element={<AddTemplate />} />

--- a/src/middleware/AppContext.tsx
+++ b/src/middleware/AppContext.tsx
@@ -8,6 +8,8 @@ import { ContentOrigin } from 'services/Content/ContentApi';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { ChromeAPI } from '@redhat-cloud-services/types';
 import getRBAC from '@redhat-cloud-services/frontend-components-utilities/RBAC';
+import { Subscriptions } from 'services/Subscriptions/SubscriptionApi';
+import { useFetchSubscriptionsQuery } from 'services/Subscriptions/SubscriptionQueries';
 
 const getRegistry = _getRegistry as unknown as () => { register: ({ notifications }) => void };
 const { appname } = PackageJson.insights;
@@ -16,6 +18,8 @@ export interface AppContextInterface {
   rbac?: Record<string, boolean>;
   features: Features | null;
   isFetchingFeatures: boolean;
+  subscriptions: Subscriptions | null;
+  isFetchingSubscriptions: boolean;
   contentOrigin: ContentOrigin;
   setContentOrigin: (contentOrigin: ContentOrigin) => void;
   chrome?: ChromeAPI;
@@ -32,6 +36,8 @@ export const ContextProvider = ({ children }: { children: ReactNode }) => {
   const chrome = useChrome();
   const [contentOrigin, setContentOrigin] = useState<ContentOrigin>(ContentOrigin.CUSTOM);
   const { fetchFeatures, isLoading: isFetchingFeatures } = useFetchFeaturesQuery();
+  const [subscriptions, setSubscriptions] = useState<Subscriptions | null>(null);
+  const { fetchSubscriptions, isLoading: isFetchingSubscriptions } = useFetchSubscriptionsQuery();
 
   useEffect(() => {
     // Get chrome and register app
@@ -58,6 +64,11 @@ export const ContextProvider = ({ children }: { children: ReactNode }) => {
       const fetchedFeatures = await fetchFeatures();
       setFeatures(fetchedFeatures);
     })();
+
+    (async () => {
+      const fetchedSubscriptions = await fetchSubscriptions();
+      setSubscriptions(fetchedSubscriptions);
+    })();
   }, [!!chrome]);
 
   return (
@@ -66,6 +77,8 @@ export const ContextProvider = ({ children }: { children: ReactNode }) => {
         rbac: rbac,
         features: features,
         isFetchingFeatures: isFetchingFeatures,
+        subscriptions: subscriptions,
+        isFetchingSubscriptions: isFetchingSubscriptions,
         contentOrigin,
         setContentOrigin,
         chrome: chrome as ChromeAPI,

--- a/src/middleware/AppContext.tsx
+++ b/src/middleware/AppContext.tsx
@@ -17,9 +17,8 @@ const { appname } = PackageJson.insights;
 export interface AppContextInterface {
   rbac?: Record<string, boolean>;
   features: Features | null;
-  isFetchingFeatures: boolean;
-  subscriptions: Subscriptions | null;
-  isFetchingSubscriptions: boolean;
+  isFetchingPermissions: boolean;
+  subscriptions?: Subscriptions;
   contentOrigin: ContentOrigin;
   setContentOrigin: (contentOrigin: ContentOrigin) => void;
   chrome?: ChromeAPI;
@@ -36,8 +35,8 @@ export const ContextProvider = ({ children }: { children: ReactNode }) => {
   const chrome = useChrome();
   const [contentOrigin, setContentOrigin] = useState<ContentOrigin>(ContentOrigin.CUSTOM);
   const { fetchFeatures, isLoading: isFetchingFeatures } = useFetchFeaturesQuery();
-  const [subscriptions, setSubscriptions] = useState<Subscriptions | null>(null);
-  const { fetchSubscriptions, isLoading: isFetchingSubscriptions } = useFetchSubscriptionsQuery();
+  const { fetchSubscriptions: subscriptions, isLoading: isFetchingSubscriptions } =
+    useFetchSubscriptionsQuery();
 
   useEffect(() => {
     // Get chrome and register app
@@ -64,11 +63,6 @@ export const ContextProvider = ({ children }: { children: ReactNode }) => {
       const fetchedFeatures = await fetchFeatures();
       setFeatures(fetchedFeatures);
     })();
-
-    (async () => {
-      const fetchedSubscriptions = await fetchSubscriptions();
-      setSubscriptions(fetchedSubscriptions);
-    })();
   }, [!!chrome]);
 
   return (
@@ -76,9 +70,8 @@ export const ContextProvider = ({ children }: { children: ReactNode }) => {
       value={{
         rbac: rbac,
         features: features,
-        isFetchingFeatures: isFetchingFeatures,
+        isFetchingPermissions: isFetchingFeatures || isFetchingSubscriptions,
         subscriptions: subscriptions,
-        isFetchingSubscriptions: isFetchingSubscriptions,
         contentOrigin,
         setContentOrigin,
         chrome: chrome as ChromeAPI,

--- a/src/middleware/AppContext.tsx
+++ b/src/middleware/AppContext.tsx
@@ -35,8 +35,7 @@ export const ContextProvider = ({ children }: { children: ReactNode }) => {
   const chrome = useChrome();
   const [contentOrigin, setContentOrigin] = useState<ContentOrigin>(ContentOrigin.CUSTOM);
   const { fetchFeatures, isLoading: isFetchingFeatures } = useFetchFeaturesQuery();
-  const { fetchSubscriptions: subscriptions, isLoading: isFetchingSubscriptions } =
-    useFetchSubscriptionsQuery();
+  const { data: subscriptions, isLoading: isFetchingSubscriptions } = useFetchSubscriptionsQuery();
 
   useEffect(() => {
     // Get chrome and register app

--- a/src/services/Subscriptions/SubscriptionApi.ts
+++ b/src/services/Subscriptions/SubscriptionApi.ts
@@ -1,0 +1,14 @@
+export interface Subscriptions {
+  RedHatEnterpriseLinux: boolean;
+}
+
+export const getSubscriptions: () => Promise<Subscriptions> = async () => {
+  // TODO: Change from dummy data when API is ready.
+  // const { data } = await axios.get('/api/content-sources/v1/subscription_check/');
+
+  const validRHEL = Math.random() > 0.5;
+  const subscriptions = { RedHatEnterpriseLinux: validRHEL } as Subscriptions;
+  const data: Promise<Subscriptions> = Promise.resolve(subscriptions);
+
+  return data;
+};

--- a/src/services/Subscriptions/SubscriptionApi.ts
+++ b/src/services/Subscriptions/SubscriptionApi.ts
@@ -9,3 +9,11 @@ export const getSubscriptions: () => Promise<Subscriptions> = async () => {
 
   return data;
 };
+
+export const getEphemeralSubscriptions: () => Promise<Subscriptions> = async () => {
+  const ephemeralSubscriptions: Subscriptions = {
+    red_hat_enterprise_linux: true,
+  };
+
+  return Promise.resolve(ephemeralSubscriptions);
+};

--- a/src/services/Subscriptions/SubscriptionApi.ts
+++ b/src/services/Subscriptions/SubscriptionApi.ts
@@ -1,14 +1,11 @@
+import axios from 'axios';
+
 export interface Subscriptions {
-  RedHatEnterpriseLinux: boolean;
+  red_hat_enterprise_linux: boolean;
 }
 
 export const getSubscriptions: () => Promise<Subscriptions> = async () => {
-  // TODO: Change from dummy data when API is ready.
-  // const { data } = await axios.get('/api/content-sources/v1/subscription_check/');
-
-  const validRHEL = Math.random() > 0.5;
-  const subscriptions = { RedHatEnterpriseLinux: validRHEL } as Subscriptions;
-  const data: Promise<Subscriptions> = Promise.resolve(subscriptions);
+  const { data } = await axios.get('/api/content-sources/v1/subscription_check/');
 
   return data;
 };

--- a/src/services/Subscriptions/SubscriptionQueries.ts
+++ b/src/services/Subscriptions/SubscriptionQueries.ts
@@ -6,22 +6,13 @@ const SUBSCRIPTION_CHECK_KEY = 'SUBSCRIPTION_CHECK_KEY';
 
 export const useFetchSubscriptionsQuery = () => {
   const errorNotifier = useErrorNotification();
-  const { data: fetchSubscriptions, isLoading } = useQuery<Subscriptions>(
-    [SUBSCRIPTION_CHECK_KEY],
-    () => getSubscriptions(),
-    {
-      keepPreviousData: true,
-      optimisticResults: true,
-      staleTime: 60000,
-      onError: (err) =>
-        errorNotifier(
-          'Error fetching subscriptions',
-          'An error occurred',
-          err,
-          'fetch-subscriptions-error',
-        ),
-    },
-  );
-
-  return { fetchSubscriptions, isLoading };
+  return useQuery<Subscriptions>([SUBSCRIPTION_CHECK_KEY], () => getSubscriptions(), {
+    onError: (err) =>
+      errorNotifier(
+        'Error fetching subscriptions',
+        'An error occurred',
+        err,
+        'fetch-subscriptions-error',
+      ),
+  });
 };

--- a/src/services/Subscriptions/SubscriptionQueries.ts
+++ b/src/services/Subscriptions/SubscriptionQueries.ts
@@ -1,27 +1,27 @@
-import { useState } from 'react';
 import { Subscriptions, getSubscriptions } from './SubscriptionApi';
 import useErrorNotification from 'Hooks/useErrorNotification';
+import { useQuery } from 'react-query';
+
+const SUBSCRIPTION_CHECK_KEY = 'SUBSCRIPTION_CHECK_KEY';
 
 export const useFetchSubscriptionsQuery = () => {
-  const [isLoading, setIsLoading] = useState(false);
   const errorNotifier = useErrorNotification();
-
-  const fetchSubscriptions = async (): Promise<Subscriptions | null> => {
-    setIsLoading(true);
-    let subscriptions: Subscriptions | null = null;
-    try {
-      subscriptions = await getSubscriptions();
-    } catch (err) {
-      errorNotifier(
-        'Error fetching subscriptions',
-        'An error occurred',
-        err,
-        'fetch-subscriptions-error',
-      );
-    }
-    setIsLoading(false);
-    return subscriptions;
-  };
+  const { data: fetchSubscriptions, isLoading } = useQuery<Subscriptions>(
+    [SUBSCRIPTION_CHECK_KEY],
+    () => getSubscriptions(),
+    {
+      keepPreviousData: true,
+      optimisticResults: true,
+      staleTime: 60000,
+      onError: (err) =>
+        errorNotifier(
+          'Error fetching subscriptions',
+          'An error occurred',
+          err,
+          'fetch-subscriptions-error',
+        ),
+    },
+  );
 
   return { fetchSubscriptions, isLoading };
 };

--- a/src/services/Subscriptions/SubscriptionQueries.ts
+++ b/src/services/Subscriptions/SubscriptionQueries.ts
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import { Subscriptions, getSubscriptions } from './SubscriptionApi';
+import useErrorNotification from 'Hooks/useErrorNotification';
+
+export const useFetchSubscriptionsQuery = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const errorNotifier = useErrorNotification();
+
+  const fetchSubscriptions = async (): Promise<Subscriptions | null> => {
+    setIsLoading(true);
+    let subscriptions: Subscriptions | null = null;
+    try {
+      subscriptions = await getSubscriptions();
+    } catch (err) {
+      errorNotifier(
+        'Error fetching subscriptions',
+        'An error occurred',
+        err,
+        'fetch-subscriptions-error',
+      );
+    }
+    setIsLoading(false);
+    return subscriptions;
+  };
+
+  return { fetchSubscriptions, isLoading };
+};

--- a/src/services/Subscriptions/SubscriptionQueries.ts
+++ b/src/services/Subscriptions/SubscriptionQueries.ts
@@ -1,12 +1,16 @@
-import { Subscriptions, getSubscriptions } from './SubscriptionApi';
+import { Subscriptions, getSubscriptions, getEphemeralSubscriptions } from './SubscriptionApi';
 import useErrorNotification from 'Hooks/useErrorNotification';
+import useIsEphemeralEnv from 'Hooks/useIsEphemeralEnv';
 import { useQuery } from 'react-query';
 
 const SUBSCRIPTION_CHECK_KEY = 'SUBSCRIPTION_CHECK_KEY';
 
 export const useFetchSubscriptionsQuery = () => {
   const errorNotifier = useErrorNotification();
-  return useQuery<Subscriptions>([SUBSCRIPTION_CHECK_KEY], () => getSubscriptions(), {
+  const isEphemeral = useIsEphemeralEnv();
+  const queryFn = isEphemeral ? getEphemeralSubscriptions() : getSubscriptions();
+
+  return useQuery<Subscriptions>([SUBSCRIPTION_CHECK_KEY], () => queryFn, {
     onError: (err) =>
       errorNotifier(
         'Error fetching subscriptions',


### PR DESCRIPTION
## Summary
This PR introduces a subscription check for disabling template add/edit actions (and routes) for users that don't have a valid RHEL subscription.

## Testing steps
Verify that when signed in with a user that has a valid subscription everything works fine. \
And when signed in with a user that doesn't (the future API implementation determines that) these things are true:
- _Add Content Template_ is disabled on the template page.
- The kebab menu is disabled for each item in the template table.
- The actions select in the _Template Detail_ view is disabled.
- You can't access the add/edit template modal by visiting the URL for it.