### PR TITLE
Fixes 4763: Add hover text pop up in Edit rpm upload modal

### DIFF
--- a/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
@@ -490,29 +490,37 @@ const AddContent = ({ isEdit = false }: Props) => {
                   onClick={() =>
                     setValues({ ...values, snapshot: false, origin: ContentOrigin.EXTERNAL })
                   }
-                />{' '}
+                />
               </Hide>
               <Hide hide={isInProd || (isEdit && contentOrigin === ContentOrigin.EXTERNAL)}>
-                <Radio
-                  isChecked={isUploadRepo}
-                  id='upload_radio'
-                  label='Upload'
-                  isDisabled={isEdit && contentOrigin === ContentOrigin.UPLOAD}
-                  description={
-                    isUploadRepo
-                      ? 'Create a repository to upload custom content to. Snapshots will be taken after every new upload, allowing you to build images with uploaded content.'
-                      : ''
-                  }
-                  name='upload-radio'
-                  onClick={() =>
-                    setValues({
-                      ...values,
-                      url: '',
-                      snapshot: true,
-                      origin: ContentOrigin.UPLOAD,
-                    })
-                  }
-                />
+                <ConditionalTooltip
+                  show={isEdit && contentOrigin === ContentOrigin.UPLOAD}
+                  setDisabled={isEdit && contentOrigin === ContentOrigin.UPLOAD}
+                  position='top-start'
+                  enableFlip
+                  flipBehavior={['top-start', 'bottom-start']}
+                  content="Repository type cannot be changed for 'Upload' repositories"
+                >
+                  <Radio
+                    isChecked={isUploadRepo}
+                    id='upload_radio'
+                    label='Upload'
+                    description={
+                      isUploadRepo
+                        ? 'Create a repository to upload custom content to. Snapshots will be taken after every new upload, allowing you to build images with uploaded content.'
+                        : ''
+                    }
+                    name='upload-radio'
+                    onClick={() =>
+                      setValues({
+                        ...values,
+                        url: '',
+                        snapshot: true,
+                        origin: ContentOrigin.UPLOAD,
+                      })
+                    }
+                  />
+                </ConditionalTooltip>
               </Hide>
             </Flex>
 


### PR DESCRIPTION
## Summary

- Adds hover text pop up in Edit rpm upload modal

![Screenshot 2024-10-28 at 3 29 08 PM](https://github.com/user-attachments/assets/3ccf89fa-71a0-4ca5-ad25-885cdb06964b)


## Testing steps

- Open edit modal for a upload repository, hover to see the new messaging.