### PR TITLE
HMS-5197: Fixes List snapshot being disabled for read only users

### DIFF
--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable quotes */
 import {
   Button,
   Flex,

--- a/src/components/SharedTables/AdvisoriesTable/index.tsx
+++ b/src/components/SharedTables/AdvisoriesTable/index.tsx
@@ -124,7 +124,7 @@ export default function AdvisoriesTable({
               </Tr>
             </Thead>
           </Hide>
-          {[...new Map(errataList.map(e => [e.errata_id, e])).values()].map(
+          {[...new Map(errataList.map((e) => [e.errata_id, e])).values()].map(
             (
               {
                 errata_id,

--- a/src/middleware/AppContext.tsx
+++ b/src/middleware/AppContext.tsx
@@ -14,8 +14,16 @@ import { useFetchSubscriptionsQuery } from 'services/Subscriptions/SubscriptionQ
 const getRegistry = _getRegistry as unknown as () => { register: ({ notifications }) => void };
 const { appname } = PackageJson.insights;
 
+// Add permissions here
+export enum RbacPermissions {
+  'repoRead', // If the user doesn't have this permission, they won't see the app, it is thus presumed true.
+  'repoWrite',
+  'templateWrite',
+  'templateRead',
+}
+
 export interface AppContextInterface {
-  rbac?: Record<string, boolean>;
+  rbac?: Record<keyof typeof RbacPermissions, boolean>;
   features: Features | null;
   isFetchingPermissions: boolean;
   subscriptions?: Subscriptions;
@@ -29,7 +37,9 @@ export interface AppContextInterface {
 export const AppContext = createContext({} as AppContextInterface);
 
 export const ContextProvider = ({ children }: { children: ReactNode }) => {
-  const [rbac, setRbac] = useState<Record<string, boolean> | undefined>(undefined);
+  const [rbac, setRbac] = useState<Record<keyof typeof RbacPermissions, boolean> | undefined>(
+    undefined,
+  );
   const [zeroState, setZeroState] = useState(true);
   const [features, setFeatures] = useState<Features | null>(null);
   const chrome = useChrome();


### PR DESCRIPTION
## Summary

Small change to update permissions to allow read-only users to view snapshots

## Testing steps
- Get a read -only user, check before and after this change. 
- With this change they should now be permitted to look at the snapshotList within the kebab for each repository.
