### PR TITLE
HMS-5267: template wizard date picker fix, UX changes

### DIFF
--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/AddTemplate.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/AddTemplate.tsx
@@ -153,7 +153,7 @@ const AddTemplateBase = () => {
             ]}
           />
           <WizardStep
-            name='Set snapshot date'
+            name='Set up date'
             id='set_up_date_step'
             isDisabled={checkIfCurrentStepValid(3)}
             footer={{ ...sharedFooterProps, isNextDisabled: checkIfCurrentStepValid(4) }}

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/AddTemplateContext.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/AddTemplateContext.tsx
@@ -15,6 +15,7 @@ import { hardcodeRedHatReposByArchAndVersion } from '../templateHelpers';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useFetchTemplate } from 'services/Templates/TemplateQueries';
 import useRootPath from 'Hooks/useRootPath';
+import { isDateValid } from 'helpers';
 
 export interface AddTemplateContextInterface {
   queryClient: QueryClient;
@@ -59,7 +60,7 @@ export const AddTemplateContextProvider = ({ children }: { children: ReactNode }
       arch && version,
       !!selectedRedhatRepos.size,
       true,
-      !!date || use_latest,
+      (!!date || use_latest) && isDateValid(date ?? ''),
       !!name && name.length < 256,
     ] as boolean[];
   }, [templateRequest, selectedRedhatRepos.size]);

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/AddTemplateContext.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/AddTemplateContext.tsx
@@ -60,7 +60,7 @@ export const AddTemplateContextProvider = ({ children }: { children: ReactNode }
       arch && version,
       !!selectedRedhatRepos.size,
       true,
-      (!!date || use_latest) && isDateValid(date ?? ''),
+      use_latest || isDateValid(date ?? ''),
       !!name && name.length < 256,
     ] as boolean[];
   }, [templateRequest, selectedRedhatRepos.size]);

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.test.tsx
@@ -23,7 +23,8 @@ jest.mock('react-router-dom', () => ({
 jest.mock('dayjs', () => () => ({
   fromNow: () => '2024-01-22',
   format: () => '2024-01-22',
-  isBefore: () => false,
+  endOf: () => '2024-01-22',
+  isBefore: () => true,
 }));
 
 it('expect Set snapshot date step to render dates', () => {
@@ -48,14 +49,11 @@ it('expect Set snapshot date step to render dates', () => {
   }));
 
   const { queryByText, getByRole } = render(<SetUpDateStep />);
-
-  expect(queryByText('Include repository changes up to this date')).toBeInTheDocument();
+  expect(queryByText('Select date for snapshotted repositories')).toBeInTheDocument();
 
   const dateInput = getByRole('textbox', { name: 'Date picker' });
-
   expect(dateInput).toBeInTheDocument();
   expect(dateInput).toHaveAttribute('value', '2024-01-22');
-  expect(queryByText(defaultContentItem.name)).toBeInTheDocument();
 });
 
 it('expect Set snapshot date step to render use latest', () => {
@@ -81,7 +79,5 @@ it('expect Set snapshot date step to render use latest', () => {
 
   const { queryByText } = render(<SetUpDateStep />);
 
-  expect(queryByText('Include repository changes up to this date')).not.toBeInTheDocument();
-
-  expect(queryByText('Always use latest content from repositories.')).toBeInTheDocument();
+  expect(queryByText('Select date for snapshotted repositories')).toBeInTheDocument();
 });

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
@@ -47,7 +47,7 @@ export default function SetUpDateStep() {
   useEffect(() => {
     setTemplateRequest({
       ...templateRequest,
-      date: templateRequest ? formatDateForPicker(templateRequest.date) : '',
+      date: templateRequest.date ? formatDateForPicker(templateRequest.date) : '',
     });
   }, []);
 
@@ -146,7 +146,6 @@ export default function SetUpDateStep() {
           onChange={(_, val) => {
             setTemplateRequest((prev) => ({ ...prev, date: val }));
           }}
-          // defaultValue={templateRequest.date ?? undefined}
         />
       </FormGroup>
       <Hide hide={!hasIsAfter || !dateIsValid}>

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
@@ -111,7 +111,7 @@ export default function SetUpDateStep() {
           ouiaId='use-latest-snapshot-radio'
           name='use-latest-snapshot'
           label='Use latest content'
-          description='Always use latest content from repositories. Snapshots may be updated daily.'
+          description='Always use latest content from repositories. Snapshots might be updated daily.'
           isChecked={templateRequest.use_latest}
           onChange={() => {
             if (!templateRequest.use_latest) {
@@ -153,7 +153,7 @@ export default function SetUpDateStep() {
         <FormAlert>
           <Alert
             variant='warning'
-            title='Selected date doesn’t include the only snapshot of some selected repositories.'
+            title='Selected date does not include the only snapshot of some selected repositories.'
             isInline
           >
             <Hide hide={isLoading}>

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
@@ -133,9 +133,10 @@ export default function SetUpDateStep() {
           }}
         />
         <DatePicker
+          id='use-snapshot-date-picker'
           value={templateRequest.date ?? ''}
-          required
-          requiredDateOptions={{ isRequired: true }}
+          required={!templateRequest.use_latest}
+          requiredDateOptions={{ isRequired: !templateRequest.use_latest }}
           style={{ paddingLeft: '20px' }}
           validators={dateValidators}
           popoverProps={{
@@ -160,7 +161,7 @@ export default function SetUpDateStep() {
                 const { name } = current;
                 if (index != 0 && index + 1 === array.length) {
                   acc += `and "${name}" `;
-                } else if (array.length === 1) {
+                } else if (array.length === 1 || index === array.length - 2) {
                   acc += `"${name}" `;
                 } else {
                   acc += `"${name}", `;

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
@@ -1,11 +1,15 @@
 import {
   Alert,
   DatePicker,
+  ExpandableSection,
   FormAlert,
   FormGroup,
   Grid,
   Radio,
   Text,
+  TextContent,
+  TextList,
+  TextListItem,
   TextVariants,
   Title,
 } from '@patternfly/react-core';
@@ -132,22 +136,24 @@ export default function SetUpDateStep() {
             }
           }}
         />
-        <DatePicker
-          id='use-snapshot-date-picker'
-          value={templateRequest.date ?? ''}
-          required={!templateRequest.use_latest}
-          requiredDateOptions={{ isRequired: !templateRequest.use_latest }}
-          style={{ paddingLeft: '20px' }}
-          validators={dateValidators}
-          popoverProps={{
-            position: 'right',
-            enableFlip: true,
-            flipBehavior: ['right', 'right-start', 'right-end', 'top-start', 'top'],
-          }}
-          onChange={(_, val) => {
-            setTemplateRequest((prev) => ({ ...prev, date: val }));
-          }}
-        />
+        <Hide hide={templateRequest.use_latest ?? false}>
+          <DatePicker
+            id='use-snapshot-date-picker'
+            value={templateRequest.date ?? ''}
+            required={!templateRequest.use_latest}
+            requiredDateOptions={{ isRequired: !templateRequest.use_latest }}
+            style={{ paddingLeft: '20px' }}
+            validators={dateValidators}
+            popoverProps={{
+              position: 'right',
+              enableFlip: true,
+              flipBehavior: ['right', 'right-start', 'right-end', 'top-start', 'top'],
+            }}
+            onChange={(_, val) => {
+              setTemplateRequest((prev) => ({ ...prev, date: val }));
+            }}
+          />
+        </Hide>
       </FormGroup>
       <Hide hide={!hasIsAfter || !dateIsValid}>
         <FormAlert>
@@ -172,8 +178,27 @@ export default function SetUpDateStep() {
                   acc += 'will be included anyway.';
                 }
                 return acc;
-              }, 'The content of the ')}
+              }, 'The snapshots of the ')}
             </Hide>
+            <ExpandableSection
+              toggleText='What does this mean?'
+              aria-label='quickStart-expansion'
+              data-ouia-component-id='quickstart_expand'
+              className={classes.whatDoesItMean}
+            >
+              <TextContent>
+                <TextList>
+                  <TextListItem>
+                    No snapshots exist for these repositories on the specified date or before it.
+                  </TextListItem>
+                  <TextListItem>The closest snapshots after that date will be used.</TextListItem>
+                  <TextListItem>
+                    Depending on the repository and time difference, this could cause a dependency
+                    issue.
+                  </TextListItem>
+                </TextList>
+              </TextContent>
+            </ExpandableSection>
           </Alert>
         </FormAlert>
       </Hide>

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
@@ -1,17 +1,11 @@
 import {
   Alert,
   DatePicker,
-  ExpandableSection,
-  FlexItem,
   FormAlert,
   FormGroup,
   Grid,
-  GridItem,
   Radio,
   Text,
-  TextContent,
-  TextList,
-  TextListItem,
   TextVariants,
   Title,
 } from '@patternfly/react-core';
@@ -20,17 +14,9 @@ import { useContentListQuery, useGetSnapshotsByDates } from 'services/Content/Co
 import { useEffect, useMemo } from 'react';
 import { global_Color_400 } from '@patternfly/react-tokens';
 import Hide from 'components/Hide/Hide';
-import { ContentItem, ContentOrigin } from 'services/Content/ContentApi';
-import { SkeletonTable } from '@patternfly/react-component-groups';
-import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip';
-import { formatDateForPicker, formatTemplateDate, reduceStringToCharsWithEllipsis } from 'helpers';
-import UrlWithExternalIcon from 'components/UrlWithLinkIcon/UrlWithLinkIcon';
-import PackageCount from 'Pages/Repositories/ContentListTable/components/PackageCount';
-import { REPOSITORIES_ROUTE } from 'Routes/constants';
-import { useHref } from 'react-router-dom';
+import { ContentOrigin } from 'services/Content/ContentApi';
+import { formatDateForPicker, formatTemplateDate, isDateValid } from 'helpers';
 import { createUseStyles } from 'react-jss';
-import dayjs from 'dayjs';
 
 const useStyles = createUseStyles({
   snapshotInfoText: {
@@ -49,8 +35,6 @@ const useStyles = createUseStyles({
 
 export default function SetUpDateStep() {
   const classes = useStyles();
-  const path = useHref('content');
-  const pathname = path.split('content')[0] + 'content';
 
   const { templateRequest, setTemplateRequest, selectedRedhatRepos, selectedCustomRepos } =
     useAddTemplateContext();
@@ -59,6 +43,13 @@ export default function SetUpDateStep() {
     [...selectedRedhatRepos, ...selectedCustomRepos],
     formatTemplateDate(templateRequest?.date || ''),
   );
+
+  useEffect(() => {
+    setTemplateRequest({
+      ...templateRequest,
+      date: templateRequest ? formatDateForPicker(templateRequest.date) : '',
+    });
+  }, []);
 
   const dateValidators = [
     (date: Date) => {
@@ -70,8 +61,7 @@ export default function SetUpDateStep() {
   ];
 
   const dateIsValid = useMemo(
-    () =>
-      RegExp(/^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/).test(templateRequest?.date || ''),
+    () => isDateValid(templateRequest?.date || ''),
     [templateRequest?.date],
   );
 
@@ -84,8 +74,6 @@ export default function SetUpDateStep() {
       mutateAsync();
     }
   }, [selectedRedhatRepos.size, selectedCustomRepos.size, templateRequest?.date]);
-
-  const columnHeaders = ['Name', /* 'Label',*/ 'Advisories', 'Packages'];
 
   const itemsAfterDate = useMemo(
     () => data?.data?.filter(({ is_after }) => is_after) || [],
@@ -107,16 +95,23 @@ export default function SetUpDateStep() {
 
   return (
     <Grid hasGutter>
-      <Title ouiaId='set_up_snapshot_date' headingLevel='h1'>
-        Set up snapshot date
+      <Title ouiaId='set_up_date' headingLevel='h1'>
+        Set up date
       </Title>
+      <Text component={TextVariants.h6}>
+        This will include snapshots up to a specific date. Content of the snapshots created after
+        the selected date will be displayed as applicable, not installable.
+      </Text>
+      <Text component={TextVariants.h6}>
+        <b>Select date for snapshotted repositories</b>
+      </Text>
       <FormGroup className={classes.radioGroup}>
         <Radio
           id='use latest snapshot radio'
           ouiaId='use-latest-snapshot-radio'
           name='use-latest-snapshot'
           label='Use latest content'
-          description='Always use latest content from repositories.'
+          description='Always use latest content from repositories. Snapshots may be updated daily.'
           isChecked={templateRequest.use_latest}
           onChange={() => {
             if (!templateRequest.use_latest) {
@@ -128,8 +123,8 @@ export default function SetUpDateStep() {
           id='use snapshot date radio'
           ouiaId='use-snapshot-date-radio'
           name='use-snapshot-date'
-          label='Use a snapshot'
-          description='Use content from snapshots up to a specific date.'
+          label='Use up to specific date'
+          description='Includes repository changes up to this date.'
           isChecked={!templateRequest.use_latest}
           onChange={() => {
             if (templateRequest.use_latest) {
@@ -137,113 +132,50 @@ export default function SetUpDateStep() {
             }
           }}
         />
+        <DatePicker
+          value={templateRequest.date ?? ''}
+          required
+          requiredDateOptions={{ isRequired: true }}
+          style={{ paddingLeft: '20px' }}
+          validators={dateValidators}
+          popoverProps={{
+            position: 'right',
+            enableFlip: true,
+            flipBehavior: ['right', 'right-start', 'right-end', 'top-start', 'top'],
+          }}
+          onChange={(_, val) => {
+            setTemplateRequest((prev) => ({ ...prev, date: val }));
+          }}
+          // defaultValue={templateRequest.date ?? undefined}
+        />
       </FormGroup>
-
-      <Hide hide={!!templateRequest.use_latest}>
-        <Title headingLevel='h1' size='xl'>
-          Use a snapshot
-        </Title>
-        <Text component={TextVariants.h6}>
-          This will include snapshots up to a specific date. Content of the snapshots created after
-          the selected date will be displayed as applicable, not installable.
-        </Text>
-        <GridItem>
-          <Text component={TextVariants.h6}>
-            <b>Select date for snapshotted repositories</b>
-          </Text>
-        </GridItem>
-        <FormGroup label='Include repository changes up to this date' required>
-          <DatePicker
-            value={formatDateForPicker(templateRequest.date)}
-            required
-            requiredDateOptions={{ isRequired: true }}
-            validators={dateValidators}
-            onChange={(_, val) => {
-              setTemplateRequest((prev) => ({ ...prev, date: val }));
-            }}
-          />
-          <Hide hide={!hasIsAfter || !dateIsValid}>
-            <FormAlert style={{ paddingTop: '20px' }}>
-              <Alert
-                variant='warning'
-                title='The items listed in the table below have snapshots after the selected date.'
-                isInline
-              />
-            </FormAlert>
-            <Hide hide={!isLoading}>
-              <Grid className=''>
-                <SkeletonTable
-                  rows={10}
-                  columnsCount={columnHeaders.length}
-                  variant={TableVariant.compact}
-                />
-              </Grid>
-            </Hide>
+      <Hide hide={!hasIsAfter || !dateIsValid}>
+        <FormAlert>
+          <Alert
+            variant='warning'
+            title='Selected date doesn’t include the only snapshot of some selected repositories.'
+            isInline
+          >
             <Hide hide={isLoading}>
-              <Table aria-label='Set up date table' ouiaId='setup_date_table' variant='compact'>
-                <Thead>
-                  <Tr>
-                    {columnHeaders.map((columnHeader) => (
-                      <Th key={columnHeader + 'column'}>{columnHeader}</Th>
-                    ))}
-                  </Tr>
-                </Thead>
-                <Tbody>
-                  {contentData.data?.map((rowData: ContentItem) => {
-                    const { uuid, name, url } = rowData;
-                    return (
-                      <Tr key={uuid}>
-                        <Td>
-                          <ConditionalTooltip show={name.length > 60} content={name}>
-                            <>{reduceStringToCharsWithEllipsis(name, 60)}</>
-                          </ConditionalTooltip>
-                          <ConditionalTooltip show={url.length > 50} content={url}>
-                            <UrlWithExternalIcon
-                              href={url}
-                              customText={reduceStringToCharsWithEllipsis(url)}
-                            />
-                          </ConditionalTooltip>
-                          <Hide hide={!rowData?.last_snapshot?.created_at}>
-                            <FlexItem className={classes.snapshotInfoText}>
-                              Last snapshot {dayjs(rowData?.last_snapshot?.created_at).fromNow()}
-                            </FlexItem>
-                          </Hide>
-                        </Td>
-                        <Td>{rowData.last_snapshot?.content_counts?.['rpm.advisory'] || '-'}</Td>
-                        <Td>
-                          <PackageCount
-                            rowData={rowData}
-                            href={pathname + '/' + REPOSITORIES_ROUTE + `/${rowData.uuid}/packages`}
-                            opensNewTab
-                          />
-                        </Td>
-                      </Tr>
-                    );
-                  })}
-                </Tbody>
-              </Table>
-              <ExpandableSection
-                toggleText='What does it mean?'
-                aria-label='quickStart-expansion'
-                data-ouia-component-id='quickstart_expand'
-                className={classes.whatDoesItMean}
-              >
-                <TextContent>
-                  <TextList>
-                    <TextListItem>
-                      No snapshots exist for these repositories on the specified date.
-                    </TextListItem>
-                    <TextListItem>The closest snapshots after that date will be used.</TextListItem>
-                    <TextListItem>
-                      Depending on the repository and time difference, this could cause a dependency
-                      issue.
-                    </TextListItem>
-                  </TextList>
-                </TextContent>
-              </ExpandableSection>
+              {contentData.data?.reduce((acc, current, index, array) => {
+                const { name } = current;
+                if (index != 0 && index + 1 === array.length) {
+                  acc += `and "${name}" `;
+                } else if (array.length === 1) {
+                  acc += `"${name}" `;
+                } else {
+                  acc += `"${name}", `;
+                }
+
+                if (index + 1 == array.length) {
+                  acc += array.length === 1 ? 'repository ' : 'repositories ';
+                  acc += 'will be included anyway.';
+                }
+                return acc;
+              }, 'The content of the ')}
             </Hide>
-          </Hide>
-        </FormGroup>
+          </Alert>
+        </FormAlert>
       </Hide>
     </Grid>
   );

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -50,6 +50,10 @@ export const formatDateUTC = (date: string): string => {
   return utc.format('DD MMM YYYY - HH:mm:ss [(UTC)]');
 };
 
+export const isDateValid = (date: string): boolean =>
+  RegExp(/^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/).test(date) &&
+  dayjs(date).isBefore(dayjs().endOf('day'));
+
 export const reduceStringToCharsWithEllipsis = (str: string, maxLength: number = 50) =>
   str.length > maxLength ? str.split('').slice(0, maxLength).join('') + '...' : str;
 


### PR DESCRIPTION
## Summary
This PR fixes the existing problems with the date picker (weird input behavior, problematic validation and it makes the "next" action dependent on the input) in our template wizard and also implements proposed UX changes.

![image](https://github.com/user-attachments/assets/df5dd2aa-beba-4982-8745-9013b48ae8f8)


## Testing steps
1. Verify the date picker works correctly/better than before. (i.e. no "Invalid Date" strings, you can type out the date normally)
2. Check that the warning and the listed repos are showing up correctly. (i.e. all repos that have all snapshots past the selected date are showing up only when they should)
3. Make sure the "Next" button doesn't allow you to go further if the "Use up to specific date" option is selected and the date isn't valid.
