### PR TITLE
Refs 4151: remove support for YYYY-MM-DD date formats

### DIFF
--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
@@ -24,7 +24,7 @@ import { ContentItem, ContentOrigin } from 'services/Content/ContentApi';
 import { SkeletonTable } from '@patternfly/react-component-groups';
 import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip';
-import { formatDateForPicker, reduceStringToCharsWithEllipsis } from 'helpers';
+import { formatDateForPicker, formatTemplateDate, reduceStringToCharsWithEllipsis } from 'helpers';
 import UrlWithExternalIcon from 'components/UrlWithLinkIcon/UrlWithLinkIcon';
 import PackageCount from 'Pages/Repositories/ContentListTable/components/PackageCount';
 import { REPOSITORIES_ROUTE } from 'Routes/constants';
@@ -57,7 +57,7 @@ export default function SetUpDateStep() {
 
   const { data, mutateAsync } = useGetSnapshotsByDates(
     [...selectedRedhatRepos, ...selectedCustomRepos],
-    templateRequest?.date || '',
+    formatTemplateDate(templateRequest?.date || ''),
   );
 
   const dateValidators = [


### PR DESCRIPTION
## Summary

- Updates template request to format the date since [this PR](https://github.com/content-services/content-sources-backend/pull/839) removes support for YYYY-MM-DD date formats

## Testing steps

1. Run the backend on the main branch
2. Create a template and set a snapshot date, this should still work as expected
3. Check out [this PR](https://github.com/content-services/content-sources-backend/pull/839) and do the same. This should also work