### PR TITLE
Fixes 4717: Add icon to download latest snapshot

### DIFF
--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.test.tsx
@@ -14,6 +14,7 @@ jest.mock('services/Content/ContentQueries', () => ({
   useFetchContent: jest.fn(),
   useGetSnapshotList: jest.fn(),
   useGetRepoConfigFileQuery: () => ({ mutateAsync: jest.fn() }),
+  useGetLatestRepoConfigFileQuery: () => ({ mutateAsync: jest.fn() })
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -39,17 +40,18 @@ it('Render 1 item', () => {
     isLoading: false,
     isFetching: false,
   }));
-  const { queryByText } = render(
+  const { queryByText, queryAllByText } = render(
     <ReactQueryTestWrapper>
       <SnapshotListModal />
     </ReactQueryTestWrapper>,
   );
 
   expect(queryByText(defaultContentItemWithSnapshot.name)).toBeInTheDocument();
+  expect(queryByText('Latest')).toBeInTheDocument();
 
   expect(
-    queryByText((defaultSnapshotItem.content_counts['rpm.package'] as number)?.toString()),
-  ).toBeInTheDocument();
+    queryAllByText((defaultSnapshotItem.content_counts['rpm.package'] as number)?.toString()),
+  ).toHaveLength(2);
 });
 
 it('Render 20 items', () => {
@@ -73,15 +75,16 @@ it('Render 20 items', () => {
     isLoading: false,
     isFetching: false,
   }));
-  const { queryByText } = render(
+  const { queryByText, queryAllByText } = render(
     <ReactQueryTestWrapper>
       <SnapshotListModal />
     </ReactQueryTestWrapper>,
   );
 
   expect(queryByText(defaultContentItemWithSnapshot.name)).toBeInTheDocument();
+  expect(queryByText('Latest')).toBeInTheDocument();
 
   expect(
-    queryByText((defaultSnapshotItem.content_counts['rpm.package'] as number)?.toString()),
-  ).toBeInTheDocument();
+    queryAllByText((defaultSnapshotItem.content_counts['rpm.package'] as number)?.toString()),
+  ).toHaveLength(2);
 });

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/components/RepoConfig.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/components/RepoConfig.tsx
@@ -2,7 +2,8 @@ import { Button, Flex, FlexItem, Icon } from '@patternfly/react-core';
 import { createUseStyles } from 'react-jss';
 import { global_disabled_color_100 } from '@patternfly/react-tokens';
 
-import { useGetRepoConfigFileQuery } from 'services/Content/ContentQueries';
+import { useGetRepoConfigFileQuery, useGetLatestRepoConfigFileQuery } from 'services/Content/ContentQueries';
+
 import { CopyIcon, DownloadIcon } from '@patternfly/react-icons';
 
 const useStyles = createUseStyles({
@@ -18,12 +19,13 @@ const useStyles = createUseStyles({
 interface Props {
   repoUUID: string;
   snapUUID: string;
+  latest: boolean;
 }
 
-const RepoConfig = ({ repoUUID, snapUUID }: Props) => {
+const RepoConfig = ({ repoUUID, snapUUID, latest }: Props) => {
   const classes = useStyles();
 
-  const { mutateAsync } = useGetRepoConfigFileQuery(repoUUID, snapUUID);
+  const { mutateAsync } = latest ? useGetLatestRepoConfigFileQuery(repoUUID) : useGetRepoConfigFileQuery(repoUUID, snapUUID);
 
   const copyConfigFile = async () => {
     const data = await mutateAsync();

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -477,6 +477,15 @@ export const getRepoConfigFile: (snapshot_uuid: string) => Promise<string> = asy
   return data;
 };
 
+export const getLatestRepoConfigFile: (repoUUID: string) => Promise<string> = async (
+    repoUUID,
+) => {
+  const { data } = await axios.get(
+      `/api/content-sources/v1/repositories/${repoUUID}/config.repo`,
+  );
+  return data;
+};
+
 export const getSnapshotPackages: (
   snap_uuid: string,
   page: number,

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -39,7 +39,7 @@ import {
   type EditContentRequestItem,
   type ValidateContentRequestItem,
   addUploads,
-  type AddUploadRequest,
+  type AddUploadRequest, getLatestRepoConfigFile,
 } from './ContentApi';
 import { ADMIN_TASK_LIST_KEY } from '../AdminTasks/AdminTaskQueries';
 import useErrorNotification from 'Hooks/useErrorNotification';
@@ -55,6 +55,7 @@ export const SNAPSHOT_ERRATA_KEY = 'SNAPSHOT_ERRATA_KEY';
 export const LIST_SNAPSHOTS_KEY = 'LIST_SNAPSHOTS_KEY';
 export const CONTENT_ITEM_KEY = 'CONTENT_ITEM_KEY';
 export const REPO_CONFIG_FILE_KEY = 'REPO_CONFIG_FILE_KEY';
+export const LATEST_REPO_CONFIG_FILE_KEY = 'LATEST_REPO_CONFIG_FILE_KEY';
 
 const CONTENT_LIST_POLLING_TIME = 15000; // 15 seconds
 
@@ -793,5 +794,24 @@ export const useGetRepoConfigFileQuery = (repo_uuid: string, snapshot_uuid: stri
         );
       },
     },
+  );
+};
+
+export const useGetLatestRepoConfigFileQuery = (repo_uuid: string) => {
+  const errorNotifier = useErrorNotification();
+  return useMutation<string>(
+      [LATEST_REPO_CONFIG_FILE_KEY, repo_uuid],
+      async () => await getLatestRepoConfigFile(repo_uuid),
+      {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onError: (err: any) => {
+          errorNotifier(
+              'Unable to find config.repo with the given UUID.',
+              'An error occurred',
+              err,
+              'repo-config-error',
+          );
+        },
+      },
   );
 };


### PR DESCRIPTION
## Summary
Depends on this backend PR: https://github.com/content-services/content-sources-backend/pull/844. Leaving as draft until the backend PR is finished.

Adds a "Latest" snapshot row to the snapshots list modal


## Testing steps
1. Create a custom repository and wait for snapshot
2. View the snapshots list
3. There will be 2 rows, "Latest" and the Snapshot with the date
4. Change the URL of the repository and wait for snapshot
5. View the snapshots list
6. The Latest row should represent the newer snapshot
7. Try sorting by date, the Latest row should be unaffected
