### PR TITLE
Fixes 4826: prevent adding systems if env not yet created

### DIFF
--- a/src/Pages/Templates/TemplateDetails/components/AddSystems/AddSystemModal.test.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/AddSystems/AddSystemModal.test.tsx
@@ -2,7 +2,11 @@ import { render, waitFor } from '@testing-library/react';
 import AddSystemModal from './AddSystemModal';
 import { useQueryClient } from 'react-query';
 import { useSystemsListQuery } from 'services/Systems/SystemsQueries';
-import { defaultSystemsListItem } from 'testingHelpers';
+import {
+  defaultSystemsListItem,
+  defaultTemplateItem,
+  defaultUpdateTemplateTaskCompleted,
+} from 'testingHelpers';
 import type { SystemItem } from 'services/Systems/SystemsApi';
 
 const bananaUUID = 'banana-uuid';
@@ -18,7 +22,12 @@ jest.mock('react-query');
 
 beforeAll(() => {
   (useQueryClient as jest.Mock).mockImplementation(() => ({
-    getQueryData: () => ({ version: 1, name: 'Steve the template', arch: 'x86_64' }),
+    getQueryData: () => ({
+      version: 1,
+      name: 'Steve the template',
+      arch: 'x86_64',
+      last_update_task: defaultUpdateTemplateTaskCompleted,
+    }),
   }));
 });
 
