### PR TITLE
HMS-5126: Add support for resume/skip uploads

### DIFF
--- a/src/Hooks/useIsEphemeralEnv.tsx
+++ b/src/Hooks/useIsEphemeralEnv.tsx
@@ -1,6 +1,8 @@
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import { useMemo } from 'react';
 
 export default function useIsEphemeralEnv(): boolean {
   const { getEnvironment } = useChrome();
-  return getEnvironment() === 'qa';
+  const isQe = useMemo(() => getEnvironment() === 'qa', []);
+  return isQe;
 }

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable quotes */
 import {
   Button,
   Flex,

--- a/src/Pages/Repositories/ContentListTable/components/UploadContent/UploadContent.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/UploadContent/UploadContent.tsx
@@ -25,7 +25,7 @@ const useStyles = createUseStyles({
 const UploadContent = () => {
   const classes = useStyles();
   const { repoUUID: uuid } = useParams();
-  const [fileUUIDs, setFileUUIDs] = useState<{ sha256: string; uuid: string }[]>([]);
+  const [fileUUIDs, setFileUUIDs] = useState<{ sha256: string; uuid: string; href: string }[]>([]);
   const [confirmModal, setConfirmModal] = useState(false);
 
   const rootPath = useRootPath();
@@ -37,7 +37,18 @@ const UploadContent = () => {
 
   const { mutateAsync: uploadItems, isLoading } = useAddUploadsQuery({
     repoUUID: uuid!,
-    uploads: fileUUIDs,
+    uploads: fileUUIDs
+      .filter(({ href }) => !href)
+      .map(({ sha256, uuid }) => ({
+        sha256,
+        uuid,
+      })),
+    artifacts: fileUUIDs
+      .filter(({ href }) => href)
+      .map(({ sha256, href }) => ({
+        sha256,
+        href,
+      })),
   });
 
   return (

--- a/src/Pages/Repositories/ContentListTable/components/UploadContent/components/UploadStatusItem.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/UploadContent/components/UploadStatusItem.tsx
@@ -37,6 +37,7 @@ export interface MultipleFileUploadStatusItemProps extends React.HTMLProps<HTMLL
   maxFileNameLength?: number;
   fileSize?: number;
   progressValue: number;
+  progressLabel?: React.ReactNode;
   progressVariant?: 'danger' | 'success' | 'warning';
   progressAriaLabel?: string;
   progressAriaLabelledBy?: string;
@@ -56,6 +57,7 @@ export default function UploadStatusItem({
   maxFileNameLength = 50,
   fileSize,
   progressValue,
+  progressLabel,
   progressVariant,
   progressAriaLabel,
   progressAriaLabelledBy,
@@ -108,6 +110,7 @@ export default function UploadStatusItem({
             </span>
           }
           value={progressValue}
+          label={progressLabel}
           variant={progressVariant}
           aria-label={progressAriaLabel}
           aria-labelledby={progressAriaLabelledBy}

--- a/src/Pages/Repositories/ContentListTable/components/UploadContent/components/helpers.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/UploadContent/components/helpers.tsx
@@ -1,5 +1,11 @@
 import CryptoJS from 'crypto-js';
 
+export const MAX_CHUNK_SIZE = 1048576 * 3; // MB
+
+export const BATCH_SIZE = 5;
+
+export const MAX_RETRY_COUNT = 3;
+
 const readSlice = (file: File, start: number, size: number): Promise<Uint8Array> =>
   new Promise<Uint8Array>((resolve, reject) => {
     const fileReader = new FileReader();
@@ -28,6 +34,9 @@ export const getFileChecksumSHA256 = async (file: File): Promise<string> => {
 };
 
 export type Chunk = {
+  slice: Blob;
+  sha256: string;
+  chunkRange: string;
   start: number;
   end: number;
   queued: boolean;
@@ -38,10 +47,12 @@ export type Chunk = {
 export type FileInfo = {
   uuid: string;
   created: string;
+  artifact: string;
   chunks: Chunk[];
   checksum: string;
+  file: File;
   error?: string;
   completed?: boolean;
   failed?: boolean;
-  file: File;
+  isResumed?: boolean;
 };

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { objectToUrlParams } from 'helpers';
 import { AdminTask } from '../AdminTasks/AdminTaskApi';
+import { MAX_CHUNK_SIZE } from 'Pages/Repositories/ContentListTable/components/UploadContent/components/helpers';
 
 export interface ContentItem {
   uuid: string;
@@ -241,11 +242,13 @@ export type IntrospectRepositoryRequestItem = {
 };
 
 export interface UploadResponse {
-  completed: string;
-  created: string;
-  last_updated: string;
+  completed_checksums?: string[];
+  artifact_href?: string;
+  completed?: string;
+  created?: string;
+  last_updated?: string;
   size: number;
-  upload_uuid: string;
+  upload_uuid?: string;
 }
 
 export interface UploadChunkRequest {
@@ -258,6 +261,7 @@ export interface UploadChunkRequest {
 
 export interface AddUploadRequest {
   uploads: { sha256: string; uuid: string }[];
+  artifacts: { sha256: string; href: string }[];
   repoUUID: string;
 }
 
@@ -544,8 +548,15 @@ export const getSnapshotErrata: (
   return data;
 };
 
-export const createUpload: (size: number) => Promise<UploadResponse> = async (size) => {
-  const { data } = await axios.post('/api/content-sources/v1.0/repositories/uploads/', { size });
+export const createUpload: (size: number, sha256: string) => Promise<UploadResponse> = async (
+  size,
+  sha256,
+) => {
+  const { data } = await axios.post('/api/content-sources/v1.0/repositories/uploads/', {
+    size,
+    sha256,
+    chunkSize: MAX_CHUNK_SIZE,
+  });
   return data;
 };
 
@@ -568,11 +579,12 @@ export const uploadChunk: (chunkRequest: UploadChunkRequest) => Promise<UploadRe
 
 export const addUploads: (chunkRequest: AddUploadRequest) => Promise<AddUploadResponse> = async ({
   uploads,
+  artifacts,
   repoUUID,
 }) => {
   const { data } = await axios.post(
     `/api/content-sources/v1.0/repositories/${repoUUID}/add_uploads/`,
-    { uploads },
+    { uploads, artifacts },
   );
   return data;
 };

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -555,7 +555,7 @@ export const createUpload: (size: number, sha256: string) => Promise<UploadRespo
   const { data } = await axios.post('/api/content-sources/v1.0/repositories/uploads/', {
     size,
     sha256,
-    chunkSize: MAX_CHUNK_SIZE,
+    chunk_size: MAX_CHUNK_SIZE,
   });
   return data;
 };

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -202,11 +202,12 @@ export const useAddUploadsQuery = (request: AddUploadRequest) => {
   const { notify } = useNotification();
   return useMutation(() => addUploads(request), {
     onSuccess: (data) => {
+      const uploadCount = (request?.uploads?.length || 0) + (request?.artifacts?.length || 0);
       notify({
         variant: AlertVariant.success,
         title:
-          request.uploads.length > 1
-            ? `${request.uploads.length} rpms successfully uploaded to ${data.object_name}`
+          uploadCount > 1
+            ? `${uploadCount} rpms successfully uploaded to ${data.object_name}`
             : `One rpm successfully uploaded to ${data.object_name}`,
         description: 'This repository will be snapshotted shortly',
         id: 'add-upload-success',

--- a/src/services/Subscriptions/SubscriptionQueries.ts
+++ b/src/services/Subscriptions/SubscriptionQueries.ts
@@ -1,6 +1,7 @@
 import { Subscriptions, getSubscriptions, getEphemeralSubscriptions } from './SubscriptionApi';
 import useErrorNotification from 'Hooks/useErrorNotification';
 import useIsEphemeralEnv from 'Hooks/useIsEphemeralEnv';
+import { useMemo } from 'react';
 import { useQuery } from 'react-query';
 
 const SUBSCRIPTION_CHECK_KEY = 'SUBSCRIPTION_CHECK_KEY';
@@ -8,7 +9,10 @@ const SUBSCRIPTION_CHECK_KEY = 'SUBSCRIPTION_CHECK_KEY';
 export const useFetchSubscriptionsQuery = () => {
   const errorNotifier = useErrorNotification();
   const isEphemeral = useIsEphemeralEnv();
-  const queryFn = isEphemeral ? getEphemeralSubscriptions() : getSubscriptions();
+  const queryFn = useMemo(
+    () => (isEphemeral ? getEphemeralSubscriptions() : getSubscriptions()),
+    [isEphemeral],
+  );
 
   return useQuery<Subscriptions>([SUBSCRIPTION_CHECK_KEY], () => queryFn, {
     onError: (err) =>


### PR DESCRIPTION
## Summary

Adds support for resumable downloads.

Can test with [this](https://github.com/content-services/content-sources-backend/pull/918) back-end PR.

## Testing steps

- Create an upoad repository.
- Select an item for upload, allow it to upload around halfway and then immediately hit refresh.
- After refresh, choose the same item, you should be able to see that item continue where you left off.
- After this item has been completed, upload it, and create another upload repository.
- Choose the same file, it should instantly be available.
