### PR TITLE
Fixes 4913: Update zero-state button to PF5

### DIFF
--- a/src/components/ZeroState/ZeroState.tsx
+++ b/src/components/ZeroState/ZeroState.tsx
@@ -112,7 +112,7 @@ export const ZeroState = () => {
               <Button
                 id='get-started-repositories-button'
                 ouiaId='get_started_repositories_button'
-                className='pf-c-button pf-m-primary pf-u-p-md pf-u-font-size-md'
+                className='pf-v5-u-p-md pf-v5-u-font-size-md'
                 onClick={() => handleMainButtonClick()}
               >
                 Add repositories now


### PR DESCRIPTION
Catch up with other zero states, see https://github.com/RedHatInsights/insights-dashboard/blob/5bf9f1bdbc7720de71dff7dc5a11ffb60b0b2b6b/src/PresentationalComponents/ZeroState/ZeroStateBanner.js#L111

Before:
![Screenshot from 2024-10-31 17-58-15](https://github.com/user-attachments/assets/a2bdb9bf-3b9f-4ffd-b1ec-d899e3834733)

Now:
![Screenshot from 2024-10-31 17-55-50](https://github.com/user-attachments/assets/2574f6cc-0469-4854-a1b9-aebdf5e32d04)


Other places:
![Screenshot from 2024-10-31 17-58-30](https://github.com/user-attachments/assets/d13cebb2-e8bd-4f3d-9176-424bfe1bb96a)