### PR TITLE
Fixes 4670: show last error and status for templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ Alternativly, simply add these lines to your /etc/hosts:
 
 4. `npm run build` (only required when setting up for the first time)
 
-5. `npm run start` to run against stage or prod environments. <br/>
+5. `npm run start` to choose whether to run against stage or prod environments. <br/>
+   OR <br/>
+   `npm run start:stage` to run against stage environment. <br/>
+   OR <br/>
+   `npm run start:prod` to run against prod environment. <br/>
    OR <br/>
    `npm run local` to run against a local backend running on port 8000. <br/>
    (keep in mind that you have to be connected to the VPN for this to work, even in the offices)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "format": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,md}' --config ./.prettierrc",
     "patch:hosts": "fec patch-etc-hosts",
     "start": "fec dev",
+    "start:stage": "fec dev --clouddotEnv=stage",
+    "start:prod": "fec dev --clouddotEnv=prod",
     "start:verbose": "VERBOSE=true fec dev",
     "local": "BACKEND_PORT=8000 npm start",
     "verify": "npm-run-all build lint test-ci",

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.test.tsx
@@ -3,6 +3,7 @@ import TemplatesTable from './TemplatesTable';
 import { useTemplateList } from 'services/Templates/TemplateQueries';
 import { ReactQueryTestWrapper, defaultTemplateItem } from 'testingHelpers';
 import { formatDateDDMMMYYYY } from 'helpers';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 jest.mock('services/Templates/TemplateQueries', () => ({
   useTemplateList: jest.fn(),
@@ -25,6 +26,14 @@ jest.mock('middleware/AppContext', () => ({
     rbac: { repoWrite: true, templateRead: true },
     setContentOrigin: () => {},
   }),
+}));
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: jest.fn(),
+}));
+
+(useChrome as jest.Mock).mockImplementation(() => ({
+  getEnvironment: () => 'stage',
 }));
 
 it('expect TemplatesTable to render empty state', () => {

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -297,9 +297,21 @@ const TemplatesTable = () => {
                 </Tr>
               </Thead>
               <Tbody>
-                {templateList.map((rowData: TemplateItem, index) => {
-                  const { uuid, name, description, arch, version, date, use_latest } = rowData;
-                  return (
+                {templateList.map(
+                  (
+                    {
+                      uuid,
+                      name,
+                      description,
+                      arch,
+                      version,
+                      date,
+                      use_latest,
+                      last_update_snapshot_error,
+                      last_update_task,
+                    }: TemplateItem,
+                    index,
+                  ) => (
                     <Tr key={uuid + index}>
                       <Td>
                         <Button
@@ -326,7 +338,11 @@ const TemplatesTable = () => {
                         </ConditionalTooltip>
                       </Td>
                       <Td>
-                        <StatusIcon rowData={rowData} />
+                        <StatusIcon
+                          uuid={uuid}
+                          last_update_snapshot_error={last_update_snapshot_error}
+                          last_update_task={last_update_task}
+                        />
                       </Td>
                       <Td>
                         <ConditionalTooltip
@@ -350,8 +366,8 @@ const TemplatesTable = () => {
                         </ConditionalTooltip>
                       </Td>
                     </Tr>
-                  );
-                })}
+                  ),
+                )}
               </Tbody>
             </Table>
             <Flex className={classes.bottomContainer}>

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -21,7 +21,7 @@ import {
   type BaseCellProps,
 } from '@patternfly/react-table';
 import { global_BackgroundColor_100 } from '@patternfly/react-tokens';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { createUseStyles } from 'react-jss';
 import { SkeletonTable } from '@patternfly/react-component-groups';
 import Hide from 'components/Hide/Hide';
@@ -37,6 +37,7 @@ import useRootPath from 'Hooks/useRootPath';
 import { DELETE_ROUTE, DETAILS_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
 import useArchVersion from 'Hooks/useArchVersion';
 import { useTemplateList } from 'services/Templates/TemplateQueries';
+import StatusIcon from './components/StatusIcon';
 
 const useStyles = createUseStyles({
   mainContainer: {
@@ -81,6 +82,8 @@ const TemplatesTable = () => {
   const [perPage, setPerPage] = useState(storedPerPage);
   const [activeSortIndex, setActiveSortIndex] = useState<number>(3); // queued_at
   const [activeSortDirection, setActiveSortDirection] = useState<'asc' | 'desc'>('desc');
+  const [polling, setPolling] = useState(false);
+  const [pollCount, setPollCount] = useState(0);
 
   const defaultValues: TemplateFilterData = {
     arch: '',
@@ -109,7 +112,33 @@ const TemplatesTable = () => {
     isError,
     isFetching,
     data = { data: [], meta: { count: 0, limit: 20, offset: 0 } },
-  } = useTemplateList(page, perPage, sortString, filterData);
+  } = useTemplateList(page, perPage, sortString, filterData, polling);
+
+  useEffect(() => {
+    if (isError) {
+      setPolling(false);
+      setPollCount(0);
+      return;
+    }
+    const containsPending = data?.data?.some(
+      ({ last_update_task }) =>
+        last_update_task?.status === 'running' || last_update_task?.status === 'pending',
+    );
+    if (polling && containsPending) {
+      // Count each consecutive time polling occurs
+      setPollCount(pollCount + 1);
+    }
+    if (polling && !containsPending) {
+      // We were polling, but now the data is valid, we stop the count.
+      setPollCount(0);
+    }
+    if (pollCount > 40) {
+      // If polling occurs 40 times in a row, we stop it. Likely a data/kafka issue has occurred with the API.
+      return setPolling(false);
+    }
+    // This sets the polling state based whether the data contains any "pending" or "running" status
+    return setPolling(containsPending);
+  }, [data?.data]);
 
   const onSetPage = (_, newPage: number) => setPage(newPage);
 
@@ -139,6 +168,7 @@ const TemplatesTable = () => {
     { title: 'Architecture', width: 10 },
     { title: 'Version', width: 10 },
     { title: 'Snapshot date', width: 15 },
+    { title: 'Status', width: 15 },
   ];
 
   const {
@@ -250,22 +280,26 @@ const TemplatesTable = () => {
             >
               <Thead>
                 <Tr>
-                  {columnHeaders.map(({ title, width }, index) => (
-                    <Th key={title + 'column'} width={width} sort={sortParams(index)}>
-                      {title}
-                    </Th>
-                  ))}
+                  {columnHeaders.map(({ title, width }, index) =>
+                    title === 'Status' ? (
+                      <Th key={title + 'column'} width={width}>
+                        {title}
+                      </Th>
+                    ) : (
+                      <Th key={title + 'column'} width={width} sort={sortParams(index)}>
+                        {title}
+                      </Th>
+                    ),
+                  )}
                   <Th className={classes.spinnerMinWidth}>
                     <Spinner size='md' className={actionTakingPlace ? '' : classes.invisible} />
                   </Th>
                 </Tr>
               </Thead>
               <Tbody>
-                {templateList.map(
-                  (
-                    { uuid, name, description, arch, version, date, use_latest }: TemplateItem,
-                    index,
-                  ) => (
+                {templateList.map((rowData: TemplateItem, index) => {
+                  const { uuid, name, description, arch, version, date, use_latest } = rowData;
+                  return (
                     <Tr key={uuid + index}>
                       <Td>
                         <Button
@@ -292,6 +326,9 @@ const TemplatesTable = () => {
                         </ConditionalTooltip>
                       </Td>
                       <Td>
+                        <StatusIcon rowData={rowData} />
+                      </Td>
+                      <Td>
                         <ConditionalTooltip
                           content='You do not have the required permissions to perform this action.'
                           show={!rbac?.templateWrite}
@@ -313,8 +350,8 @@ const TemplatesTable = () => {
                         </ConditionalTooltip>
                       </Td>
                     </Tr>
-                  ),
-                )}
+                  );
+                })}
               </Tbody>
             </Table>
             <Flex className={classes.bottomContainer}>

--- a/src/Pages/Templates/TemplatesTable/components/StatusIcon.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/StatusIcon.test.tsx
@@ -1,0 +1,86 @@
+import { render, waitFor } from '@testing-library/react';
+import StatusIcon from './StatusIcon';
+import {
+  defaultTemplateItem,
+  defaultUpdateTemplateTaskCompleted,
+  defaultUpdateTemplateTaskFailed,
+  defaultUpdateTemplateTaskRunning,
+} from 'testingHelpers';
+
+it('Render with Valid status', () => {
+  const { queryByText } = render(
+    <StatusIcon
+      rowData={{
+        ...defaultTemplateItem,
+        last_update_snapshot_error: '',
+        last_update_task: defaultUpdateTemplateTaskCompleted,
+      }}
+    />,
+  );
+
+  const SelectComponent = queryByText('Valid');
+  expect(SelectComponent).toBeInTheDocument();
+});
+
+it('Render with In progress status', () => {
+  const { queryByText } = render(
+    <StatusIcon
+      rowData={{
+        ...defaultTemplateItem,
+        last_update_snapshot_error: '',
+        last_update_task: defaultUpdateTemplateTaskRunning,
+      }}
+    />,
+  );
+
+  const SelectComponent = queryByText('In progress');
+  expect(SelectComponent).toBeInTheDocument();
+});
+
+it('Render with Invalid status with an error from the update-latest-snapshot task', async () => {
+  const { queryByText } = render(
+    <StatusIcon
+      rowData={{
+        ...defaultTemplateItem,
+        last_update_snapshot_error: 'error',
+        last_update_task: defaultUpdateTemplateTaskFailed,
+      }}
+    />,
+  );
+
+  const SelectComponent = queryByText('Invalid');
+  expect(SelectComponent).toBeInTheDocument();
+
+  await waitFor(() => {
+    SelectComponent?.click();
+  });
+
+  await waitFor(() => {
+    expect(
+      queryByText('An error occurred when updating the latest snapshot: error'),
+    ).toBeInTheDocument();
+  });
+});
+
+it('Render with Invalid status with an error from the update-template-content task', async () => {
+  const { queryByText } = render(
+    <StatusIcon
+      rowData={{
+        ...defaultTemplateItem,
+        last_update_snapshot_error: '',
+        last_update_task: defaultUpdateTemplateTaskFailed,
+      }}
+    />,
+  );
+
+  const SelectComponent = queryByText('Invalid');
+  expect(SelectComponent).toBeInTheDocument();
+
+  await waitFor(() => {
+    SelectComponent?.click();
+  });
+
+  await waitFor(() => {
+    expect(queryByText('An error occurred when updating the template: error')).toBeInTheDocument();
+  });
+});

--- a/src/Pages/Templates/TemplatesTable/components/StatusIcon.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/StatusIcon.test.tsx
@@ -6,6 +6,15 @@ import {
   defaultUpdateTemplateTaskFailed,
   defaultUpdateTemplateTaskRunning,
 } from 'testingHelpers';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: jest.fn(),
+}));
+
+(useChrome as jest.Mock).mockImplementation(() => ({
+  getEnvironment: () => 'stage',
+}));
 
 it('Render with Valid status', () => {
   const { queryByText } = render(

--- a/src/Pages/Templates/TemplatesTable/components/StatusIcon.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/StatusIcon.test.tsx
@@ -10,11 +10,9 @@ import {
 it('Render with Valid status', () => {
   const { queryByText } = render(
     <StatusIcon
-      rowData={{
-        ...defaultTemplateItem,
-        last_update_snapshot_error: '',
-        last_update_task: defaultUpdateTemplateTaskCompleted,
-      }}
+      uuid={defaultTemplateItem.uuid}
+      last_update_snapshot_error=''
+      last_update_task={defaultUpdateTemplateTaskCompleted}
     />,
   );
 
@@ -25,11 +23,9 @@ it('Render with Valid status', () => {
 it('Render with In progress status', () => {
   const { queryByText } = render(
     <StatusIcon
-      rowData={{
-        ...defaultTemplateItem,
-        last_update_snapshot_error: '',
-        last_update_task: defaultUpdateTemplateTaskRunning,
-      }}
+      uuid={defaultTemplateItem.uuid}
+      last_update_snapshot_error=''
+      last_update_task={defaultUpdateTemplateTaskRunning}
     />,
   );
 
@@ -40,11 +36,9 @@ it('Render with In progress status', () => {
 it('Render with Invalid status with an error from the update-latest-snapshot task', async () => {
   const { queryByText } = render(
     <StatusIcon
-      rowData={{
-        ...defaultTemplateItem,
-        last_update_snapshot_error: 'error',
-        last_update_task: defaultUpdateTemplateTaskFailed,
-      }}
+      uuid={defaultTemplateItem.uuid}
+      last_update_snapshot_error='error'
+      last_update_task={defaultUpdateTemplateTaskFailed}
     />,
   );
 
@@ -65,11 +59,9 @@ it('Render with Invalid status with an error from the update-latest-snapshot tas
 it('Render with Invalid status with an error from the update-template-content task', async () => {
   const { queryByText } = render(
     <StatusIcon
-      rowData={{
-        ...defaultTemplateItem,
-        last_update_snapshot_error: '',
-        last_update_task: defaultUpdateTemplateTaskFailed,
-      }}
+      uuid={defaultTemplateItem.uuid}
+      last_update_snapshot_error=''
+      last_update_task={defaultUpdateTemplateTaskFailed}
     />,
   );
 

--- a/src/Pages/Templates/TemplatesTable/components/StatusIcon.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/StatusIcon.tsx
@@ -27,7 +27,6 @@ const StatusIcon = ({ uuid, last_update_snapshot_error, last_update_task }: Prop
   const classes = useStyles();
   const { getEnvironment } = useChrome();
   const isInEphemeral = useMemo(() => getEnvironment() === 'qa', []);
-  console.log(getEnvironment());
 
   const showError = (
     snapshotError: string | undefined,

--- a/src/Pages/Templates/TemplatesTable/components/StatusIcon.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/StatusIcon.tsx
@@ -2,8 +2,8 @@ import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons'
 import { Button, Flex, FlexItem, Popover, Spinner, Tooltip } from '@patternfly/react-core';
 import StatusText from 'components/StatusText/StatusText';
 import { global_danger_color_100, global_success_color_100 } from '@patternfly/react-tokens';
-import { TemplateItem } from 'services/Templates/TemplateApi';
 import { createUseStyles } from 'react-jss';
+import { AdminTask } from 'services/AdminTasks/AdminTaskApi';
 
 const red = global_danger_color_100.value;
 const green = global_success_color_100.value;
@@ -16,16 +16,12 @@ const useStyles = createUseStyles({
 });
 
 interface Props {
-  rowData: TemplateItem;
+  uuid: string;
+  last_update_snapshot_error: string;
+  last_update_task: AdminTask | undefined;
 }
 
-interface DescriptionProps {
-  error?: string;
-}
-
-const PopoverDescription = ({ error }: DescriptionProps) => <div>{error}</div>;
-
-const StatusIcon = ({ rowData: { uuid, last_update_snapshot_error, last_update_task } }: Props) => {
+const StatusIcon = ({ uuid, last_update_snapshot_error, last_update_task }: Props) => {
   const classes = useStyles();
 
   const showError = (
@@ -93,11 +89,7 @@ const StatusIcon = ({ rowData: { uuid, last_update_snapshot_error, last_update_t
             alertSeverityVariant='danger'
             headerContent='Invalid'
             headerIcon={<ExclamationCircleIcon />}
-            bodyContent={
-              <PopoverDescription
-                error={showError(last_update_snapshot_error, last_update_task?.error)}
-              />
-            }
+            bodyContent={showError(last_update_snapshot_error, last_update_task?.error)}
             position='left'
           >
             <Button variant='link' isInline>

--- a/src/Pages/Templates/TemplatesTable/components/StatusIcon.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/StatusIcon.tsx
@@ -4,6 +4,8 @@ import StatusText from 'components/StatusText/StatusText';
 import { global_danger_color_100, global_success_color_100 } from '@patternfly/react-tokens';
 import { createUseStyles } from 'react-jss';
 import { AdminTask } from 'services/AdminTasks/AdminTaskApi';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import { useMemo } from 'react';
 
 const red = global_danger_color_100.value;
 const green = global_success_color_100.value;
@@ -23,6 +25,9 @@ interface Props {
 
 const StatusIcon = ({ uuid, last_update_snapshot_error, last_update_task }: Props) => {
   const classes = useStyles();
+  const { getEnvironment } = useChrome();
+  const isInEphemeral = useMemo(() => getEnvironment() === 'qa', []);
+  console.log(getEnvironment());
 
   const showError = (
     snapshotError: string | undefined,
@@ -38,9 +43,10 @@ const StatusIcon = ({ uuid, last_update_snapshot_error, last_update_task }: Prop
   };
 
   if (
-    last_update_task?.status === 'completed' &&
-    last_update_task?.error === '' &&
-    last_update_snapshot_error === ''
+    (last_update_task?.status === 'completed' &&
+      last_update_task?.error === '' &&
+      last_update_snapshot_error === '') ||
+    (last_update_snapshot_error === '' && isInEphemeral)
   ) {
     return (
       <Flex

--- a/src/Pages/Templates/TemplatesTable/components/StatusIcon.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/StatusIcon.tsx
@@ -1,0 +1,115 @@
+import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+import { Button, Flex, FlexItem, Popover, Spinner, Tooltip } from '@patternfly/react-core';
+import StatusText from 'components/StatusText/StatusText';
+import { global_danger_color_100, global_success_color_100 } from '@patternfly/react-tokens';
+import { TemplateItem } from 'services/Templates/TemplateApi';
+import { createUseStyles } from 'react-jss';
+
+const red = global_danger_color_100.value;
+const green = global_success_color_100.value;
+
+const useStyles = createUseStyles({
+  spinner: {
+    animationDuration: '6s !important',
+    margin: '-3px 0',
+  },
+});
+
+interface Props {
+  rowData: TemplateItem;
+}
+
+interface DescriptionProps {
+  error?: string;
+}
+
+const PopoverDescription = ({ error }: DescriptionProps) => <div>{error}</div>;
+
+const StatusIcon = ({ rowData: { uuid, last_update_snapshot_error, last_update_task } }: Props) => {
+  const classes = useStyles();
+
+  const showError = (
+    snapshotError: string | undefined,
+    updateTemplateError: string | undefined,
+  ) => {
+    if (!snapshotError && !updateTemplateError) {
+      return 'An unknown error occurred';
+    } else if (snapshotError) {
+      return `An error occurred when updating the latest snapshot: ${snapshotError}`;
+    } else if (updateTemplateError) {
+      return `An error occurred when updating the template: ${updateTemplateError}`;
+    }
+  };
+
+  if (
+    last_update_task?.status === 'completed' &&
+    last_update_task?.error === '' &&
+    last_update_snapshot_error === ''
+  ) {
+    return (
+      <Flex
+        key={`${uuid}`}
+        alignContent={{ default: 'alignContentCenter' }}
+        direction={{ default: 'row' }}
+      >
+        <FlexItem spacer={{ default: 'spacerSm' }}>
+          <CheckCircleIcon color={green} />
+        </FlexItem>
+        <FlexItem>
+          <StatusText color='green'>Valid</StatusText>
+        </FlexItem>
+      </Flex>
+    );
+  } else if (last_update_task?.status === 'pending' || last_update_task?.status === 'running') {
+    return (
+      <Tooltip position='top-start' content='Template update in progress'>
+        <Flex
+          key={`${uuid}`}
+          alignContent={{ default: 'alignContentCenter' }}
+          direction={{ default: 'row' }}
+        >
+          <FlexItem spacer={{ default: 'spacerSm' }}>
+            <Spinner size='md' className={classes.spinner} />
+          </FlexItem>
+          <FlexItem>
+            <StatusText color='blue'>In progress</StatusText>
+          </FlexItem>
+        </Flex>
+      </Tooltip>
+    );
+  } else {
+    return (
+      <Flex
+        key={`${uuid}`}
+        alignContent={{ default: 'alignContentCenter' }}
+        direction={{ default: 'row' }}
+      >
+        <FlexItem spacer={{ default: 'spacerSm' }}>
+          <ExclamationCircleIcon color={red} />
+        </FlexItem>
+        <FlexItem>
+          <Popover
+            aria-label='invalid popover'
+            alertSeverityVariant='danger'
+            headerContent='Invalid'
+            headerIcon={<ExclamationCircleIcon />}
+            bodyContent={
+              <PopoverDescription
+                error={showError(last_update_snapshot_error, last_update_task?.error)}
+              />
+            }
+            position='left'
+          >
+            <Button variant='link' isInline>
+              <StatusText color='red' isLink>
+                Invalid
+              </StatusText>
+            </Button>
+          </Popover>
+        </FlexItem>
+      </Flex>
+    );
+  }
+};
+
+export default StatusIcon;

--- a/src/services/Templates/TemplateApi.ts
+++ b/src/services/Templates/TemplateApi.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { Links, Meta, type ErrataResponse, type PackageItem } from '../Content/ContentApi';
 import { objectToUrlParams } from 'helpers';
+import { AdminTask } from 'services/AdminTasks/AdminTaskApi';
 
 export interface TemplateRequest {
   arch: string;
@@ -30,6 +31,9 @@ export interface TemplateItem {
   updated_at: string;
   created_by: string;
   last_updated_by: string;
+  last_update_task_uuid?: string;
+  last_update_task?: AdminTask;
+  last_update_snapshot_error: string;
 }
 
 export interface TemplateCollectionResponse {

--- a/src/services/Templates/TemplateQueries.ts
+++ b/src/services/Templates/TemplateQueries.ts
@@ -25,6 +25,8 @@ export const GET_TEMPLATES_KEY = 'GET_TEMPLATES_KEY';
 export const GET_TEMPLATE_PACKAGES_KEY = 'GET_TEMPLATE_PACKAGES_KEY';
 export const TEMPLATE_ERRATA_KEY = 'TEMPLATE_ERRATA_KEY';
 
+const TEMPLATE_LIST_POLLING_TIME = 15000; // 15 seconds
+
 export const useEditTemplateQuery = (queryClient: QueryClient, request: EditTemplateRequest) => {
   const errorNotifier = useErrorNotification();
   const { notify } = useNotification();
@@ -129,6 +131,7 @@ export const useTemplateList = (
   limit: number,
   sortBy: string,
   filterData: TemplateFilterData,
+  polling: boolean = false,
 ) => {
   const errorNotifier = useErrorNotification();
   return useQuery<TemplateCollectionResponse>(
@@ -144,6 +147,7 @@ export const useTemplateList = (
           'template-list-error',
         );
       },
+      refetchInterval: polling ? TEMPLATE_LIST_POLLING_TIME : undefined,
       keepPreviousData: true,
       staleTime: 20000,
     },

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -187,6 +187,39 @@ export const defaultContentItem: ContentItem = {
   last_introspection_status: 'Pending',
 };
 
+export const defaultUpdateTemplateTaskCompleted: AdminTask = {
+  uuid: 'a44540de-b8ce-4843-94ae-53b1f630ca93',
+  status: 'completed',
+  error: '',
+  org_id: '17684632',
+  queued_at: '2024-09-18T20:24:57Z',
+  started_at: '2024-09-18T20:24:57Z',
+  finished_at: '2024-09-18T20:25:57Z',
+  typename: 'update-template-content',
+};
+
+export const defaultUpdateTemplateTaskRunning: AdminTask = {
+  uuid: 'b44540de-b8ce-4843-94ae-53b1f630ca94',
+  status: 'running',
+  error: '',
+  org_id: '17684632',
+  queued_at: '2024-09-18T20:24:57Z',
+  started_at: '2024-09-18T20:24:57Z',
+  finished_at: '',
+  typename: 'update-template-content',
+};
+
+export const defaultUpdateTemplateTaskFailed: AdminTask = {
+  uuid: 'x44540de-b8ce-4843-94ae-53b1f630ca99',
+  status: 'failed',
+  error: 'error',
+  org_id: '17684632',
+  queued_at: '2024-09-18T20:24:57Z',
+  started_at: '2024-09-18T20:24:57Z',
+  finished_at: '2024-09-18T20:25:57Z',
+  typename: 'update-template-content',
+};
+
 export const defaultMetaItem: Meta = {
   limit: 10,
   offset: 0,
@@ -265,6 +298,9 @@ export const defaultTemplateItem: TemplateItem = {
   updated_at: '2024-01-22T00:00:00-07:00',
   created_by: 'Dudeguy',
   last_updated_by: 'Dudeguy',
+  last_update_snapshot_error: '',
+  last_update_task_uuid: '60412eda-7df5-4fac-8556-278f45e2ef9c',
+  last_update_task: defaultUpdateTemplateTaskCompleted,
 };
 
 // Template used for testing delete modal where repo is not in any templates
@@ -285,6 +321,7 @@ export const defaultTemplateItem2: TemplateItem = {
   updated_at: '2024-01-22T00:00:00-07:00',
   created_by: 'Dudeguy',
   last_updated_by: 'Dudeguy',
+  last_update_snapshot_error: '',
 };
 
 export const defaultSnapshotForDateItem: SnapshotForDate = {


### PR DESCRIPTION
## Summary

- Adds a status column to the template list page
- Displays any errors if there's an Invalid status

### Additional changes
- Also adds 2 commands to run the app against stage or prod (`npm run start:stage` and `npm run start:prod`) without needing to select from a menu - thank you @marusak for the suggestion!

## Testing steps

1. Add a custom and RH repository, let them snapshot, and create a template using latest content. The template status in the UI should change to In progress and then Valid once the update-template-content task completes.
2. Edit the custom repo URL used in the template to create a new snapshot. Once the snapshot finishes, stop the server and remove the pulp URL. Restart the server. The template status should now be Invalid and display the error from the update-latest-snapshot task when clicking on it.
3. Edit the template. The status should still be Invalid, with the error from the update-template-content task displayed on click.

For QE - it would be difficult to simulate an error here, so validating the happy path should be sufficient. I've added a check to see if we're in the ephemeral environment, so in ephemeral it will not depend on the task that only runs with candlepin enabled
