### PR TITLE
Test: fix describe usage, use playwright test describe

### DIFF
--- a/_playwright-tests/UI/CustomRepo.spec.ts
+++ b/_playwright-tests/UI/CustomRepo.spec.ts
@@ -1,10 +1,9 @@
-import { describe } from 'node:test';
 import { test, expect, type Page } from '@playwright/test';
 import { navigateToRepositories } from './helpers/navHelpers';
 import { deleteAllRepos } from './helpers/deleteRepositories';
 import { closePopupsIfExist } from './helpers/helpers';
 
-describe('Custom Repositories', () => {
+test.describe('Custom Repositories', () => {
   test('Clean - Delete any current repos that exist', async ({ page }) => {
     await deleteAllRepos(page);
   });

--- a/_playwright-tests/UI/Templates.spec.ts
+++ b/_playwright-tests/UI/Templates.spec.ts
@@ -1,9 +1,8 @@
-import { describe } from 'node:test';
 import { test } from '@playwright/test';
 import { navigateToTemplates } from './helpers/navHelpers';
 import { closePopupsIfExist } from './helpers/helpers';
 
-describe('Templates', () => {
+test.describe('Templates', () => {
   test('Navigate to templates, make sure the Add content template button can be clicked', async ({
     page,
   }) => {

--- a/_playwright-tests/UI/UploadRepo.spec.ts
+++ b/_playwright-tests/UI/UploadRepo.spec.ts
@@ -1,11 +1,10 @@
-import { describe } from 'node:test';
 import { test, expect } from '@playwright/test';
 import { navigateToRepositories } from './helpers/navHelpers';
 import path from 'path';
 import { closePopupsIfExist } from './helpers/helpers';
 import { deleteAllRepos } from './helpers/deleteRepositories';
 
-describe('Upload Repositories', () => {
+test.describe('Upload Repositories', () => {
   test('Clean - Delete any current repos that exist', async ({ page }) => {
     await deleteAllRepos(page);
   });

--- a/_playwright-tests/auth.setup.ts
+++ b/_playwright-tests/auth.setup.ts
@@ -4,10 +4,9 @@ import {
   logInWithUser1,
   storeStorageStateAndToken,
 } from './helpers/loginHelpers';
-import { describe } from 'node:test';
 import { closePopupsIfExist } from './UI/helpers/helpers';
 
-describe('Setup', async () => {
+setup.describe('Setup', async () => {
   setup('Ensure needed ENV variables exist', async () => {
     expect(() => throwIfMissingEnvVariables()).not.toThrow();
   });


### PR DESCRIPTION
## Summary
This PR is a small fix that changes the so far used describe method for test suites to one that comes from `playwright` rather then from `node:test`. This will enable integration with playwright adapters and minimize imports.

## Testing steps
- Verify that tests run as expected.
- If you are using playwright through some sort of plugin/extension, you should now have option to run the whole describe with one action. (i.e.: if you are using VS Code, you will have a play/run button next to the describe 🎉 )