### PR TITLE
Build: Removes the maxUploadSize for uploaded items

### DIFF
--- a/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
@@ -28,7 +28,6 @@ import {
   isValidURL,
   mapFormikToAPIValues,
   validationSchema,
-  maxUploadSize,
   failedFileUpload,
   getDefaultValues,
   mapValidationData,
@@ -690,7 +689,6 @@ const AddContent = ({ isEdit = false }: Props) => {
               onTextChange={(_event, value) => updateGpgKey(value)}
               onClearClick={() => updateVariable({ gpgKey: '' })}
               dropzoneProps={{
-                maxSize: maxUploadSize,
                 onDropRejected: (files) => failedFileUpload(files, notify),
               }}
               allowEditingUploadedText

--- a/src/Pages/Repositories/ContentListTable/components/AddContent/helpers.test.ts
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/helpers.test.ts
@@ -7,7 +7,6 @@ import {
   isValidURL,
   mapFormikToAPIValues,
   mapValidationData,
-  maxUploadSize,
 } from './helpers';
 
 it('REGEX_URL', () => {
@@ -110,24 +109,6 @@ it('mapValidationData, ensure url error heirarchy', () => {
   };
 
   expect(mapValidationData(validationData, formikErrors)).toEqual(success);
-});
-
-it('Notifies on file upload failure due to size', () => {
-  const notif = jest.fn((payload) => payload);
-  const file = new File([''], 'filename', { type: 'text/html' });
-  Object.defineProperty(file, 'size', { value: maxUploadSize + 1 });
-
-  failedFileUpload(
-    [
-      {
-        file,
-        errors: [],
-      },
-    ],
-    notif,
-  );
-  expect(notif.mock.calls).toHaveLength(1);
-  expect(notif.mock.calls[0][0].description).toMatch(/file is larger than/);
 });
 
 it('Notifies on file upload failure due to too many files', () => {

--- a/src/Pages/Repositories/ContentListTable/components/AddContent/helpers.ts
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/helpers.ts
@@ -164,8 +164,6 @@ export const validationSchema = (upload?: boolean) =>
       : { url: Yup.string().url('Invalid URL').required('Required').min(2, 'Too Short!') }),
   });
 
-export const maxUploadSize = 32000;
-
 export const failedFileUpload = (
   files: FileRejection[],
   notify: (arg: NotificationPayload) => void,
@@ -173,8 +171,6 @@ export const failedFileUpload = (
   let description = 'Check the file and try again.';
   if (files.length != 1) {
     description = 'Only a single file upload is supported.';
-  } else if (files[0].file.size > maxUploadSize) {
-    description = 'The file is larger than ' + maxUploadSize + ' bytes.';
   }
   notify({
     variant: AlertVariant.danger,


### PR DESCRIPTION
## Summary

- Removes the maxUploadSize for uploaded items
- This was only limiting "drag and drop" files from being uploaded.

As we are now breaking down large uploads into 3mb blocks for upload, file size will likely only be limited by browser/processing power to calculate the hash of the file.

No hard limits are set in our upload components, as of this PR.

## Testing steps
