### PR TITLE
Refs 3483: fix locator typo

### DIFF
--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
@@ -247,7 +247,7 @@ export default function SnapshotListModal() {
                       <Td>
                         <Button
                           variant='link'
-                          ouiaId='snapshot_advistory_count_button'
+                          ouiaId='snapshot_advisory_count_button'
                           isInline
                           isDisabled={!content_counts?.['rpm.advisory']}
                           onClick={() =>


### PR DESCRIPTION
## Summary

This just fixes a locator typo for the snapshot advisory count button

## Testing steps
