### PR TITLE
Build: allow for prs with Test prefix

### DIFF
--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
-          regex: '^Build|^(\w+-\d+(,\w+-\d+)*): .+' # Regex the title should match.
+          regex: '^Build|Test|^(\w+-\d+(,\w+-\d+)*): .+' # Regex the title should match.
           disallowed_prefixes: "" # title should not start with the given prefix
           prefix_case_sensitive: false # title prefix are case insensitive
           min_length: 5 # Min length of the title


### PR DESCRIPTION
Same as https://github.com/content-services/content-sources-backend/pull/966
