### PR TITLE
Add line about use of proxy when running playwright tests

### DIFF
--- a/playwright_example.env
+++ b/playwright_example.env
@@ -6,3 +6,4 @@ USER1PASSWORD="" # Required
 BASE_URL="https://stage.foo.redhat.com:1337" # Required
 CI="" # This is set to true for CI jobs, if checking for CI do  !!process.env.CI
 TOKEN="" # This is handled programmatically.
+PROXY="" # Set this if running directly against stage (not using "yarn local")


### PR DESCRIPTION
## Summary

Explain when to use proxy for running playwright tests

## Testing steps

```
:~/content-sources-frontend$ grep -r PROXY playwright_example.env 
PROXY="" # Set this if running directly against stage (not using "yarn local")
```
