### PR TITLE
Build: add data-uuid to latest snap config

### DIFF
--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
@@ -190,6 +190,8 @@ const SnapshotListModal = () => {
 
   const isRedHatRepository = contentOrigin === ContentOrigin.REDHAT;
 
+  const latestSnapshotUUID = snapshotsList[0]?.uuid;
+
   const rowActions = useCallback(
     (snap_uuid: string): IAction[] =>
       isRedHatRepository
@@ -275,7 +277,7 @@ const SnapshotListModal = () => {
                   </FlexItem>
                 </Hide>
                 <FlexItem>
-                  <LatestRepoConfig repoUUID={uuid} />
+                  <LatestRepoConfig repoUUID={uuid} snapUUID={latestSnapshotUUID} />
                 </FlexItem>
                 <FlexItem>
                   <Pagination

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/components/LatestRepoConfig.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/components/LatestRepoConfig.tsx
@@ -3,9 +3,10 @@ import RepoConfig from './RepoConfig';
 
 interface Props {
   repoUUID: string;
+  snapUUID: string;
 }
 
-const LatestRepoConfig = ({ repoUUID }: Props) => (
+const LatestRepoConfig = ({ repoUUID, snapUUID }: Props) => (
   <Flex>
     <FlexItem>
       <TextContent>
@@ -13,7 +14,7 @@ const LatestRepoConfig = ({ repoUUID }: Props) => (
       </TextContent>
     </FlexItem>
     <FlexItem>
-      <RepoConfig repoUUID={repoUUID} snapUUID='' latest />
+      <RepoConfig repoUUID={repoUUID} snapUUID={snapUUID} latest />
     </FlexItem>
   </Flex>
 );

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/components/RepoConfig.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/components/RepoConfig.tsx
@@ -56,6 +56,7 @@ const RepoConfig = ({ repoUUID, snapUUID, latest }: Props) => {
           variant='link'
           className={classes.link}
           onClick={() => copyConfigFile()}
+          data-uuid={snapUUID}
         >
           <Icon>
             <CopyIcon />
@@ -69,6 +70,7 @@ const RepoConfig = ({ repoUUID, snapUUID, latest }: Props) => {
           variant='link'
           className={classes.link}
           onClick={() => downloadConfigFile()}
+          data-uuid={snapUUID}
         >
           <Icon>
             <DownloadIcon />


### PR DESCRIPTION
## Summary

This adds the latest snapshot uuid as a data-uuid on the latest snapshot config buttons so we can target that in IQE tests ([HMS-4890](https://issues.redhat.com/browse/HMS-4890)) 

## Testing steps

`data-uuid` should be set to the latest snapshot uuid on the copy and download buttons for the latest snapshot config
