### PR TITLE
Build: Add open source badge

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,5 +1,6 @@
 import { Text } from '@patternfly/react-core';
 import {
+  OpenSourceBadge,
   PageHeader as _PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components';
@@ -37,7 +38,14 @@ export default function Header({ title, ouiaId, paragraph }: Props) {
 
   return (
     <PageHeader>
-      <PageHeaderTitle title={title} className={classes.remove100percent} />
+      <PageHeaderTitle title={
+        <>
+        {title}
+        <OpenSourceBadge
+            repositoriesURL='https://github.com/content-services/content-sources-frontend'
+        />
+        </>
+        } className={classes.remove100percent} />
       <Text className={classes.subtext} ouiaId={ouiaId}>
         {paragraph}
       </Text>


### PR DESCRIPTION
Add an 'open source' badge that let's anyone coming to the service easily discover the source code associated with it. Ideally we'd redirect to a page similar to the one Image Builder has that shows the architecture and has more docs. As a starting point, the frontend repository may be ok.

This is what it looks like:
![image](https://github.com/user-attachments/assets/21164bd9-dec3-4ec2-a2aa-639db9c055a5)

Note: I hardcoded the page title to 'Repositories' - not sure if that's desirable.