### PR TITLE
Test: allow targeting of elements by OUIA ID

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
     baseURL: process.env.BASE_URL,
     trace: 'on-first-retry',
     ignoreHTTPSErrors: true,
+    testIdAttribute: 'data-ouia-component-id'
   },
   projects: [
     { name: 'setup', testMatch: /.*\.setup\.ts/ },


### PR DESCRIPTION
## Summary

Adjusts the `testIdAttribute` in the PW config so we can also target elements by their existing OUIA ID if they have one (ref: https://playwright.dev/docs/api/class-testoptions#test-options-test-id-attribute)

## Testing steps

Tested in this [PR](https://github.com/content-services/content-sources-frontend/pull/424/files#diff-2e9a283d227e8009621a499930fe4cc45b364803fc6967adb0c1c644455d79acR10), you could also adjust an existing test case to target an element by OUIA ID to verify