### PR TITLE
HMS-5426: add PW test for RH repos

### DIFF
--- a/_playwright-tests/UI/RedHatRepo.spec.ts
+++ b/_playwright-tests/UI/RedHatRepo.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { navigateToRepositories } from './helpers/navHelpers';
+import { closePopupsIfExist } from './helpers/helpers';
+
+test.describe('Red Hat Repositories', () => {
+    const smallRHRepo = 'Red Hat Ansible Engine 2 for RHEL 8 x86_64 (RPMs)'
+
+    test.beforeEach(async ({ page }) => {
+        await test.step('Navigate to repositories page', async () => {
+            await navigateToRepositories(page);
+            await closePopupsIfExist(page);
+        });
+        await test.step('Navigate to Red Hat repositories', async () => {
+            await page.getByRole('button', { name: 'Red Hat' }).click();
+        });
+    });
+
+    test('Wait for repository status to be "Valid"', async ({ page }) => {
+        test.setTimeout(600000);
+        const status = page
+            .getByRole('row')
+            .filter({ hasText: smallRHRepo })
+            .getByRole('gridcell')
+            .filter({ hasText: 'Valid' });
+        
+        await test.step('Filter repos by name', async () => {
+            await page.getByPlaceholder('Filter by name/url').fill(smallRHRepo);
+        });
+
+        await test.step('Wait for a valid status', async () => {
+            await status.waitFor({ state: 'visible' });
+        });
+    });
+
+    test('Check repository snapshots', async ({ page }) => {
+        await test.step('Open the snapshots list modal', async () => {
+            await page
+                .getByRole('row')
+                .filter({ hasText: smallRHRepo })
+                .getByLabel('Kebab toggle')
+                .click();
+            await expect(page.getByRole('menuitem', { name: 'View all snapshots' })).toBeVisible();
+            await page.getByRole('menuitem', { name: 'View all snapshots' }).click();
+            await expect(page
+                .getByTestId('snapshot_list_modal')
+                .filter({ hasText: smallRHRepo }))
+                .toBeVisible();
+        });
+
+        await test.step('Close the snapshots list modal', async () => {
+            // Using testId here because the modal has 2 close buttons
+            await page.getByTestId('snapshot_list_modal-ModalBoxCloseButton').click();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Depends on this [PR](https://github.com/content-services/content-sources-frontend/pull/440) adding in the CDN cert
- Adds test to validate the imported RH repo exists, has a status of "Valid", and has at least one snapshot

## Testing steps

- Tests pass, all criteria in linked issue is covered