### PR TITLE
HMS-5039: eliminates re-uploads of finished uploads

### DIFF
--- a/src/Pages/Repositories/ContentListTable/components/UploadContent/UploadContent.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/UploadContent/UploadContent.test.tsx
@@ -20,7 +20,7 @@ it('Render base upload modal', async () => {
 
   jest
     .spyOn(React, 'useState')
-    .mockImplementationOnce(() => realUseState([{ sha256: 'string', uuid: 'string' }] as unknown))
+    .mockImplementationOnce(() => realUseState([{ sha256: 'string', uuid: 'string', href: '' }] as unknown))
     .mockImplementationOnce(() => realUseState(true as unknown));
 
   const { queryByText } = render(<UploadContent />);

--- a/src/Pages/Repositories/ContentListTable/components/UploadContent/UploadContent.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/UploadContent/UploadContent.tsx
@@ -25,7 +25,7 @@ const useStyles = createUseStyles({
 const UploadContent = () => {
   const classes = useStyles();
   const { repoUUID: uuid } = useParams();
-  const [fileUUIDs, setFileUUIDs] = useState<{ sha256: string; uuid: string }[]>([]);
+  const [fileUUIDs, setFileUUIDs] = useState<{ sha256: string; uuid: string; href: string }[]>([]);
   const [confirmModal, setConfirmModal] = useState(false);
 
   const rootPath = useRootPath();
@@ -37,7 +37,18 @@ const UploadContent = () => {
 
   const { mutateAsync: uploadItems, isLoading } = useAddUploadsQuery({
     repoUUID: uuid!,
-    uploads: fileUUIDs,
+    uploads: fileUUIDs
+      .filter((f) => f.href.length == 0)
+      .map((f) => ({
+        sha256: f.sha256,
+        uuid: f.uuid,
+      })),
+    artifacts: fileUUIDs
+      .filter((f) => f.href.length > 0)
+      .map((f) => ({
+        sha256: f.sha256,
+        href: f.href,
+      })),
   });
 
   return (

--- a/src/Pages/Repositories/ContentListTable/components/UploadContent/components/helpers.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/UploadContent/components/helpers.tsx
@@ -40,6 +40,7 @@ export type FileInfo = {
   created: string;
   chunks: Chunk[];
   checksum: string;
+  artifactHref?: string;
   error?: string;
   completed?: boolean;
   failed?: boolean;

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -258,6 +258,7 @@ export interface UploadChunkRequest {
 
 export interface AddUploadRequest {
   uploads: { sha256: string; uuid: string }[];
+  artifacts: { sha256: string; href: string }[];
   repoUUID: string;
 }
 
@@ -272,6 +273,15 @@ export interface AddUploadResponse {
   object_type: string;
   object_name: string;
   object_uuid: string;
+}
+
+export interface SearchUploadsRequest {
+  sha256: string[];
+}
+
+export interface SearchUploadsResponse {
+  found: Map<string, string>;
+  missing: string[];
 }
 
 export const getPopularRepositories: (
@@ -561,11 +571,25 @@ export const uploadChunk: (chunkRequest: UploadChunkRequest) => Promise<UploadRe
 
 export const addUploads: (chunkRequest: AddUploadRequest) => Promise<AddUploadResponse> = async ({
   uploads,
+  artifacts,
   repoUUID,
 }) => {
   const { data } = await axios.post(
     `/api/content-sources/v1.0/repositories/${repoUUID}/add_uploads/`,
-    { uploads },
+    {
+      uploads: uploads,
+      artifacts: artifacts,
+    },
   );
+  return data;
+};
+
+export const searchUploads: (
+  searchRequest: SearchUploadsRequest,
+) => Promise<SearchUploadsResponse> = async (hashes) => {
+  const { data } = await axios.post('/api/content-sources/v1/repositories/uploads/search', {
+    sha256: hashes.sha256,
+  });
+  data.found = new Map<string, string>(Object.entries(data.found));
   return data;
 };


### PR DESCRIPTION
## Summary
> DRAFT until it is decided how we want solve the problem with interrupted uploads. 

This PR adds a check before the upload of a file to see, if there is an artifact in pulp with the same hash and that's the case it skips the upload and sets the artifact href for it, which then can be used to add the file to the repo.

## Testing steps
1. Create 2 upload repositories.
2. Upload a big file to one of the repos (more than one chunk at least).
3. Let it upload and confirm the upload.
4. Try uploading the same file to the other repo and verify that the upload was skipped and the file can be added.
