### PR TITLE
Fixes kebab being disabled on content list page

### DIFF
--- a/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
@@ -643,7 +643,6 @@ const ContentListTable = () => {
                                   rowData.status,
                                 )}
                                 show={!isRedHatRepository && rowData?.status === 'Pending'}
-                                setDisabled
                               >
                                 <ActionsColumn items={rowActions(rowData)} />
                               </ConditionalTooltip>


### PR DESCRIPTION
## Summary

Kebab no longer needs to be disabled on the content list page. 

This fix is the result of a failing test! Huzzah!

## Testing steps
