### PR TITLE
Build: add konflux workaround

### DIFF
--- a/.tekton/content-sources-frontend-pull-request.yaml
+++ b/.tekton/content-sources-frontend-pull-request.yaml
@@ -366,6 +366,7 @@ spec:
         value: $(params.build-args-file)
       runAfter:
       - prefetch-dependencies
+      - create-frontend-dockerfile
       taskRef:
         params:
         - name: name

--- a/.tekton/content-sources-frontend-push.yaml
+++ b/.tekton/content-sources-frontend-push.yaml
@@ -363,6 +363,7 @@ spec:
         value: $(params.build-args-file)
       runAfter:
       - prefetch-dependencies
+      - create-frontend-dockerfile
       taskRef:
         params:
         - name: name

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Workaround needed for Konflux pipeline to pass
+
+DEL_DIR="./source/source/"
+if [ -d "$DEL_DIR" ]; then rm -Rf $DEL_DIR; fi
+
+setNpmOrYarn
+install
+build
+if [ "$IS_PR" == true ]; then
+    verify
+else
+    export BETA=false
+    build
+    source build_app_info.sh
+    mv ${DIST_FOLDER} stable
+    export BETA=true
+    # export sentry specific variables
+    export SENTRY_AUTH_TOKEN SENTRY_DSN SENTRY_ORG SENTRY_PROJECT
+    build
+    source build_app_info.sh
+    mv ${DIST_FOLDER} preview
+    mkdir -p ${DIST_FOLDER}
+    mv stable ${DIST_FOLDER}/stable
+    mv preview ${DIST_FOLDER}/preview
+fi
+
+# End workaround
+


### PR DESCRIPTION
## Summary

* make the build-container step dependent on the  build-dockerfile step
* adds a workaround to delete duplicate source code in the tree

## Testing steps