@@ -36,6 +45,12 @@ jest.mock('middleware/AppContext', () => ({
   isFetching: false,
   isError: false,
   data: undefined,
+}));
+
+jest.mock('Hooks/useNotification', () => () => ({ notify: () => null }));
+
+jest.mock('services/Templates/TemplateQueries', () => ({
+  useFetchTemplate: () => ({ data: defaultTemplateItem }),
 }));
 
 it('expect AddSystemModal to render blank state', async () => {

--- a/src/Pages/Templates/TemplateDetails/components/AddSystems/AddSystemModal.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/AddSystems/AddSystemModal.tsx
@@ -155,9 +155,12 @@ export default function AddSystemModal() {
 
   const { data: template } = useFetchTemplate(uuid as string, true, polling);
 
-  const templatePending =
-    template?.last_update_task?.status === 'running' ||
-    template?.last_update_task?.status === 'pending';
+  const templatePending = useMemo(
+    () =>
+      template?.last_update_task?.status === 'running' ||
+      template?.last_update_task?.status === 'pending',
+    [template?.last_update_task],
+  );
 
   useEffect(() => {
     if (isError) {
@@ -176,7 +179,7 @@ export default function AddSystemModal() {
       return setPolling(false);
     }
     return setPolling(templatePending);
-  }, [template]);
+  }, [templatePending, isError]);
 
   useEffect(() => {
     if (
@@ -274,29 +277,31 @@ export default function AddSystemModal() {
       onClose={onClose}
       footer={
         <>
-          <ConditionalTooltip
-            content='Cannot assign this template to a system yet.'
-            show={!template?.rhsm_environment_created}
-            setDisabled
-          >
-            <Button
-              isLoading={isAdding}
-              isDisabled={
-                isAdding ||
-                !selected.length ||
-                (!template?.rhsm_environment_created &&
-                  template?.last_update_task?.status !== 'completed')
-              }
-              key='add_system'
-              variant='primary'
-              onClick={() => addSystems().then(onClose)}
+          <Flex gap={{ default: 'gapMd' }}>
+            <ConditionalTooltip
+              content='Cannot assign this template to a system yet.'
+              show={!template?.rhsm_environment_created}
+              setDisabled
             >
-              Assign
+              <Button
+                isLoading={isAdding}
+                isDisabled={
+                  isAdding ||
+                  !selected.length ||
+                  (!template?.rhsm_environment_created &&
+                    template?.last_update_task?.status !== 'completed')
+                }
+                key='add_system'
+                variant='primary'
+                onClick={() => addSystems().then(onClose)}
+              >
+                Assign
+              </Button>
+            </ConditionalTooltip>
+            <Button key='close' variant='secondary' onClick={onClose}>
+              Close
             </Button>
-          </ConditionalTooltip>
-          <Button key='close' variant='secondary' onClick={onClose}>
-            Close
-          </Button>
+          </Flex>
         </>
       }
     >

--- a/src/Pages/Templates/TemplateDetails/components/AddSystems/AddSystemModal.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/AddSystems/AddSystemModal.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertVariant,
   Bullseye,
   Button,
   Flex,
@@ -33,7 +34,7 @@ import {
 import EmptyTableState from 'components/EmptyTableState/EmptyTableState';
 import { useQueryClient } from 'react-query';
 import type { TemplateItem } from 'services/Templates/TemplateApi';
-import { FETCH_TEMPLATE_KEY } from 'services/Templates/TemplateQueries';
+import { FETCH_TEMPLATE_KEY, useFetchTemplate } from 'services/Templates/TemplateQueries';
 import Loader from 'components/Loader';
 import {
   DETAILS_ROUTE,
@@ -42,6 +43,8 @@ import {
   PATCH_SYSTEMS_ROUTE,
 } from 'Routes/constants';
 import ModalSystemsTable from './ModalSystemsTable';
+import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip';
+import useNotification from 'Hooks/useNotification';
 
 const useStyles = createUseStyles({
   description: {
@@ -91,6 +94,9 @@ export default function AddSystemModal() {
   const [searchQuery, setSearchQuery] = useState('');
   const [selected, setSelected] = useState<string[]>([]);
   const selectedList = useMemo(() => new Set(selected), [selected]);
+  const { notify } = useNotification();
+  const [pollCount, setPollCount] = useState(0);
+  const [polling, setPolling] = useState(false);
 
   useEffect(() => {
     if (!selectedList.size) {
@@ -146,6 +152,49 @@ export default function AddSystemModal() {
       onClose();
     }
   }, [isError]);
+
+  const { data: template } = useFetchTemplate(uuid as string, true, polling);
+
+  const templatePending =
+    template?.last_update_task?.status === 'running' ||
+    template?.last_update_task?.status === 'pending';
+
+  useEffect(() => {
+    if (isError) {
+      setPolling(false);
+      setPollCount(0);
+      return;
+    }
+
+    if (polling && templatePending) {
+      setPollCount(pollCount + 1);
+    }
+    if (polling && !templatePending) {
+      setPollCount(0);
+    }
+    if (pollCount > 40) {
+      return setPolling(false);
+    }
+    return setPolling(templatePending);
+  }, [template]);
+
+  useEffect(() => {
+    if (
+      (template?.rhsm_environment_created === false &&
+        template?.last_update_task?.status === 'failed') ||
+      (template?.rhsm_environment_created === false &&
+        template?.last_update_task?.status === 'completed')
+    ) {
+      notify({
+        title: 'Environment not created for template',
+        description:
+          'An error occurred when creating the environment. Cannot assign this template to a system.',
+        variant: AlertVariant.danger,
+        id: 'rhsm-environment-error',
+        dismissable: true,
+      });
+    }
+  }, [template?.last_update_task]);
 
   const onSetPage = (_, newPage) => setPage(newPage);
 
@@ -225,15 +274,26 @@ export default function AddSystemModal() {
       onClose={onClose}
       footer={
         <>
-          <Button
-            isLoading={isAdding}
-            isDisabled={isAdding || !selected.length}
-            key='add_system'
-            variant='primary'
-            onClick={() => addSystems().then(onClose)}
+          <ConditionalTooltip
+            content='Cannot assign this template to a system yet.'
+            show={!template?.rhsm_environment_created}
+            setDisabled
           >
-            Assign
-          </Button>
+            <Button
+              isLoading={isAdding}
+              isDisabled={
+                isAdding ||
+                !selected.length ||
+                (!template?.rhsm_environment_created &&
+                  template?.last_update_task?.status !== 'completed')
+              }
+              key='add_system'
+              variant='primary'
+              onClick={() => addSystems().then(onClose)}
+            >
+              Assign
+            </Button>
+          </ConditionalTooltip>
           <Button key='close' variant='secondary' onClick={onClose}>
             Close
           </Button>

--- a/src/services/Templates/TemplateApi.ts
+++ b/src/services/Templates/TemplateApi.ts
@@ -40,6 +40,7 @@ export interface TemplateItem {
   last_update_task_uuid?: string;
   last_update_task?: AdminTask;
   last_update_snapshot_error: string;
+  rhsm_environment_created: boolean;
 }
 
 export interface TemplateCollectionResponse {

--- a/src/services/Templates/TemplateQueries.ts
+++ b/src/services/Templates/TemplateQueries.ts
@@ -28,6 +28,7 @@ export const TEMPLATE_ERRATA_KEY = 'TEMPLATE_ERRATA_KEY';
 export const TEMPLATE_SNAPSHOTS_KEY = 'TEMPLATE_SNAPSHOTS_KEY';
 
 const TEMPLATE_LIST_POLLING_TIME = 15000; // 15 seconds
+const TEMPLATE_FETCH_POLLING_TIME = 5000; // 5 seconds
 
 export const useEditTemplateQuery = (queryClient: QueryClient, request: EditTemplateRequest) => {
   const errorNotifier = useErrorNotification();
@@ -57,7 +58,11 @@ export const useEditTemplateQuery = (queryClient: QueryClient, request: EditTemp
   });
 };
 
-export const useFetchTemplate = (uuid: string, enabled: boolean = true) => {
+export const useFetchTemplate = (
+  uuid: string,
+  enabled: boolean = true,
+  polling: boolean = false,
+) => {
   const errorNotifier = useErrorNotification();
   return useQuery<TemplateItem>([FETCH_TEMPLATE_KEY, uuid], () => fetchTemplate(uuid), {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -68,6 +73,7 @@ export const useFetchTemplate = (uuid: string, enabled: boolean = true) => {
         err,
         'fetch-template-error',
       ),
+    refetchInterval: polling ? TEMPLATE_FETCH_POLLING_TIME : undefined,
     keepPreviousData: true,
     staleTime: 20000,
     enabled,

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -301,6 +301,7 @@ export const defaultTemplateItem: TemplateItem = {
   last_update_snapshot_error: '',
   last_update_task_uuid: '60412eda-7df5-4fac-8556-278f45e2ef9c',
   last_update_task: defaultUpdateTemplateTaskCompleted,
+  rhsm_environment_created: true,
 };
 
 // Template used for testing delete modal where repo is not in any templates
@@ -322,6 +323,7 @@ export const defaultTemplateItem2: TemplateItem = {
   created_by: 'Dudeguy',
   last_updated_by: 'Dudeguy',
   last_update_snapshot_error: '',
+  rhsm_environment_created: true,
 };
 
 export const defaultSnapshotForDateItem: SnapshotForDate = {


### PR DESCRIPTION
## Summary

- Checks if environment is created (`rhsm_environment_created == true`) before allowing user to assign the template to a system
- Displays an error if the environment has not been created but the template's update task has finished
- (You will see some unintended behavior here when adding multiple templates until this [PR](https://github.com/content-services/content-sources-backend/pull/866) is merged)

## Testing steps

Since this depends on Patch's API, this needs to be tested on stage (`npm run start:stage`). You will also need to have [registered](https://github.com/content-services/content-sources-backend/blob/main/docs/register_client.md#registering-a-subscription-manager-client-to-stage-environment) at least one system on stage. This also cannot be tested in ephemeral as the task that sets the `rhsm_environment_created` flag depends on candlepin.

1. Create a template and select `Create template and add to systems` to navigate to the AddSystemModal
2. Select a system. The Assign button should be disabled for a few seconds and have a tooltip. Once the template's update task has finished and the environment was created, the button should be enabled
