### PR TITLE
Fixes 4572: list snapshots/repositories in template detail

### DIFF
--- a/src/Pages/Templates/TemplateDetails/components/Tables/TemplateRepositoriesTable.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tables/TemplateRepositoriesTable.tsx
@@ -1,0 +1,210 @@
+import EmptyTableState from 'components/EmptyTableState/EmptyTableState';
+import Hide from 'components/Hide/Hide';
+import { formatDateDDMMMYYYY } from 'helpers';
+import useDeepCompareEffect from 'Hooks/useDeepCompareEffect';
+import useRootPath from 'Hooks/useRootPath';
+import { isEmpty } from 'lodash';
+import { SnapshotDetailTab } from 'Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal';
+import ChangedArrows from 'Pages/Repositories/ContentListTable/components/SnapshotListModal/components/ChangedArrows';
+import React, { useEffect, useState } from 'react';
+import { createUseStyles } from 'react-jss';
+import { useNavigate } from 'react-router-dom';
+import { REPOSITORIES_ROUTE } from 'Routes/constants';
+import { SnapshotItem } from 'services/Content/ContentApi';
+
+import { SkeletonTable } from '@patternfly/react-component-groups';
+import { Button, Grid } from '@patternfly/react-core';
+import {
+  BaseCellProps,
+  Table,
+  TableVariant,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  ThProps,
+  Tr,
+} from '@patternfly/react-table';
+import {
+  global_BackgroundColor_100,
+  global_danger_color_200,
+  global_success_color_200,
+} from '@patternfly/react-tokens';
+
+const red = global_danger_color_200.value;
+const green = global_success_color_200.value;
+
+const useStyles = createUseStyles({
+  mainContainer: {
+    backgroundColor: global_BackgroundColor_100.value,
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+  },
+  expansionBox: {
+    padding: '16px 0',
+  },
+  rightMargin: { marginRight: '6px' },
+  red: { extend: 'rightMargin', color: red },
+  green: { extend: 'rightMargin', color: green },
+  retainSpaces: { whiteSpace: 'pre-line' },
+});
+
+interface Props {
+  isFetchingOrLoading: boolean;
+  isLoadingOrZeroCount: boolean;
+  snapshotList: SnapshotItem[];
+  clearSearch: () => void;
+  perPage: number;
+  sortParams: (columnIndex: number) => ThProps['sort'];
+  hasSearch: boolean;
+}
+
+export default function TemplateRepositoriesTable({
+  isFetchingOrLoading,
+  isLoadingOrZeroCount,
+  snapshotList,
+  clearSearch,
+  perPage,
+  sortParams,
+  hasSearch,
+}: Props) {
+  const classes = useStyles();
+  const rootPath = useRootPath();
+  const navigate = useNavigate();
+  const [prevLength, setPrev] = useState(perPage || 10);
+  const [expandState, setExpandState] = useState({});
+
+  useDeepCompareEffect(() => {
+    if (!isEmpty(expandState)) setExpandState({});
+  }, [snapshotList]);
+
+  useEffect(() => {
+    setPrev(snapshotList.length || 10);
+  }, [snapshotList.length]);
+
+  const columnHeaders = [
+    { name: 'Repository Name' },
+    { name: 'Snapshot Date', width: 20 },
+    { name: 'Change', width: 15 },
+    { name: 'Packages', width: 15 },
+    { name: 'Errata', width: 15 },
+  ];
+
+  return (
+    <>
+      <Hide hide={!isFetchingOrLoading}>
+        <Grid className={classes.mainContainer}>
+          <SkeletonTable
+            rows={prevLength}
+            numberOfColumns={columnHeaders.length}
+            variant={TableVariant.compact}
+          />
+        </Grid>
+      </Hide>
+      <Hide hide={isFetchingOrLoading}>
+        <Table aria-label='repositories table' ouiaId='repositories_table' variant='compact'>
+          <Hide hide={isLoadingOrZeroCount}>
+            <Thead>
+              <Tr>
+                {columnHeaders.map(({ name, width }, index) =>
+                  name === 'Repository Name' || name === 'Snapshot Date' ? (
+                    <Th
+                      width={width as BaseCellProps['width']}
+                      key={index + name + '_header'}
+                      sort={sortParams(index)}
+                    >
+                      {name}
+                    </Th>
+                  ) : (
+                    <Th width={width as BaseCellProps['width']} key={index + name + '_header'}>
+                      {name}
+                    </Th>
+                  ),
+                )}
+              </Tr>
+            </Thead>
+          </Hide>
+          {snapshotList.map(
+            (
+              {
+                uuid,
+                created_at,
+                content_counts,
+                added_counts,
+                removed_counts,
+                repository_name,
+                repository_uuid,
+              }: SnapshotItem,
+              rowIndex,
+            ) => (
+              <Tbody key={uuid + rowIndex + '-column'}>
+                <Tr>
+                  <Td>
+                    <Button
+                      variant='link'
+                      ouiaId='repository_edit_button'
+                      isInline
+                      onClick={() =>
+                        navigate(
+                          `${rootPath}/${REPOSITORIES_ROUTE}/edit?repoUUIDS=${repository_uuid}`,
+                        )
+                      }
+                    >
+                      {repository_name}
+                    </Button>
+                  </Td>
+                  <Td>{formatDateDDMMMYYYY(created_at, true)}</Td>
+                  <Td>
+                    <ChangedArrows
+                      addedCount={added_counts?.['rpm.package'] || 0}
+                      removedCount={removed_counts?.['rpm.package'] || 0}
+                    />
+                  </Td>
+                  <Td>
+                    <Button
+                      variant='link'
+                      ouiaId='snapshot_package_count_button'
+                      isInline
+                      isDisabled={!content_counts?.['rpm.package']}
+                      onClick={() =>
+                        navigate(
+                          `${rootPath}/${REPOSITORIES_ROUTE}/${repository_uuid}/snapshots/${uuid}`,
+                        )
+                      }
+                    >
+                      {content_counts?.['rpm.package'] || 0}
+                    </Button>
+                  </Td>
+                  <Td>
+                    <Button
+                      variant='link'
+                      ouiaId='snapshot_advisory_count_button'
+                      isInline
+                      isDisabled={!content_counts?.['rpm.advisory']}
+                      onClick={() =>
+                        navigate(
+                          `${rootPath}/${REPOSITORIES_ROUTE}/${repository_uuid}/snapshots/${uuid}?tab=${SnapshotDetailTab.ERRATA}`,
+                        )
+                      }
+                    >
+                      {content_counts?.['rpm.advisory'] || 0}
+                    </Button>
+                  </Td>
+                </Tr>
+              </Tbody>
+            ),
+          )}
+          <Hide hide={!isLoadingOrZeroCount}>
+            <EmptyTableState
+              notFiltered={!hasSearch}
+              clearFilters={clearSearch}
+              itemName='repositories'
+              notFilteredBody='You may need to add repositories that have snapshots.'
+            />
+          </Hide>
+        </Table>
+      </Hide>
+    </>
+  );
+}

