### PR TITLE
HMS-5203: Remove template patch banner

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -76,7 +76,7 @@ export default [
       'react/react-in-jsx-scope': 'off',
       camelcase: 'off',
       'spaced-comment': 'error',
-      quotes: ['warn', 'single'],
+      'prettier/prettier': ['warn', { singleQuote: true }],
       'no-duplicate-imports': 'error',
       'unused-imports/no-unused-imports': 'error',
       'unused-imports/no-unused-vars': ['warn'],

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
@@ -268,7 +268,7 @@ const SnapshotListModal = () => {
                         {!checkedSnapshots.size || !rbac?.repoWrite
                           ? 'Remove selected snapshots'
                           : checkedSnapshots.size == count
-                            ? 'Can\'t remove all snapshots'
+                            ? "Can't remove all snapshots"
                             : `Remove ${checkedSnapshots.size} snapshots`}
                       </Button>
                     </ConditionalTooltip>
@@ -398,7 +398,7 @@ const SnapshotListModal = () => {
                             <ConditionalTooltip
                               content={
                                 count < 2
-                                  ? 'You can\'t delete the last snapshot in a repository'
+                                  ? "You can't delete the last snapshot in a repository"
                                   : 'You do not have the required permissions to perform this action.'
                               }
                               show={!isRedHatRepository && (!rbac?.repoWrite || count < 2)}

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
@@ -268,7 +268,7 @@ const SnapshotListModal = () => {
                         {!checkedSnapshots.size || !rbac?.repoWrite
                           ? 'Remove selected snapshots'
                           : checkedSnapshots.size == count
-                            ? "Can't remove all snapshots"
+                            ? `Can't remove all snapshots`
                             : `Remove ${checkedSnapshots.size} snapshots`}
                       </Button>
                     </ConditionalTooltip>
@@ -398,7 +398,7 @@ const SnapshotListModal = () => {
                             <ConditionalTooltip
                               content={
                                 count < 2
-                                  ? "You can't delete the last snapshot in a repository"
+                                  ? `You can't delete the last snapshot in a repository`
                                   : 'You do not have the required permissions to perform this action.'
                               }
                               show={!isRedHatRepository && (!rbac?.repoWrite || count < 2)}

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -1,6 +1,4 @@
 import {
-  Alert,
-  AlertActionCloseButton,
   Button,
   Flex,
   FlexItem,
@@ -36,12 +34,7 @@ import TemplateFilters from './components/TemplateFilters';
 import { formatDateDDMMMYYYY, formatDateUTC } from 'helpers';
 import Header from 'components/Header/Header';
 import useRootPath from 'Hooks/useRootPath';
-import {
-  DELETE_ROUTE,
-  DETAILS_ROUTE,
-  PATCH_SYSTEMS_ROUTE,
-  TEMPLATES_ROUTE,
-} from 'Routes/constants';
+import { DELETE_ROUTE, DETAILS_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
 import useArchVersion from 'Hooks/useArchVersion';
 import { useTemplateList } from 'services/Templates/TemplateQueries';
 import StatusIcon from './components/StatusIcon';
@@ -95,15 +88,6 @@ const TemplatesTable = () => {
   const [activeSortDirection, setActiveSortDirection] = useState<'asc' | 'desc'>('desc');
   const [polling, setPolling] = useState(false);
   const [pollCount, setPollCount] = useState(0);
-
-  const basePath = rootPath.slice(1).replace('content', '');
-  const storedBannerDismissal = !!sessionStorage.getItem('bannerDismissal');
-  const [dismissed, setDismissed] = useState(storedBannerDismissal);
-
-  const onDismissBanner = () => {
-    sessionStorage.setItem('bannerDismissal', 'true');
-    setDismissed(true);
-  };
 
   const defaultValues: TemplateFilterData = {
     arch: '',
@@ -234,29 +218,6 @@ const TemplatesTable = () => {
         ouiaId='templates_description'
         paragraph='View all content templates within your organization.'
       />
-      <Hide hide={dismissed}>
-        <Grid className={classes.bannerContainer}>
-          <Alert
-            variant='info'
-            title='Content templates is currently in preview'
-            actionClose={<AlertActionCloseButton onClose={onDismissBanner} />}
-          >
-            <p>
-              <b>Note:</b>{' '}
-              <Button
-                isInline
-                variant='link'
-                component='a'
-                href={`${basePath}${PATCH_SYSTEMS_ROUTE}`}
-              >
-                Systems within Patch
-              </Button>{' '}
-              might not properly indicate which template is assigned to a system or which updates
-              are installable.
-            </p>
-          </Alert>
-        </Grid>
-      </Hide>
       <Grid data-ouia-component-id='content_template_list_page' className={classes.mainContainer}>
         <Outlet />
         <Flex className={classes.topContainer}>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -38,14 +38,15 @@ export default function Header({ title, ouiaId, paragraph }: Props) {
 
   return (
     <PageHeader>
-      <PageHeaderTitle title={
-        <>
-        {title}
-        <OpenSourceBadge
-            repositoriesURL='https://github.com/content-services/content-sources-frontend'
-        />
-        </>
-        } className={classes.remove100percent} />
+      <PageHeaderTitle
+        title={
+          <>
+            {title}
+            <OpenSourceBadge repositoriesURL='https://github.com/content-services/content-sources-frontend' />
+          </>
+        }
+        className={classes.remove100percent}
+      />
       <Text className={classes.subtext} ouiaId={ouiaId}>
         {paragraph}
       </Text>


### PR DESCRIPTION
## Summary

Removes a banner that is no longer needed.
![Screenshot 2024-12-16 at 2 39 42 PM](https://github.com/user-attachments/assets/0ce214a0-9f92-4ceb-985b-56ec153c9611)

## Testing steps
- Without the PR, there is a banner in templates
- After the PR, no banner.