### PR TITLE
HMS-5187: fix duplicate errata in template detail

### DIFF
--- a/src/components/SharedTables/AdvisoriesTable/index.tsx
+++ b/src/components/SharedTables/AdvisoriesTable/index.tsx
@@ -124,7 +124,7 @@ export default function AdvisoriesTable({
               </Tr>
             </Thead>
           </Hide>
-          {errataList.map(
+          {[...new Map(errataList.map(e => [e.errata_id, e])).values()].map(
             (
               {
                 errata_id,


### PR DESCRIPTION
## Summary
This PR fixes a bug where errata are duplicated in the advisories tab in the template detail. 

Before:
![image](https://github.com/user-attachments/assets/be3ce9b1-b636-45ad-9d5d-26798a7d833a)
After:
![image](https://github.com/user-attachments/assets/231c2ec2-7df5-4726-8505-f3b8af010d0e)

## Testing steps
- In stage navigate to a template and verify the errata aren't duplicated.