--- a/src/Pages/Templates/TemplateDetails/components/Tables/TemplateRepositoriesTable.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tables/TemplateRepositoriesTable.tsx
@@ -25,14 +25,7 @@ import {
   ThProps,
   Tr,
 } from '@patternfly/react-table';
-import {
-  global_BackgroundColor_100,
-  global_danger_color_200,
-  global_success_color_200,
-} from '@patternfly/react-tokens';
-
-const red = global_danger_color_200.value;
-const green = global_success_color_200.value;
+import { global_BackgroundColor_100 } from '@patternfly/react-tokens';
 
 const useStyles = createUseStyles({
   mainContainer: {
@@ -41,13 +34,6 @@ const useStyles = createUseStyles({
     flexDirection: 'column',
     height: '100%',
   },
-  expansionBox: {
-    padding: '16px 0',
-  },
-  rightMargin: { marginRight: '6px' },
-  red: { extend: 'rightMargin', color: red },
-  green: { extend: 'rightMargin', color: green },
-  retainSpaces: { whiteSpace: 'pre-line' },
 });
 
 interface Props {

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateRepositoriesTab.test.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateRepositoriesTab.test.tsx
@@ -1,0 +1,61 @@
+import { render } from '@testing-library/react';
+
+import { defaultSnapshotItem } from 'testingHelpers';
+import TemplateRepositoriesTab from './TemplateRepositoriesTab';
+import { useFetchTemplateSnapshotsQuery } from 'services/Templates/TemplateQueries';
+import type { SnapshotItem } from 'services/Content/ContentApi';
+
+const bananaUUID = 'banana-uuid';
+
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({ templateUUID: bananaUUID }),
+  useNavigate: jest.fn(),
+  Outlet: () => <></>,
+}));
+
+jest.mock('dayjs', () => (value) => ({
+  fromNow: () => value,
+  format: () => value,
+  isBefore: () => value,
+}));
+
+jest.mock('Hooks/useRootPath', () => () => 'someUrl');
+
+jest.mock('react-query');
+
+jest.mock('services/Templates/TemplateQueries', () => ({
+  useFetchTemplateSnapshotsQuery: jest.fn(),
+}));
+
+(useFetchTemplateSnapshotsQuery as jest.Mock).mockImplementation(() => ({
+  isLoading: false,
+  isFetching: false,
+  data: {
+    data: new Array(15).fill(defaultSnapshotItem).map((item: SnapshotItem, index) => ({
+      ...item,
+      repository_name: item.repository_name + index,
+    })),
+    meta: { count: 15, limit: 20, offset: 0 },
+  },
+}));
+
+it('expect TemplateRepositoriesTab to render 15 items', async () => {
+  const { queryByText } = render(<TemplateRepositoriesTab />);
+
+  // Ensure the first row renders
+  expect(queryByText(defaultSnapshotItem.repository_name + 0)).toBeInTheDocument();
+  // Ensure the last row renders
+  expect(queryByText(defaultSnapshotItem.repository_name + 14)).toBeInTheDocument();
+});
+
+it('expect TemplateRepositoriesTab to render blank state', async () => {
+  (useFetchTemplateSnapshotsQuery as jest.Mock).mockImplementation(() => ({
+    isLoading: false,
+    isFetching: false,
+  }));
+
+  const { queryByText } = render(<TemplateRepositoriesTab />);
+
+  expect(queryByText('No repositories')).toBeInTheDocument();
+  expect(queryByText('You may need to add repositories that have snapshots.')).toBeInTheDocument();
+});

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateRepositoriesTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateRepositoriesTab.tsx
@@ -1,0 +1,171 @@
+import Loader from 'components/Loader';
+import { useEffect, useMemo, useState } from 'react';
+import { createUseStyles } from 'react-jss';
+import { useParams } from 'react-router-dom';
+
+import {
+  Flex,
+  FlexItem,
+  Grid,
+  InputGroup,
+  InputGroupItem,
+  InputGroupText,
+  Pagination,
+  PaginationVariant,
+  TextInput,
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+import { global_BackgroundColor_100, global_Color_200 } from '@patternfly/react-tokens';
+
+import { useFetchTemplateSnapshotsQuery } from 'services/Templates/TemplateQueries';
+import TemplateRepositoriesTable from 'Pages/Templates/TemplateDetails/components/Tables/TemplateRepositoriesTable';
+
+import type { ThProps } from '@patternfly/react-table';
+
+const useStyles = createUseStyles({
+  description: {
+    paddingTop: '12px', // 4px on the title bottom padding makes this the "standard" 16 total padding
+    paddingBottom: '8px',
+    color: global_Color_200.value,
+  },
+  mainContainer: {
+    backgroundColor: global_BackgroundColor_100.value,
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+  },
+  topContainer: {
+    justifyContent: 'space-between',
+    padding: '16px 24px',
+    height: 'fit-content',
+    minHeight: '68px', // Prevents compacting of the search box (patternfly bug?)
+  },
+  bottomContainer: {
+    justifyContent: 'space-between',
+    minHeight: '68px',
+  },
+});
+
+const perPageKey = 'TemplateRepositoriesPerPage';
+
+export default function TemplateRepositoriesTab() {
+  const classes = useStyles();
+  const { templateUUID: uuid } = useParams();
+  const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(storedPerPage);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [activeSortIndex, setActiveSortIndex] = useState<number>(-1);
+  const [activeSortDirection, setActiveSortDirection] = useState<'asc' | 'desc'>('asc');
+
+  const hasSearch = useMemo(() => !!searchQuery, [searchQuery]);
+  useEffect(() => {
+    setPage(1);
+  }, [hasSearch]);
+
+  const columnSortAttributes = ['repository_name', 'created_at'];
+  const sortString = useMemo(
+    () =>
+      activeSortIndex === -1
+        ? ''
+        : columnSortAttributes[activeSortIndex] + ':' + activeSortDirection,
+    [activeSortIndex, activeSortDirection],
+  );
+
+  const {
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    data = { data: [], meta: { count: 0, limit: 20, offset: 0 } },
+  } = useFetchTemplateSnapshotsQuery(uuid as string, page, perPage, searchQuery, sortString);
+
+  const onSetPage = (_, newPage) => setPage(newPage);
+  const onPerPageSelect = (_, newPerPage, newPage) => {
+    // Save this value through page refresh for use on next reload
+    setPerPage(newPerPage);
+    setPage(newPage);
+    localStorage.setItem(perPageKey, newPerPage.toString());
+  };
+
+  const {
+    data: snapshotList = [],
+    meta: { count = 0 },
+  } = data;
+
+  const fetchingOrLoading = isFetching || isLoading;
+  const loadingOrZeroCount = fetchingOrLoading || !count;
+
+  const sortParams = (columnIndex: number): ThProps['sort'] => ({
+    sortBy: {
+      index: activeSortIndex,
+      direction: activeSortDirection,
+      defaultDirection: 'asc',
+    },
+    onSort: (_event, index, direction) => {
+      setActiveSortIndex(index);
+      setActiveSortDirection(direction);
+    },
+    columnIndex,
+  });
+
+  if (isLoading) {
+    return <Loader />;
+  }
+  if (isError) {
+    throw error;
+  }
+
+  return (
+    <Grid className={classes.mainContainer}>
+      <InputGroup className={classes.topContainer}>
+        <InputGroupItem>
+          <TextInput
+            id='search'
+            ouiaId='name_search'
+            placeholder='Filter by repository name'
+            value={searchQuery}
+            onChange={(_event, value) => setSearchQuery(value)}
+          />
+          <InputGroupText id='search-icon'>
+            <SearchIcon />
+          </InputGroupText>
+        </InputGroupItem>
+        <Pagination
+          id='top-pagination-id'
+          widgetId='topPaginationWidgetId'
+          itemCount={count}
+          perPage={perPage}
+          page={page}
+          onSetPage={onSetPage}
+          isCompact
+          onPerPageSelect={onPerPageSelect}
+        />
+      </InputGroup>
+      <TemplateRepositoriesTable
+        isFetchingOrLoading={fetchingOrLoading}
+        isLoadingOrZeroCount={loadingOrZeroCount}
+        snapshotList={snapshotList}
+        clearSearch={() => setSearchQuery('')}
+        perPage={perPage}
+        sortParams={sortParams}
+        hasSearch={hasSearch}
+      />
+      <Flex className={classes.bottomContainer}>
+        <FlexItem />
+        <FlexItem>
+          <Pagination
+            id='bottom-pagination-id'
+            widgetId='bottomPaginationWidgetId'
+            itemCount={count}
+            perPage={perPage}
+            page={page}
+            onSetPage={onSetPage}
+            variant={PaginationVariant.bottom}
+            onPerPageSelect={onPerPageSelect}
+          />
+        </FlexItem>
+      </Flex>
+    </Grid>
+  );
+}

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateRepositoriesTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateRepositoriesTab.tsx
@@ -15,7 +15,7 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
-import { global_BackgroundColor_100, global_Color_200 } from '@patternfly/react-tokens';
+import { global_BackgroundColor_100 } from '@patternfly/react-tokens';
 
 import { useFetchTemplateSnapshotsQuery } from 'services/Templates/TemplateQueries';
 import TemplateRepositoriesTable from 'Pages/Templates/TemplateDetails/components/Tables/TemplateRepositoriesTable';
@@ -23,11 +23,6 @@ import TemplateRepositoriesTable from 'Pages/Templates/TemplateDetails/component
 import type { ThProps } from '@patternfly/react-table';
 
 const useStyles = createUseStyles({
-  description: {
-    paddingTop: '12px', // 4px on the title bottom padding makes this the "standard" 16 total padding
-    paddingBottom: '8px',
-    color: global_Color_200.value,
-  },
   mainContainer: {
     backgroundColor: global_BackgroundColor_100.value,
     display: 'flex',
@@ -123,7 +118,7 @@ export default function TemplateRepositoriesTab() {
           <TextInput
             id='search'
             ouiaId='name_search'
-            placeholder='Filter by repository name'
+            placeholder='Filter by name'
             value={searchQuery}
             onChange={(_event, value) => setSearchQuery(value)}
           />

--- a/src/Pages/Templates/TemplateDetails/components/TemplateDetailsTabs.test.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/TemplateDetailsTabs.test.tsx
@@ -18,4 +18,5 @@ it('expect TemplateDetailsTabs to render all tabs, and have Advisories selected'
   expect(queryByText('Advisories')).toBeInTheDocument();
   expect(queryByText('Systems')).toBeInTheDocument();
   expect(queryByText('Advisories')!.closest('button')).toHaveAttribute('aria-selected', 'true');
+  expect(queryByText('Repositories'))!.toBeInTheDocument();
 });

--- a/src/Pages/Templates/TemplateDetails/components/TemplateDetailsTabs.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/TemplateDetailsTabs.tsx
@@ -7,6 +7,7 @@ import {
   DETAILS_ROUTE,
   PACKAGES_ROUTE,
   SYSTEMS_ROUTE,
+  REPOSITORIES_ROUTE,
 } from 'Routes/constants';
 
 type ContentTabType = typeof CONTENT_ROUTE | typeof SYSTEMS_ROUTE;
@@ -69,6 +70,12 @@ export default function TemplateDetailsTabs() {
             ouiaId='advisories_tab'
             title={<TabTitleText>Advisories</TabTitleText>}
             aria-label='Template advisories detail tab'
+          />
+          <Tab
+            eventKey={REPOSITORIES_ROUTE}
+            ouiaId='repositories_tab'
+            title={<TabTitleText>Repositories</TabTitleText>}
+            aria-label='Template repositories detail tab'
           />
         </Tabs>
       </Tab>

--- a/src/Pages/Templates/TemplateDetails/components/TemplateDetailsTabs.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/TemplateDetailsTabs.tsx
@@ -11,7 +11,10 @@ import {
 } from 'Routes/constants';
 
 type ContentTabType = typeof CONTENT_ROUTE | typeof SYSTEMS_ROUTE;
-type ContentSubTabType = typeof PACKAGES_ROUTE | typeof ADVISORIES_ROUTE;
+type ContentSubTabType =
+  | typeof PACKAGES_ROUTE
+  | typeof ADVISORIES_ROUTE
+  | typeof REPOSITORIES_ROUTE;
 
 export default function TemplateDetailsTabs() {
   const { pathname } = useLocation();

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -39,6 +39,7 @@ import PopularRepositoriesTable from 'Pages/Repositories/PopularRepositoriesTabl
 import AdminTaskTable from 'Pages/Repositories/AdminTaskTable/AdminTaskTable';
 import ViewPayloadModal from 'Pages/Repositories/AdminTaskTable/components/ViewPayloadModal/ViewPayloadModal';
 import DeleteTemplateModal from 'Pages/Templates/TemplatesTable/components/DeleteTemplateModal';
+import TemplateRepositoriesTab from 'Pages/Templates/TemplateDetails/components/Tabs/TemplateRepositoriesTab';
 
 export default function RepositoriesRoutes() {
   const key = useMemo(() => Math.random(), []);
@@ -109,6 +110,7 @@ export default function RepositoriesRoutes() {
             <Route path='' element={<Navigate to={PACKAGES_ROUTE} replace />} />
             <Route path={PACKAGES_ROUTE} element={<TemplatePackageTab />} />
             <Route path={ADVISORIES_ROUTE} element={<TemplateErrataTab />} />
+            <Route path={REPOSITORIES_ROUTE} element={<TemplateRepositoriesTab />} />
             <Route path='*' element={<Navigate to={PACKAGES_ROUTE} replace />} />
           </Route>
           <Route path={SYSTEMS_ROUTE} element={<TemplateSystemsTab />}>

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -202,6 +202,8 @@ export interface SnapshotItem {
   content_counts: ContentCounts;
   added_counts: ContentCounts;
   removed_counts: ContentCounts;
+  repository_name: string;
+  repository_uuid: string;
 }
 
 export type SnapshotByDateResponse = {

--- a/src/services/Templates/TemplateApi.ts
+++ b/src/services/Templates/TemplateApi.ts
@@ -1,5 +1,11 @@
 import axios from 'axios';
-import { Links, Meta, type ErrataResponse, type PackageItem } from '../Content/ContentApi';
+import {
+  Links,
+  Meta,
+  type ErrataResponse,
+  type PackageItem,
+  SnapshotListResponse,
+} from '../Content/ContentApi';
 import { objectToUrlParams } from 'helpers';
 
 export interface TemplateRequest {
@@ -117,6 +123,30 @@ export const getTemplateErrata: (
       search,
       type: type.join(',').toLowerCase(),
       severity: severity.join(','),
+      sort_by: sortBy,
+    })}`,
+  );
+  return data;
+};
+
+export const getTemplateSnapshots: (
+  uuid: string,
+  page: number,
+  limit: number,
+  search: string,
+  sortBy: string,
+) => Promise<SnapshotListResponse> = async (
+  uuid: string,
+  page: number,
+  limit: number,
+  search: string,
+  sortBy: string,
+) => {
+  const { data } = await axios.get(
+    `/api/content-sources/v1/templates/${uuid}/snapshots/?${objectToUrlParams({
+      offset: ((page - 1) * limit).toString(),
+      limit: limit?.toString(),
+      repository_search: search,
       sort_by: sortBy,
     })}`,
   );

--- a/src/services/Templates/TemplateQueries.ts
+++ b/src/services/Templates/TemplateQueries.ts
@@ -15,15 +15,17 @@ import {
   type SnapshotRpmCollectionResponse,
   getTemplatePackages,
   getTemplateErrata,
+  getTemplateSnapshots,
 } from './TemplateApi';
 import useNotification from 'Hooks/useNotification';
 import { AlertVariant } from '@patternfly/react-core';
-import type { ErrataResponse } from 'services/Content/ContentApi';
+import { ErrataResponse, SnapshotListResponse } from 'services/Content/ContentApi';
 
 export const FETCH_TEMPLATE_KEY = 'FETCH_TEMPLATE_KEY';
 export const GET_TEMPLATES_KEY = 'GET_TEMPLATES_KEY';
 export const GET_TEMPLATE_PACKAGES_KEY = 'GET_TEMPLATE_PACKAGES_KEY';
 export const TEMPLATE_ERRATA_KEY = 'TEMPLATE_ERRATA_KEY';
+export const TEMPLATE_SNAPSHOTS_KEY = 'TEMPLATE_SNAPSHOTS_KEY';
 
 export const useEditTemplateQuery = (queryClient: QueryClient, request: EditTemplateRequest) => {
   const errorNotifier = useErrorNotification();
@@ -116,6 +118,32 @@ export const useFetchTemplateErrataQuery = (
           'An error occurred',
           err,
           'Template-errata-list-error',
+        );
+      },
+      keepPreviousData: true,
+      staleTime: 60000,
+    },
+  );
+};
+
+export const useFetchTemplateSnapshotsQuery = (
+  uuid: string,
+  page: number,
+  limit: number,
+  search: string,
+  sortBy: string,
+) => {
+  const errorNotifier = useErrorNotification();
+  return useQuery<SnapshotListResponse>(
+    [TEMPLATE_SNAPSHOTS_KEY, uuid, page, limit, search, sortBy],
+    () => getTemplateSnapshots(uuid, page, limit, search, sortBy),
+    {
+      onError: (err) => {
+        errorNotifier(
+          'Unable to find snapshots for the given template UUID.',
+          'An error occurred',
+          err,
+          'template-snapshots-list-error',
         );
       },
       keepPreviousData: true,

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -224,6 +224,8 @@ export const defaultSnapshotItem: SnapshotItem = {
     'rpm.packageenvironment': 1,
     'rpm.packagegroup': 1,
   },
+  repository_name: 'SteveTheRepo',
+  repository_uuid: '053603c7-6ef0-4abe-8542-feacb8f7d575',
 };
 
 export const defaultContentItemWithSnapshot: ContentItem = {


### PR DESCRIPTION
## Summary
This PR adds a new "Repositories" tab in the template detail view, which displays the snapshots of repositories contained in that template. With links to the repositories and it's packages and errata. 
\
![image](https://github.com/user-attachments/assets/60e2aea1-8637-4250-afc2-ce950a8f9e6e)

## Testing steps
1. Create two templates one with some custom repos in it and one without any.
2. Verify that when viewing the empty template there is a "No repositories" message and when you search the message changes to no repos found.
3. Verify that the template with custom repos has the snapshots for those repos listed in the new tab. You should also be able to filter them by the repo name and order by the repo name or the snapshot date. Also the links should all navigate to the right destinations as per the [issue description](https://issues.redhat.com/browse/HMS-4572).
