### PR TITLE
Build: Update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,19 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "@patternfly/react-core"
+        versions: ["6.x.x"]
+      - dependency-name: "@patternfly/react-icons"
+        versions: ["6.x.x"]
+      - dependency-name: "@patternfly/react-table"
+        versions: ["6.x.x"]
+      - dependency-name: "react-router-dom"
+        versions: ["7.x.x"]
+      - dependency-name: "@redhat-cloud-services/frontend-components-utilities"
+        versions: ["5.x.x"]
+      - dependency-name: "@redhat-cloud-services/frontend-components"
+        versions: ["5.x.x"]
     commit-message:
       prefix: "Build: "
     groups:


### PR DESCRIPTION
## Summary

This makes dependabot ignore major versions of a few modules, as it isn't capable of making the upgrade without assistance.

## Testing steps
