### PR TITLE
"not (subscription or introspection)"

### DIFF
--- a/.rhcicd/pr_check.sh
+++ b/.rhcicd/pr_check.sh
@@ -24,7 +24,7 @@ COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-fronten
 # --------------------------------------------
 export IQE_PLUGINS="content-sources"
 export IQE_MARKER_EXPRESSION="smoke and ui"
-export IQE_FILTER_EXPRESSION=""
+export IQE_FILTER_EXPRESSION="not (subscription or introspection)"
 export IQE_ENV="ephemeral"
 export IQE_SELENIUM="true"
 export IQE_CJI_TIMEOUT="60m"


### PR DESCRIPTION
## Summary

Inhibiting subscription test because the fronted pr check runs in ephemeral which does not support real users and subscriptions. Also inhibiting introspection tests as that is not relevant to UI changes.

## Testing steps

tests pass
