### PR TITLE
Fixes 4624: add template delete modal

### DIFF
--- a/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.tsx
@@ -16,7 +16,7 @@ export default function TemplateActionDropdown() {
   const { pathname } = useLocation();
   const [mainRoute] = pathname?.split(`${TEMPLATES_ROUTE}/`) || [];
   const baseRoute = mainRoute + `${TEMPLATES_ROUTE}`;
-  const navigate = useNavigate();  
+  const navigate = useNavigate();
   const { templateUUID: uuid } = useParams();
   const { rbac } = useAppContext();
 
@@ -31,7 +31,7 @@ export default function TemplateActionDropdown() {
         setIsOpen(false);
         break;
       case 'delete':
-        navigate(`${baseRoute}/${uuid}/${DELETE_ROUTE}`)      
+        navigate(`${baseRoute}/${uuid}/${DELETE_ROUTE}`);
         break;
 
       default:
@@ -51,11 +51,7 @@ export default function TemplateActionDropdown() {
           show={!rbac?.templateWrite}
           setDisabled
         >
-          <MenuToggle
-            ref={toggleRef}
-            onClick={onToggleClick}
-            isExpanded={isOpen}
-          >
+          <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
             Actions
           </MenuToggle>
         </ConditionalTooltip>
@@ -64,9 +60,7 @@ export default function TemplateActionDropdown() {
     >
       <DropdownList>
         <DropdownItem value='edit'>Edit</DropdownItem>
-        <DropdownItem value='delete'>
-          Delete
-        </DropdownItem>
+        <DropdownItem value='delete'>Delete</DropdownItem>
       </DropdownList>
     </Dropdown>
   );

--- a/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.tsx
@@ -7,9 +7,7 @@ import {
   MenuToggleElement,
 } from '@patternfly/react-core';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { useQueryClient } from 'react-query';
-import { useDeleteTemplateItemMutate } from 'services/Templates/TemplateQueries';
-import { TEMPLATES_ROUTE } from 'Routes/constants';
+import { DELETE_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
 import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip';
 import { useAppContext } from 'middleware/AppContext';
 
@@ -18,13 +16,9 @@ export default function TemplateActionDropdown() {
   const { pathname } = useLocation();
   const [mainRoute] = pathname?.split(`${TEMPLATES_ROUTE}/`) || [];
   const baseRoute = mainRoute + `${TEMPLATES_ROUTE}`;
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
+  const navigate = useNavigate();  
   const { templateUUID: uuid } = useParams();
   const { rbac } = useAppContext();
-
-  const { mutateAsync: deleteItem, isLoading: isDeleting } =
-    useDeleteTemplateItemMutate(queryClient);
 
   const onToggleClick = () => {
     setIsOpen(!isOpen);
@@ -37,10 +31,7 @@ export default function TemplateActionDropdown() {
         setIsOpen(false);
         break;
       case 'delete':
-        deleteItem(uuid as string).then(() => {
-          setIsOpen(false);
-          navigate(baseRoute);
-        });
+        navigate(`${baseRoute}/${uuid}/${DELETE_ROUTE}`)      
         break;
 
       default:
@@ -61,7 +52,6 @@ export default function TemplateActionDropdown() {
           setDisabled
         >
           <MenuToggle
-            isDisabled={isDeleting}
             ref={toggleRef}
             onClick={onToggleClick}
             isExpanded={isOpen}
@@ -74,7 +64,7 @@ export default function TemplateActionDropdown() {
     >
       <DropdownList>
         <DropdownItem value='edit'>Edit</DropdownItem>
-        <DropdownItem isLoading={isDeleting} isDisabled={isDeleting} value='delete'>
+        <DropdownItem value='delete'>
           Delete
         </DropdownItem>
       </DropdownList>

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.test.tsx
@@ -27,8 +27,6 @@ jest.mock('middleware/AppContext', () => ({
   }),
 }));
 
-
-
 it('expect TemplatesTable to render empty state', () => {
   (useTemplateList as jest.Mock).mockImplementation(() => ({
     isLoading: false,

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.test.tsx
@@ -27,12 +27,7 @@ jest.mock('middleware/AppContext', () => ({
   }),
 }));
 
-jest.mock('Hooks/useArchVersion', () => () => ({
-  isError: false,
-  isLoading: false,
-  archesDisplay: () => 'x86_64',
-  versionDisplay: () => 'Rhel9',
-}));
+
 
 it('expect TemplatesTable to render empty state', () => {
   (useTemplateList as jest.Mock).mockImplementation(() => ({

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -28,16 +28,15 @@ import Hide from 'components/Hide/Hide';
 import EmptyTableState from 'components/EmptyTableState/EmptyTableState';
 import { Outlet, useNavigate } from 'react-router-dom';
 import { TemplateFilterData, TemplateItem } from 'services/Templates/TemplateApi';
-import { useDeleteTemplateItemMutate, useTemplateList } from 'services/Templates/TemplateQueries';
 import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip';
 import { useAppContext } from 'middleware/AppContext';
 import TemplateFilters from './components/TemplateFilters';
 import { formatDateDDMMMYYYY, formatDateUTC } from 'helpers';
-import { useQueryClient } from 'react-query';
 import Header from 'components/Header/Header';
 import useRootPath from 'Hooks/useRootPath';
-import { DETAILS_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
+import { DELETE_ROUTE, DETAILS_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
 import useArchVersion from 'Hooks/useArchVersion';
+import { useTemplateList } from 'services/Templates/TemplateQueries';
 
 const useStyles = createUseStyles({
   mainContainer: {
@@ -76,8 +75,7 @@ const TemplatesTable = () => {
   const classes = useStyles();
   const rootPath = useRootPath();
   const navigate = useNavigate();
-  const { rbac } = useAppContext();
-  const queryClient = useQueryClient();
+  const { rbac } = useAppContext();  
   const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(storedPerPage);
@@ -112,9 +110,6 @@ const TemplatesTable = () => {
     isFetching,
     data = { data: [], meta: { count: 0, limit: 20, offset: 0 } },
   } = useTemplateList(page, perPage, sortString, filterData);
-
-  const { mutateAsync: deleteItem, isLoading: isDeleting } =
-    useDeleteTemplateItemMutate(queryClient);
 
   const onSetPage = (_, newPage: number) => setPage(newPage);
 
@@ -154,7 +149,7 @@ const TemplatesTable = () => {
     versionDisplay,
   } = useArchVersion();
 
-  const actionTakingPlace = isLoading || isFetching || repositoryParamsLoading || isDeleting;
+  const actionTakingPlace = isLoading || isFetching || repositoryParamsLoading;
 
   // Error is caught in the wrapper component
   if (isError) throw error;
@@ -311,17 +306,7 @@ const TemplatesTable = () => {
                               { isSeparator: true },
                               {
                                 title: 'Delete',
-                                onClick: () =>
-                                  deleteItem(uuid).then(() => {
-                                    // If last item being deleted on a page, go back one page.
-                                    if (
-                                      page > 1 &&
-                                      count / perPage + 1 >= page &&
-                                      (count - 1) % perPage === 0
-                                    ) {
-                                      setPage(page - 1);
-                                    }
-                                  }),
+                                onClick: () => navigate(`${uuid}/${DELETE_ROUTE}`),
                               },
                             ]}
                           />

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -75,7 +75,7 @@ const TemplatesTable = () => {
   const classes = useStyles();
   const rootPath = useRootPath();
   const navigate = useNavigate();
-  const { rbac } = useAppContext();  
+  const { rbac } = useAppContext();
   const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(storedPerPage);

--- a/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.test.tsx
@@ -1,0 +1,71 @@
+import { render } from '@testing-library/react';
+import {
+  ReactQueryTestWrapper,
+  defaultSystemsListItem,
+  defaultTemplateItem,
+} from 'testingHelpers';
+
+import DeleteTemplateModal from './DeleteTemplateModal';
+import { useListSystemsByTemplateId } from 'services/Systems/SystemsQueries';
+
+jest.mock('react-query', () => ({
+  ...jest.requireActual('react-query'),
+  useQueryClient: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({
+    templateUUID: `${defaultTemplateItem.uuid}`,
+  }),
+  useNavigate: () => jest.fn,
+}));
+
+jest.mock('Hooks/useRootPath', () => () => 'someUrl');
+
+jest.mock('services/Systems/SystemsQueries', () => ({
+    useListSystemsByTemplateId: jest.fn(),
+}));
+
+jest.mock('services/Templates/TemplateQueries', () => ({
+    useDeleteTemplateItemMutate: () => ({ mutate: () => undefined, isLoading: false }),
+  }));
+  
+jest.mock('middleware/AppContext', () => ({ useAppContext: () => ({}) }));
+
+it('Render delete modal where there are no systems', () => {
+  (useListSystemsByTemplateId as jest.Mock).mockImplementation(() => ({
+    data: {
+      isLoading: false,
+      data: [],
+      count: 0,
+    },
+  }));
+
+  const { queryByText } = render(
+    <ReactQueryTestWrapper>
+      <DeleteTemplateModal />
+    </ReactQueryTestWrapper>,
+  );
+
+  expect(queryByText('This template is in use.')).toBeNull()
+  expect(queryByText('Are you sure you want to remove this template?')).toBeInTheDocument(); 
+});
+
+it('Render delete modal where template has one system', () => {
+  (useListSystemsByTemplateId as jest.Mock).mockImplementation(() => ({
+    data: {
+      isLoading: false,
+      data: [defaultSystemsListItem],
+      count: 1,
+    },
+  }));
+
+  const { queryByText } = render(
+    <ReactQueryTestWrapper>
+      <DeleteTemplateModal />
+    </ReactQueryTestWrapper>,
+  );
+  
+  expect(queryByText('This template is in use.')).toBeInTheDocument();  
+  expect(queryByText('Are you sure you want to remove this template?')).toBeInTheDocument(); 
+});

--- a/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.test.tsx
@@ -1,9 +1,5 @@
 import { render } from '@testing-library/react';
-import {
-  ReactQueryTestWrapper,
-  defaultSystemsListItem,
-  defaultTemplateItem,
-} from 'testingHelpers';
+import { ReactQueryTestWrapper, defaultSystemsListItem, defaultTemplateItem } from 'testingHelpers';
 
 import DeleteTemplateModal from './DeleteTemplateModal';
 import { useListSystemsByTemplateId } from 'services/Systems/SystemsQueries';
@@ -23,13 +19,13 @@ jest.mock('react-router-dom', () => ({
 jest.mock('Hooks/useRootPath', () => () => 'someUrl');
 
 jest.mock('services/Systems/SystemsQueries', () => ({
-    useListSystemsByTemplateId: jest.fn(),
+  useListSystemsByTemplateId: jest.fn(),
 }));
 
 jest.mock('services/Templates/TemplateQueries', () => ({
-    useDeleteTemplateItemMutate: () => ({ mutate: () => undefined, isLoading: false }),
-  }));
-  
+  useDeleteTemplateItemMutate: () => ({ mutate: () => undefined, isLoading: false }),
+}));
+
 jest.mock('middleware/AppContext', () => ({ useAppContext: () => ({}) }));
 
 it('Render delete modal where there are no systems', () => {
@@ -47,8 +43,8 @@ it('Render delete modal where there are no systems', () => {
     </ReactQueryTestWrapper>,
   );
 
-  expect(queryByText('This template is in use.')).toBeNull()
-  expect(queryByText('Are you sure you want to remove this template?')).toBeInTheDocument(); 
+  expect(queryByText('This template is in use.')).toBeNull();
+  expect(queryByText('Are you sure you want to remove this template?')).toBeInTheDocument();
 });
 
 it('Render delete modal where template has one system', () => {
@@ -65,7 +61,7 @@ it('Render delete modal where template has one system', () => {
       <DeleteTemplateModal />
     </ReactQueryTestWrapper>,
   );
-  
-  expect(queryByText('This template is in use.')).toBeInTheDocument();  
-  expect(queryByText('Are you sure you want to remove this template?')).toBeInTheDocument(); 
+
+  expect(queryByText('This template is in use.')).toBeInTheDocument();
+  expect(queryByText('Are you sure you want to remove this template?')).toBeInTheDocument();
 });

--- a/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.tsx
@@ -1,124 +1,122 @@
 import {
-    Alert,
-    Bullseye,
-    Button,
-    Modal,
-    ModalVariant,
-    Spinner,
-    Stack,
-    StackItem,
-    Text,
-  } from '@patternfly/react-core';
+  Alert,
+  Bullseye,
+  Button,
+  Flex,
+  Modal,
+  ModalVariant,
+  Spinner,
+  Stack,
+  StackItem,
+  Text,
+} from '@patternfly/react-core';
 
-  import { global_Color_100 } from '@patternfly/react-tokens';
-  import { createUseStyles } from 'react-jss';
-  import Hide from 'components/Hide/Hide';
-  import { useQueryClient } from 'react-query';
-  import {  useNavigate, useParams } from 'react-router-dom';
-  import useRootPath from 'Hooks/useRootPath';
-  import { GET_TEMPLATES_KEY, useDeleteTemplateItemMutate } from 'services/Templates/TemplateQueries';  
-  import { DETAILS_ROUTE,  SYSTEMS_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
-  import { useListSystemsByTemplateId } from 'services/Systems/SystemsQueries';
-  
-  const useStyles = createUseStyles({
-    description: {
-        paddingTop: '12px', // 4px on the title bottom padding makes this the "standard" 16 total padding
-        color: global_Color_100.value,
-      },
-      removeButton: {
-        marginRight: '36px',
-        transition: 'unset!important',
-      },
-      link: {
-        padding: 4,
-      },
-  });
-  
-  export default function DeleteTemplateModal() {
-    const classes = useStyles();
-    const navigate = useNavigate();
-    const rootPath = useRootPath();
-    const queryClient = useQueryClient();
-  
-    const { templateUUID: uuid} = useParams();
+import { global_Color_100 } from '@patternfly/react-tokens';
+import { createUseStyles } from 'react-jss';
+import Hide from 'components/Hide/Hide';
+import { useQueryClient } from 'react-query';
+import { useNavigate, useParams } from 'react-router-dom';
+import useRootPath from 'Hooks/useRootPath';
+import { GET_TEMPLATES_KEY, useDeleteTemplateItemMutate } from 'services/Templates/TemplateQueries';
+import { DETAILS_ROUTE, SYSTEMS_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
+import { useListSystemsByTemplateId } from 'services/Systems/SystemsQueries';
 
-    const { mutateAsync: deleteTemplate, isLoading: isDeleting } =
-        useDeleteTemplateItemMutate(queryClient);
- 
-    const onClose = () =>
-      navigate(
-        `${rootPath}/${TEMPLATES_ROUTE}`
-      );
-  
-    const onSave = async () => {
-        deleteTemplate(uuid as string).then(() => {
-        onClose();                
-        queryClient.invalidateQueries(GET_TEMPLATES_KEY);
-      });
-    };
-    
-    const {      
-      isLoading: isLoading,
-      data: systems = { data: [], meta: { count: 0, limit: 1, offset: 0 } },
-    } = useListSystemsByTemplateId(uuid as string, 1, 1,  '', '')
-  
-    const actionTakingPlace = isLoading || isDeleting;      
-  
-    return (
-      <Modal
-        titleIconVariant='warning'
-        position='top'
-        variant={ModalVariant.large}
-        title='Remove template?'
-        ouiaId='delete_template'
-        description={
-          <>
+const useStyles = createUseStyles({
+  description: {
+    paddingTop: '12px', // 4px on the title bottom padding makes this the "standard" 16 total padding
+    color: global_Color_100.value,
+  },
+  removeButton: {
+    marginRight: '36px',
+    transition: 'unset!important',
+  },
+  link: {
+    padding: 4,
+  },
+});
 
-          </>
-        }
-        isOpen
-        onClose={onClose}
-        footer={
-          <Stack>
-            <StackItem>
-              <Button
-                key='confirm'
-                ouiaId='delete_modal_confirm'
-                variant='danger'
-                isLoading={actionTakingPlace}
-                isDisabled={actionTakingPlace}
-                onClick={onSave}
-              >
-                Remove
-              </Button>
-              <Button key='cancel' variant='link' onClick={onClose} ouiaId='delete_modal_cancel'>
-                Cancel
-              </Button>
-            </StackItem>
-          </Stack>
-        }
-      >
-        <Hide hide={!isLoading}>
-          <Bullseye>
-            <Spinner />
-          </Bullseye>
-        </Hide>
-        <Hide hide={systems.data.length <= 0}>
-            <Alert variant='warning' isInline title='This template is in use.'>
-                <a
-                href={`${rootPath}/${TEMPLATES_ROUTE}/${uuid}/${DETAILS_ROUTE}/${SYSTEMS_ROUTE}`}
-                className={classes.link}                                
-                >
-                    {systems.data.length} {systems.data.length == 1 ?  'system is' : 'systems are'} assigned to this template.
-                </a>
-                Removing this template will cause all of these systems to stop recieving custom content and snapshotted Red Hat content.  They will still recieve the latest Red Hat content updates.
-            </Alert>
-        </Hide>
-        <Text component='p' className={classes.description}>
-            Are you sure you want to remove this template?
-        </Text>
+export default function DeleteTemplateModal() {
+  const classes = useStyles();
+  const navigate = useNavigate();
+  const rootPath = useRootPath();
+  const queryClient = useQueryClient();
 
-      </Modal>
-    );
-  }
-  
+  const { templateUUID: uuid } = useParams();
+
+  const { mutateAsync: deleteTemplate, isLoading: isDeleting } =
+    useDeleteTemplateItemMutate(queryClient);
+
+  const onClose = () => navigate(`${rootPath}/${TEMPLATES_ROUTE}`);
+
+  const onSave = async () => {
+    deleteTemplate(uuid as string).then(() => {
+      onClose();
+      queryClient.invalidateQueries(GET_TEMPLATES_KEY);
+    });
+  };
+
+  const {
+    isLoading: isLoading,
+    data: systems = { data: [], meta: { count: 0, limit: 1, offset: 0 } },
+  } = useListSystemsByTemplateId(uuid as string, 1, 1, '', '');
+
+  const actionTakingPlace = isLoading || isDeleting;
+
+  return (
+    <Modal
+      titleIconVariant='warning'
+      position='top'
+      variant={ModalVariant.medium}
+      title='Remove template?'
+      ouiaId='delete_template'
+      isOpen
+      onClose={onClose}
+      footer={
+        <Stack>
+          <StackItem>
+            <Button
+              key='confirm'
+              ouiaId='delete_modal_confirm'
+              variant='danger'
+              isLoading={actionTakingPlace}
+              isDisabled={actionTakingPlace}
+              onClick={onSave}
+            >
+              Remove
+            </Button>
+            <Button key='cancel' variant='link' onClick={onClose} ouiaId='delete_modal_cancel'>
+              Cancel
+            </Button>
+          </StackItem>
+        </Stack>
+      }
+    >
+      <Hide hide={!isLoading}>
+        <Bullseye>
+          <Spinner />
+        </Bullseye>
+      </Hide>
+      <Hide hide={systems.data.length <= 0}>
+        <Alert variant='warning' isInline title='This template is in use.'>
+          <Flex direction={{ default: 'column' }}>
+            <a
+              href={`${rootPath}/${TEMPLATES_ROUTE}/${uuid}/${DETAILS_ROUTE}/${SYSTEMS_ROUTE}`}
+              className={classes.link}
+            >
+              {systems.data.length} {systems.data.length === 1 ? 'system is' : 'systems are'}{' '}
+              assigned to this template.
+            </a>
+            <span>
+              Removing this template will cause all associated systems to stop recieving custom
+              content and snapshotted Red Hat content; they will still recieve the latest Red Hat
+              content updates.
+            </span>
+          </Flex>
+        </Alert>
+      </Hide>
+      <Text component='p' className={classes.description}>
+        Are you sure you want to remove this template?
+      </Text>
+    </Modal>
+  );
+}

--- a/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.tsx
@@ -103,8 +103,8 @@ export default function DeleteTemplateModal() {
               href={`${rootPath}/${TEMPLATES_ROUTE}/${uuid}/${DETAILS_ROUTE}/${SYSTEMS_ROUTE}`}
               className={classes.link}
             >
-              {systems.data.length} {systems.data.length === 1 ? 'system is' : 'systems are'}{' '}
-              assigned to this template.
+              This template is assigned to {systems.data.length}{' '}
+              {systems.data.length === 1 ? 'system' : 'systems'}.
             </a>
             <span>
               Removing this template will cause all associated systems to stop recieving custom

--- a/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.tsx
@@ -1,0 +1,124 @@
+import {
+    Alert,
+    Bullseye,
+    Button,
+    Modal,
+    ModalVariant,
+    Spinner,
+    Stack,
+    StackItem,
+    Text,
+  } from '@patternfly/react-core';
+
+  import { global_Color_100 } from '@patternfly/react-tokens';
+  import { createUseStyles } from 'react-jss';
+  import Hide from 'components/Hide/Hide';
+  import { useQueryClient } from 'react-query';
+  import {  useNavigate, useParams } from 'react-router-dom';
+  import useRootPath from 'Hooks/useRootPath';
+  import { GET_TEMPLATES_KEY, useDeleteTemplateItemMutate } from 'services/Templates/TemplateQueries';  
+  import { DETAILS_ROUTE,  SYSTEMS_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
+  import { useListSystemsByTemplateId } from 'services/Systems/SystemsQueries';
+  
+  const useStyles = createUseStyles({
+    description: {
+        paddingTop: '12px', // 4px on the title bottom padding makes this the "standard" 16 total padding
+        color: global_Color_100.value,
+      },
+      removeButton: {
+        marginRight: '36px',
+        transition: 'unset!important',
+      },
+      link: {
+        padding: 4,
+      },
+  });
+  
+  export default function DeleteTemplateModal() {
+    const classes = useStyles();
+    const navigate = useNavigate();
+    const rootPath = useRootPath();
+    const queryClient = useQueryClient();
+  
+    const { templateUUID: uuid} = useParams();
+
+    const { mutateAsync: deleteTemplate, isLoading: isDeleting } =
+        useDeleteTemplateItemMutate(queryClient);
+ 
+    const onClose = () =>
+      navigate(
+        `${rootPath}/${TEMPLATES_ROUTE}`
+      );
+  
+    const onSave = async () => {
+        deleteTemplate(uuid as string).then(() => {
+        onClose();                
+        queryClient.invalidateQueries(GET_TEMPLATES_KEY);
+      });
+    };
+    
+    const {      
+      isLoading: isLoading,
+      data: systems = { data: [], meta: { count: 0, limit: 1, offset: 0 } },
+    } = useListSystemsByTemplateId(uuid as string, 1, 1,  '', '')
+  
+    const actionTakingPlace = isLoading || isDeleting;      
+  
+    return (
+      <Modal
+        titleIconVariant='warning'
+        position='top'
+        variant={ModalVariant.large}
+        title='Remove template?'
+        ouiaId='delete_template'
+        description={
+          <>
+
+          </>
+        }
+        isOpen
+        onClose={onClose}
+        footer={
+          <Stack>
+            <StackItem>
+              <Button
+                key='confirm'
+                ouiaId='delete_modal_confirm'
+                variant='danger'
+                isLoading={actionTakingPlace}
+                isDisabled={actionTakingPlace}
+                onClick={onSave}
+              >
+                Remove
+              </Button>
+              <Button key='cancel' variant='link' onClick={onClose} ouiaId='delete_modal_cancel'>
+                Cancel
+              </Button>
+            </StackItem>
+          </Stack>
+        }
+      >
+        <Hide hide={!isLoading}>
+          <Bullseye>
+            <Spinner />
+          </Bullseye>
+        </Hide>
+        <Hide hide={systems.data.length <= 0}>
+            <Alert variant='warning' isInline title='This template is in use.'>
+                <a
+                href={`${rootPath}/${TEMPLATES_ROUTE}/${uuid}/${DETAILS_ROUTE}/${SYSTEMS_ROUTE}`}
+                className={classes.link}                                
+                >
+                    {systems.data.length} {systems.data.length == 1 ?  'system is' : 'systems are'} assigned to this template.
+                </a>
+                Removing this template will cause all of these systems to stop recieving custom content and snapshotted Red Hat content.  They will still recieve the latest Red Hat content updates.
+            </Alert>
+        </Hide>
+        <Text component='p' className={classes.description}>
+            Are you sure you want to remove this template?
+        </Text>
+
+      </Modal>
+    );
+  }
+  

--- a/src/Routes/constants.ts
+++ b/src/Routes/constants.ts
@@ -2,6 +2,7 @@ export const REPOSITORIES_ROUTE = 'repositories';
 export const POPULAR_REPOSITORIES_ROUTE = 'popular';
 export const ADMIN_TASKS_ROUTE = 'admin-tasks';
 export const TEMPLATES_ROUTE = 'templates';
+export const TEMPLATES_DELETE_ROUTE = 'templates_delete';
 export const CONTENT_ROUTE = 'content';
 export const SNAPSHOTS_ROUTE = 'snapshots';
 export const SYSTEMS_ROUTE = 'systems';

--- a/src/Routes/constants.ts
+++ b/src/Routes/constants.ts
@@ -2,7 +2,6 @@ export const REPOSITORIES_ROUTE = 'repositories';
 export const POPULAR_REPOSITORIES_ROUTE = 'popular';
 export const ADMIN_TASKS_ROUTE = 'admin-tasks';
 export const TEMPLATES_ROUTE = 'templates';
-export const TEMPLATES_DELETE_ROUTE = 'templates_delete';
 export const CONTENT_ROUTE = 'content';
 export const SNAPSHOTS_ROUTE = 'snapshots';
 export const SYSTEMS_ROUTE = 'systems';

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -121,7 +121,11 @@ export default function RepositoriesRoutes() {
             <>
               <Route key='1' path={ADD_ROUTE} element={<AddTemplate />} />
               <Route key='2' path={`:templateUUID/${EDIT_ROUTE}`} element={<AddTemplate />} />
-              <Route key='3' path={`:templateUUID/${DELETE_ROUTE}`} element={<DeleteTemplateModal />} />
+              <Route
+                key='3'
+                path={`:templateUUID/${DELETE_ROUTE}`}
+                element={<DeleteTemplateModal />}
+              />
             </>
           ) : (
             ''

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -38,6 +38,7 @@ import PackageModal from 'Pages/Repositories/ContentListTable/components/Package
 import PopularRepositoriesTable from 'Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable';
 import AdminTaskTable from 'Pages/Repositories/AdminTaskTable/AdminTaskTable';
 import ViewPayloadModal from 'Pages/Repositories/AdminTaskTable/components/ViewPayloadModal/ViewPayloadModal';
+import DeleteTemplateModal from 'Pages/Templates/TemplatesTable/components/DeleteTemplateModal';
 
 export default function RepositoriesRoutes() {
   const key = useMemo(() => Math.random(), []);
@@ -120,6 +121,7 @@ export default function RepositoriesRoutes() {
             <>
               <Route key='1' path={ADD_ROUTE} element={<AddTemplate />} />
               <Route key='2' path={`:templateUUID/${EDIT_ROUTE}`} element={<AddTemplate />} />
+              <Route key='3' path={`:templateUUID/${DELETE_ROUTE}`} element={<DeleteTemplateModal />} />
             </>
           ) : (
             ''


### PR DESCRIPTION
## Summary

Adds a delete modal for templates when deleting a template:
* via the kabab menu in the templates list
*  via the actions drop down in the templates detail

When there is a system assigned:
![image](https://github.com/user-attachments/assets/05b48c0c-8795-4d5e-92b4-22aeb042a986)


When there are no systems assigned: 
![image](https://github.com/user-attachments/assets/bc7e154b-ebf5-4c09-9f2e-48428e3c9533)




## Testing steps
