### PR TITLE
HMS-5226: Fix redirect for zerostate

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import { useAppContext } from './middleware/AppContext';
 import { ContentOrigin, FilterData } from './services/Content/ContentApi';
 import { useContentListQuery } from './services/Content/ContentQueries';
 import { perPageKey } from './Pages/Repositories/ContentListTable/ContentListTable';
-import { REPOSITORIES_ROUTE } from './Routes/constants';
+import { CONTENT_ROUTE, REPOSITORIES_ROUTE } from './Routes/constants';
 import usePageSafe from 'Hooks/usePageSafe';
 
 export default function App() {
@@ -23,7 +23,7 @@ export default function App() {
   const { hideGlobalFilter } = useChrome();
 
   const isDefaultRoute = useMemo(
-    () => last(pathname.split('/')) === REPOSITORIES_ROUTE,
+    () => [REPOSITORIES_ROUTE, '', CONTENT_ROUTE].includes(last(pathname.split('/')) || ''),
     [pathname],
   );
 
@@ -55,7 +55,7 @@ export default function App() {
     if ((zeroState && data.data.length > 0) || (zeroState && !isDefaultRoute)) {
       setZeroState(false);
     }
-  }, [data.data.length]);
+  }, [data.data.length, zeroState]);
 
   if (!rbac || isFetchingPermissions || isLoading) {
     return (

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -46,6 +46,7 @@ import DeleteSnapshotsModal from 'Pages/Repositories/ContentListTable/components
 export default function RepositoriesRoutes() {
   const key = useMemo(() => Math.random(), []);
   const { zeroState, features, rbac, subscriptions } = useAppContext();
+
   return (
     <ErrorPage>
       <Routes key={key}>


### PR DESCRIPTION
## Summary

Tiny change to ensure that zerostate is checked on redirect from /content/ /content  <  in these two default cases.

## Testing steps
