### PR TITLE
Fixes 4918: missing invalidation on introspection

### DIFF
--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -757,6 +757,7 @@ export const useIntrospectRepositoryMutate = (
         });
       }
       queryClient.invalidateQueries(ADMIN_TASK_LIST_KEY);
+      queryClient.invalidateQueries(CONTENT_LIST_KEY);
     },
     // If the mutation fails, use the context returned from onMutate to roll back
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

Adds an invalidation of the content list to the introspect query. Without this we may see cached results in the UI after a successful introspection.

## Testing steps

1. Create 2 repos of type Introspect only
2. Introspect one of the repos via the action in the kebab. Once the status becomes valid, you should see the Last Introspection time for both repos updated