### PR TITLE
HMS-5024: add use template modal

### DIFF
--- a/src/Pages/Templates/TemplateDetails/TemplateDetails.test.tsx
+++ b/src/Pages/Templates/TemplateDetails/TemplateDetails.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import {fireEvent, render} from '@testing-library/react';
 import TemplateDetails from './TemplateDetails';
 import { defaultTemplateItem } from 'testingHelpers';
 
@@ -14,6 +14,9 @@ jest.mock('react-router-dom', () => ({
   useNavigate: jest.fn(),
   useParams: () => ({ templateUUID: 'templateUUID' }),
   Outlet: () => <></>,
+  useLocation: () => ({
+    pathname: '/templates/8b9f5062-5256-459a-9833-2b85b735225b/details/content/advisories',
+  }),
 }));
 
 jest.mock('Hooks/useArchVersion', () => () => ({
@@ -30,4 +33,23 @@ it('expect TemplateDetails to render correctly', () => {
   expect(queryByText('x86_64')).toBeInTheDocument();
   expect(queryByText('Rhel9')).toBeInTheDocument();
   expect(queryAllByText(defaultTemplateItem.name)).toHaveLength(2);
+});
+
+it('expect UseTemplateModal to render correctly', () => {
+  const { queryByText, getByLabelText } = render(<TemplateDetails />);
+
+  const useTemplate = getByLabelText('use-template-button') as Element;
+  expect(useTemplate).toBeInTheDocument();
+  fireEvent.click(useTemplate);
+  expect(queryByText('Assign the template to a system')).toBeInTheDocument()
+
+  const curlTab = getByLabelText('curl-tab') as Element;
+  expect(curlTab).toBeInTheDocument();
+  fireEvent.click(curlTab);
+  expect(queryByText('Download the repo file')).toBeInTheDocument()
+
+  const ansibleTab = getByLabelText('ansible-tab') as Element;
+  expect(ansibleTab).toBeInTheDocument();
+  fireEvent.click(ansibleTab);
+  expect(queryByText('Use this ansible playbook to download the repo file')).toBeInTheDocument()
 });

--- a/src/Pages/Templates/TemplateDetails/TemplateDetails.tsx
+++ b/src/Pages/Templates/TemplateDetails/TemplateDetails.tsx
@@ -7,7 +7,7 @@ import {
   LabelGroup,
   Stack,
   StackItem,
-  Title,
+  Title, Toolbar, ToolbarContent, ToolbarItem,
 } from '@patternfly/react-core';
 import { Outlet, useNavigate, useParams } from 'react-router-dom';
 import { createUseStyles } from 'react-jss';
@@ -17,10 +17,12 @@ import { useFetchTemplate } from 'services/Templates/TemplateQueries';
 import useArchVersion from 'Hooks/useArchVersion';
 import DetailItem from './components/DetaiItem';
 import { formatDateDDMMMYYYY } from 'helpers';
-import TemplateDetailsTabs from './components/TemplateDetailsTabs';
 import { global_BackgroundColor_light_100 } from '@patternfly/react-tokens';
 import Loader from 'components/Loader';
 import TemplateActionDropdown from './components/TemplateActionDropdown';
+import UseTemplateModal from './components/UseTemplate/UseTemplateModal';
+import React from 'react';
+import TemplateDetailsTabs from './components/TemplateDetailsTabs';
 
 const useStyles = createUseStyles({
   fullHeight: {
@@ -107,7 +109,16 @@ export default function TemplateDetails() {
                 </Label>
               </LabelGroup>
             </Flex>
-            <TemplateActionDropdown />
+            <Toolbar>
+              <ToolbarContent>
+                <ToolbarItem spacer={{ default: 'spacerNone' }}>
+                  <UseTemplateModal/>
+                </ToolbarItem>
+                <ToolbarItem>
+                 <TemplateActionDropdown />
+                </ToolbarItem>
+              </ToolbarContent>
+            </Toolbar>
           </StackItem>
           <StackItem className={classes.descriptionMaxWidth}>
             <Flex

--- a/src/Pages/Templates/TemplateDetails/TemplateDetails.tsx
+++ b/src/Pages/Templates/TemplateDetails/TemplateDetails.tsx
@@ -111,7 +111,7 @@ export default function TemplateDetails() {
             </Flex>
             <Toolbar>
               <ToolbarContent>
-                <ToolbarItem spacer={{ default: 'spacerNone' }}>
+                <ToolbarItem>
                   <UseTemplateModal/>
                 </ToolbarItem>
                 <ToolbarItem>

--- a/src/Pages/Templates/TemplateDetails/components/UseTemplate/AnsibleTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/UseTemplate/AnsibleTab.tsx
@@ -1,4 +1,5 @@
 import {
+    Alert,
     ClipboardCopy,
     ClipboardCopyButton,
     ClipboardCopyVariant, CodeBlock, CodeBlockAction, CodeBlockCode,
@@ -11,6 +12,7 @@ import {
 import React from 'react';
 import {createUseStyles} from 'react-jss';
 import {useParams} from 'react-router-dom';
+import {ExternalLinkAltIcon} from "@patternfly/react-icons";
 
 export const ANSIBLE_TAB = 'ansible'
 
@@ -72,18 +74,32 @@ const AnsibleTab = ({ tabContentRef }: Props) => {
 
     return (
         <TabContent eventKey={ANSIBLE_TAB} id={ANSIBLE_TAB} ref={tabContentRef} hidden>
+            <div className={classes.textGroup}>
+                <Alert
+                    variant='warning'
+                    title='Consuming a template in this way will result in the system not reporting applicable errata properly within Insights.'
+                    isInline
+                >
+                    System advisory information will not be available via {' '}
+                    <a href="insights/patch/systems/" rel='noreferrer' target='_blank'>
+                        Systems <ExternalLinkAltIcon/>
+                    </a>
+                </Alert>
+            </div>
             <TextContent className={classes.textGroup}>
                 <Text component={TextVariants.h2}>Register for subscriptions</Text>
                 <TextList isPlain>
                     <TextListItem>
                         <Text component="h6">Register with rhc</Text>
-                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied" variant={ClipboardCopyVariant.expansion}>
+                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied"
+                                       variant={ClipboardCopyVariant.expansion}>
                             rhc connect
                         </ClipboardCopy>
                     </TextListItem>
                     <TextListItem>
                         <Text component="h6">Or register with subscription manager</Text>
-                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied" variant={ClipboardCopyVariant.expansion}>
+                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied"
+                                       variant={ClipboardCopyVariant.expansion}>
                             subscription-manager register
                         </ClipboardCopy>
                     </TextListItem>
@@ -93,13 +109,20 @@ const AnsibleTab = ({ tabContentRef }: Props) => {
                         <Text component={TextVariants.h2}>Use this ansible playbook to download the repo file</Text>
                         <CodeBlock actions={actions}>
                             <CodeBlockCode>
-                                {playbook1+`${templateUUID}`+playbook2}
+                                {playbook1 + `${templateUUID}` + playbook2}
                             </CodeBlockCode>
                         </CodeBlock>
-                        <Text>Note:  Adding or removing a repository from the template will not be reflected on the client until this file is re-downloaded</Text>
                     </TextListItem>
                 </TextList>
             </TextContent>
+            <div className={classes.textGroup}>
+                <Alert
+                    variant='info'
+                    title='Adding or removing a repository from the template will not be reflected on the
+                            client until the repo file is re-downloaded.'
+                    isInline
+                />
+            </div>
         </TabContent>
     )
 }

--- a/src/Pages/Templates/TemplateDetails/components/UseTemplate/AnsibleTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/UseTemplate/AnsibleTab.tsx
@@ -1,0 +1,107 @@
+import {
+    ClipboardCopy,
+    ClipboardCopyButton,
+    ClipboardCopyVariant, CodeBlock, CodeBlockAction, CodeBlockCode,
+    TabContent,
+    Text, TextContent,
+    TextList,
+    TextListItem,
+    TextVariants
+} from '@patternfly/react-core';
+import React from 'react';
+import {createUseStyles} from 'react-jss';
+import {useParams} from 'react-router-dom';
+
+export const ANSIBLE_TAB = 'ansible'
+
+const useStyles = createUseStyles({
+    textGroup: {
+        paddingTop: '8px',
+    },
+})
+
+type Props = {
+    tabContentRef:  React.RefObject<HTMLElement>
+}
+
+const playbook1 = `---
+- hosts: all
+  tasks:
+    - name: Download template.repo
+      ansible.builtin.get_url:
+        url: https://console.redhat.com/api/content-sources/v1/templates/`
+const playbook2 = `/config.repo
+        dest: /etc/yum.repos.d/template.repo
+        mode: '0444'
+        client_cert: /etc/pki/consumer/cert.pem
+        client_key:  /etc/pki/consumer/cert.key
+`
+
+const AnsibleTab = ({ tabContentRef }: Props) => {
+    const classes = useStyles();
+    const { templateUUID } = useParams();
+    const [copied, setCopied] = React.useState(false);
+
+    const clipboardCopyFunc = (event, text) => {
+        navigator.clipboard.writeText(text.toString());
+    };
+
+    const onClick = (event, text) => {
+        clipboardCopyFunc(event, text);
+        setCopied(true);
+    };
+
+    const actions = (
+        <React.Fragment>
+            <CodeBlockAction>
+                <ClipboardCopyButton
+                    id="basic-copy-button"
+                    textId="code-content"
+                    aria-label="Copy to clipboard"
+                    onClick={(e) => onClick(e, playbook1+`${templateUUID}`+playbook2)}
+                    exitDelay={copied ? 1500 : 600}
+                    maxWidth="110px"
+                    variant="plain"
+                    onTooltipHidden={() => setCopied(false)}
+                >
+                    {copied ? 'Successfully copied to clipboard!' : 'Copy to clipboard'}
+                </ClipboardCopyButton>
+            </CodeBlockAction>
+        </React.Fragment>
+    );
+
+    return (
+        <TabContent eventKey={ANSIBLE_TAB} id={ANSIBLE_TAB} ref={tabContentRef} hidden>
+            <TextContent className={classes.textGroup}>
+                <Text component={TextVariants.h2}>Register for subscriptions</Text>
+                <TextList isPlain>
+                    <TextListItem>
+                        <Text component="h6">Register with rhc</Text>
+                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied" variant={ClipboardCopyVariant.expansion}>
+                            rhc connect
+                        </ClipboardCopy>
+                    </TextListItem>
+                    <TextListItem>
+                        <Text component="h6">Or register with subscription manager</Text>
+                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied" variant={ClipboardCopyVariant.expansion}>
+                            subscription-manager register
+                        </ClipboardCopy>
+                    </TextListItem>
+                </TextList>
+                <TextList isPlain>
+                    <TextListItem>
+                        <Text component={TextVariants.h2}>Use this ansible playbook to download the repo file</Text>
+                        <CodeBlock actions={actions}>
+                            <CodeBlockCode>
+                                {playbook1+`${templateUUID}`+playbook2}
+                            </CodeBlockCode>
+                        </CodeBlock>
+                        <Text>Note:  Adding or removing a repository from the template will not be reflected on the client until this file is re-downloaded</Text>
+                    </TextListItem>
+                </TextList>
+            </TextContent>
+        </TabContent>
+    )
+}
+
+export default AnsibleTab;

--- a/src/Pages/Templates/TemplateDetails/components/UseTemplate/CurlTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/UseTemplate/CurlTab.tsx
@@ -1,4 +1,5 @@
 import {
+    Alert,
     ClipboardCopy,
     ClipboardCopyVariant,
     TabContent,
@@ -10,6 +11,7 @@ import {
 import React from 'react';
 import {createUseStyles} from 'react-jss';
 import {useParams} from 'react-router-dom';
+import {ExternalLinkAltIcon} from "@patternfly/react-icons";
 
 export const CURL_TAB = 'curl'
 
@@ -29,18 +31,32 @@ const CurlTab = ({ tabContentRef }: Props) => {
 
     return (
         <TabContent eventKey={CURL_TAB} id={CURL_TAB} ref={tabContentRef} hidden>
+            <div className={classes.textGroup}>
+                <Alert
+                    variant='warning'
+                    title='Consuming a template in this way will result in the system not reporting applicable errata properly within Insights.'
+                    isInline
+                >
+                    System advisory information will not be available via {' '}
+                    <a href="insights/patch/systems/" rel='noreferrer' target='_blank'>
+                        Systems <ExternalLinkAltIcon/>
+                    </a>
+                </Alert>
+            </div>
             <TextContent className={classes.textGroup}>
                 <Text component={TextVariants.h2}>Register for subscriptions</Text>
                 <TextList isPlain>
                     <TextListItem>
                         <Text component="h6">Register with rhc</Text>
-                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied" variant={ClipboardCopyVariant.expansion}>
+                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied"
+                                       variant={ClipboardCopyVariant.expansion}>
                             rhc connect
                         </ClipboardCopy>
                     </TextListItem>
                     <TextListItem>
                         <Text component="h6">Or register with subscription manager</Text>
-                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied" variant={ClipboardCopyVariant.expansion}>
+                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied"
+                                       variant={ClipboardCopyVariant.expansion}>
                             subscription-manager register
                         </ClipboardCopy>
                     </TextListItem>
@@ -48,13 +64,21 @@ const CurlTab = ({ tabContentRef }: Props) => {
                 <TextList isPlain>
                     <TextListItem>
                         <Text component={TextVariants.h2}>Download the repo file</Text>
-                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied" variant={ClipboardCopyVariant.expansion}>
-                            {'curl -o /etc/yum.repos.d/template.repo  https://console.redhat.com/api/content-sources/v1/templates/'+templateUUID+'/config.repo'}
+                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied"
+                                       variant={ClipboardCopyVariant.expansion}>
+                            {'curl -o /etc/yum.repos.d/template.repo  https://console.redhat.com/api/content-sources/v1/templates/' + templateUUID + '/config.repo'}
                         </ClipboardCopy>
-                        <Text>Note: Adding or removing a repository from the template will not be reflected on the client until this file is re-downloaded.</Text>
                     </TextListItem>
                 </TextList>
             </TextContent>
+            <div className={classes.textGroup}>
+                <Alert
+                    variant='info'
+                    title='Adding or removing a repository from the template will not be reflected on the
+                            client until the repo file is re-downloaded.'
+                    isInline
+                />
+            </div>
         </TabContent>
     )
 }

--- a/src/Pages/Templates/TemplateDetails/components/UseTemplate/CurlTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/UseTemplate/CurlTab.tsx
@@ -1,0 +1,62 @@
+import {
+    ClipboardCopy,
+    ClipboardCopyVariant,
+    TabContent,
+    Text, TextContent,
+    TextList,
+    TextListItem,
+    TextVariants
+} from '@patternfly/react-core';
+import React from 'react';
+import {createUseStyles} from 'react-jss';
+import {useParams} from 'react-router-dom';
+
+export const CURL_TAB = 'curl'
+
+const useStyles = createUseStyles({
+    textGroup: {
+        paddingTop: '8px',
+    },
+})
+
+type Props = {
+    tabContentRef:  React.RefObject<HTMLElement>
+}
+
+const CurlTab = ({ tabContentRef }: Props) => {
+    const classes = useStyles();
+    const { templateUUID } = useParams();
+
+    return (
+        <TabContent eventKey={CURL_TAB} id={CURL_TAB} ref={tabContentRef} hidden>
+            <TextContent className={classes.textGroup}>
+                <Text component={TextVariants.h2}>Register for subscriptions</Text>
+                <TextList isPlain>
+                    <TextListItem>
+                        <Text component="h6">Register with rhc</Text>
+                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied" variant={ClipboardCopyVariant.expansion}>
+                            rhc connect
+                        </ClipboardCopy>
+                    </TextListItem>
+                    <TextListItem>
+                        <Text component="h6">Or register with subscription manager</Text>
+                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied" variant={ClipboardCopyVariant.expansion}>
+                            subscription-manager register
+                        </ClipboardCopy>
+                    </TextListItem>
+                </TextList>
+                <TextList isPlain>
+                    <TextListItem>
+                        <Text component={TextVariants.h2}>Download the repo file</Text>
+                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied" variant={ClipboardCopyVariant.expansion}>
+                            {'curl -o /etc/yum.repos.d/template.repo  https://console.redhat.com/api/content-sources/v1/templates/'+templateUUID+'/config.repo'}
+                        </ClipboardCopy>
+                        <Text>Note: Adding or removing a repository from the template will not be reflected on the client until this file is re-downloaded.</Text>
+                    </TextListItem>
+                </TextList>
+            </TextContent>
+        </TabContent>
+    )
+}
+
+export default CurlTab;

--- a/src/Pages/Templates/TemplateDetails/components/UseTemplate/InsightsTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/UseTemplate/InsightsTab.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import {ADD_ROUTE, DETAILS_ROUTE, SYSTEMS_ROUTE} from '../../../../../Routes/constants';
 import {ExternalLinkAltIcon} from '@patternfly/react-icons';
 import {createUseStyles} from 'react-jss';
-import {useLocation} from 'react-router-dom';
+import {useLocation, useParams} from 'react-router-dom';
 
 export const INSIGHTS_TAB = 'insights'
 
@@ -31,6 +31,7 @@ const InsightsTab = ({ tabContentRef }: Props) => {
     const { pathname } = useLocation();
     const [mainRoute] = pathname?.split(`${DETAILS_ROUTE}/`) || [];
     const addSystemsRoute = mainRoute + `${DETAILS_ROUTE}/`+ `${SYSTEMS_ROUTE}/` + `${ADD_ROUTE}/`;
+    const { templateUUID } = useParams();
 
     return (
         <TabContent eventKey={INSIGHTS_TAB} id={INSIGHTS_TAB} ref={tabContentRef}>
@@ -47,12 +48,27 @@ const InsightsTab = ({ tabContentRef }: Props) => {
                 <Text component={TextVariants.h2}>Assign the template to a system</Text>
                 <TextList isPlain>
                     <TextListItem>
+                        <Text component="h6"> Add the template via the UI </Text>
                         <Text>
-                            Add template in {' '}
+                            Add the template in {' '}
                             <a href={addSystemsRoute} rel='noreferrer' target='_blank'>
                                 Systems <ExternalLinkAltIcon/>
                             </a>
                         </Text>
+                    </TextListItem>
+                    <TextListItem>
+                        <Text component="h6"> Or add the template via the API </Text>
+                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied" variant={ClipboardCopyVariant.expansion}>
+                            {'curl --cert /etc/pki/consumer/cert.pem  --key /etc/pki/consumer/key.pem -X PATCH https://console.redhat.com/api/patch/v3/templates/'+templateUUID+'/subscribed-systems'}
+                        </ClipboardCopy>
+                    </TextListItem>
+                </TextList>
+                <Text component={TextVariants.h2}>Refresh Subscription Manager</Text>
+                <TextList isPlain>
+                    <TextListItem>
+                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied" variant={ClipboardCopyVariant.expansion}>
+                            subscription-manager refresh
+                        </ClipboardCopy>
                     </TextListItem>
                 </TextList>
             </TextContent>

--- a/src/Pages/Templates/TemplateDetails/components/UseTemplate/InsightsTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/UseTemplate/InsightsTab.tsx
@@ -1,0 +1,63 @@
+import {
+    ClipboardCopy,
+    ClipboardCopyVariant,
+    TabContent,
+    Text, TextContent,
+    TextList,
+    TextListItem,
+    TextVariants
+} from '@patternfly/react-core';
+import React from 'react';
+import {ADD_ROUTE, DETAILS_ROUTE, SYSTEMS_ROUTE} from '../../../../../Routes/constants';
+import {ExternalLinkAltIcon} from '@patternfly/react-icons';
+import {createUseStyles} from 'react-jss';
+import {useLocation} from 'react-router-dom';
+
+export const INSIGHTS_TAB = 'insights'
+
+const useStyles = createUseStyles({
+    textGroup: {
+        paddingTop: '8px',
+    },
+})
+
+type Props = {
+    tabContentRef:  React.RefObject<HTMLElement>
+}
+
+const InsightsTab = ({ tabContentRef }: Props) => {
+    const classes = useStyles();
+
+    const { pathname } = useLocation();
+    const [mainRoute] = pathname?.split(`${DETAILS_ROUTE}/`) || [];
+    const addSystemsRoute = mainRoute + `${DETAILS_ROUTE}/`+ `${SYSTEMS_ROUTE}/` + `${ADD_ROUTE}/`;
+
+    return (
+        <TabContent eventKey={INSIGHTS_TAB} id={INSIGHTS_TAB} ref={tabContentRef}>
+            <TextContent className={classes.textGroup}>
+                <Text component={TextVariants.h2}>Register for subscriptions</Text>
+                <TextList isPlain>
+                    <TextListItem>
+                        <Text component="h6">Register with rhc</Text>
+                        <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied" variant={ClipboardCopyVariant.expansion}>
+                            rhc connect
+                        </ClipboardCopy>
+                    </TextListItem>
+                </TextList>
+                <Text component={TextVariants.h2}>Assign the template to a system</Text>
+                <TextList isPlain>
+                    <TextListItem>
+                        <Text>
+                            Add template in {' '}
+                            <a href={addSystemsRoute} rel='noreferrer' target='_blank'>
+                                Systems <ExternalLinkAltIcon/>
+                            </a>
+                        </Text>
+                    </TextListItem>
+                </TextList>
+            </TextContent>
+        </TabContent>
+    )
+}
+
+export default InsightsTab;

--- a/src/Pages/Templates/TemplateDetails/components/UseTemplate/UseTemplateModal.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/UseTemplate/UseTemplateModal.tsx
@@ -1,0 +1,85 @@
+import {
+    Button,
+    Modal,
+    ModalVariant,
+    Tab,
+    Tabs,
+    TabTitleText,
+} from '@patternfly/react-core'
+import React from 'react';
+import InsightsTab, {INSIGHTS_TAB} from './InsightsTab';
+import CurlTab, {CURL_TAB} from './CurlTab';
+import AnsibleTab, {ANSIBLE_TAB} from './AnsibleTab';
+
+const UseTemplateModal = () => {
+    const [isModalOpen, setIsModalOpen] = React.useState(false);
+    const [activeTabKey, setActiveTabKey] = React.useState<string | number>(INSIGHTS_TAB);
+
+    const handleModalToggle = () => {
+        setIsModalOpen(!isModalOpen);
+    };
+
+    const handleTabClick = (_event: React.MouseEvent<HTMLElement, MouseEvent>, tabIndex: string | number) => {
+        setActiveTabKey(tabIndex);
+    };
+
+    const contentRefInsights = React.createRef<HTMLElement>();
+    const contentRefCurl = React.createRef<HTMLElement>();
+    const contentRefAnsible = React.createRef<HTMLElement>();
+
+    return (
+        <div>
+        <Button aria-label="use-template-button" variant="primary" onClick={handleModalToggle}>
+            Use template
+        </Button>
+
+        <Modal
+            tabIndex={0}
+            variant={ModalVariant.large}
+            title="Use template"
+            isOpen={isModalOpen}
+            onClose={handleModalToggle}
+            footer={
+                <Button key='close' variant='secondary' onClick={handleModalToggle}>
+                    Close
+                </Button>
+            }
+        >
+            <Tabs
+                activeKey={activeTabKey}
+                onSelect={handleTabClick}
+                aria-label='Use template tabs'
+            >
+                <Tab
+                    eventKey={INSIGHTS_TAB}
+                    title={<TabTitleText>Insights (Preferred)</TabTitleText>}
+                    tabContentId={INSIGHTS_TAB}
+                    tabContentRef={contentRefInsights}
+                    aria-label='insights-tab'
+                />
+                <Tab
+                    eventKey={CURL_TAB}
+                    title={<TabTitleText>Curl</TabTitleText>}
+                    tabContentId={CURL_TAB}
+                    tabContentRef={contentRefCurl}
+                    aria-label='curl-tab'
+                />
+                <Tab
+                    eventKey={ANSIBLE_TAB}
+                    title={<TabTitleText>Ansible</TabTitleText>}
+                    tabContentId={ANSIBLE_TAB}
+                    tabContentRef={contentRefAnsible}
+                    aria-label='ansible-tab'
+                />
+            </Tabs>
+            <div>
+                <InsightsTab tabContentRef={contentRefInsights}/>
+                <CurlTab tabContentRef={contentRefCurl}/>
+                <AnsibleTab tabContentRef={contentRefAnsible}/>
+            </div>
+        </Modal>
+        </div>
+    )
+}
+
+export default UseTemplateModal


### PR DESCRIPTION
## Summary
Adds a "use template" button in the top left of the template details page that opens a modal with different sets of instructions on how to use templates.

![image](https://github.com/user-attachments/assets/f2f9225b-d502-4eba-be61-94b28507f0e8)
![image](https://github.com/user-attachments/assets/18bf5716-4d19-4d95-b0f3-7d93d51b7b99)
![image](https://github.com/user-attachments/assets/6f182dba-f7e1-486d-a33d-e671187d5d9e)
![image](https://github.com/user-attachments/assets/cf8a5a76-ab10-4a20-806e-2a31324a1033)
## Testing steps
