### PR TITLE
HMS-5425: add PW tests for introspect repos

### DIFF
--- a/_playwright-tests/UI/IntrospectRepo.spec.ts
+++ b/_playwright-tests/UI/IntrospectRepo.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import { navigateToRepositories } from './helpers/navHelpers';
+import { closePopupsIfExist, getRowByName } from './helpers/helpers';
+import { deleteAllRepos } from './helpers/deleteRepositories';
+
+test.describe('Introspect Repositories', () => {
+  const repoName = 'introspection-test';
+  const repoUrl = 'https://fedorapeople.org/groups/katello/fakerepos/zoo/';
+
+  test.beforeEach(async ({ page }) => {
+    await test.step('Navigate to the repository page', async () => {
+      await navigateToRepositories(page);
+      await closePopupsIfExist(page);
+    });
+  });
+
+  test('Create an introspection repository', async ({ page }) => {
+    await test.step('Cleanup repository, if using the same url', async () => {
+      await deleteAllRepos(page, `&url=${repoUrl}`);
+    });
+
+    await test.step('Open the add repository modal', async () => {
+      await page.getByRole('button', { name: 'Add repositories' }).first().click();
+      await expect(page.getByText('Add custom repositories')).toBeVisible();
+    });
+
+    await test.step('Fill the create repository form', async () => {
+      await page.getByPlaceholder('Enter name').fill(repoName);
+      await page.getByPlaceholder('https://').fill(repoUrl);
+    });
+
+    await test.step('Submit the form and wait for modal to disappear', async () => {
+      await Promise.all([
+        page.getByRole('button', { name: 'Save' }).click(),
+        page.waitForResponse(
+          (resp) =>
+            resp.url().includes('/bulk_create/') && resp.status() >= 200 && resp.status() < 300,
+        ),
+        expect(page.getByText('Add custom repositories')).not.toBeVisible(),
+      ]);
+    });
+  });
+
+  test('Wait for valid introspection status', async ({ page }) => {
+    await test.step('Wait for status to be "Valid"', async () => {
+      const row = await getRowByName(page, repoName);
+      await expect(row.getByText('Valid')).toBeVisible();
+    });
+  });
+
+  test('Check introspected repository packages', async ({ page }) => {
+    await test.step('Open the packages modal', async () => {
+      const row = await getRowByName(page, repoName);
+      await row.getByRole('gridcell', { name: '8', exact: true }).locator('a').click();
+      await expect(page.getByText('View list of packages')).toBeVisible();
+    });
+
+    await test.step('Check the modal for expected content', async () => {
+      await Promise.all([
+        expect(page.getByText('noarch')).toHaveCount(8),
+        expect(page.getByText('cheetah')).toBeVisible(),
+        expect(page.getByText('0.3').first()).toBeVisible(),
+        expect(page.getByText('0.8').first()).toBeVisible(),
+        expect(page.getByText('noarch').first()).toBeVisible(),
+      ]);
+    });
+  });
+
+  test('Delete introspected repository', async ({ page }) => {
+    await test.step('Delete created repository', async () => {
+      const row = await getRowByName(page, repoName);
+      await row.getByLabel('Kebab toggle').first().click();
+      await row.getByRole('menuitem', { name: 'Delete' }).click();
+      await expect(page.getByText('Remove repositories?')).toBeVisible();
+
+      await Promise.all([
+        page.waitForResponse(
+          (resp) =>
+            resp.url().includes('bulk_delete') && resp.status() >= 200 && resp.status() < 300,
+        ),
+        page.getByRole('button', { name: 'Remove' }).click(),
+      ]);
+    });
+  });
+});

--- a/_playwright-tests/UI/IntrospectRepo.spec.ts
+++ b/_playwright-tests/UI/IntrospectRepo.spec.ts
@@ -56,6 +56,7 @@ test.describe('Introspect Repositories', () => {
       const row = await getRowByName(page, repoName);
       await row.getByRole('gridcell', { name: repoPackageCount, exact: true }).locator('a').click();
       await expect(page.getByText('View list of packages')).toBeVisible();
+      await expect(page.getByText('Version').first()).toBeVisible();
     });
 
     await test.step('Check the modal for expected content', async () => {

--- a/_playwright-tests/UI/IntrospectRepo.spec.ts
+++ b/_playwright-tests/UI/IntrospectRepo.spec.ts
@@ -10,6 +10,7 @@ test.describe('Introspect Repositories', () => {
   const repoVersion = '0.3';
   const repoRelease = '0.8';
   const repoArch = 'noarch';
+  const testPackage = 'cheetah';
 
   test.beforeEach(async ({ page }) => {
     await test.step('Navigate to the repository page', async () => {
@@ -60,12 +61,13 @@ test.describe('Introspect Repositories', () => {
     });
 
     await test.step('Check the modal for expected content', async () => {
+      const row = page.getByRole('row').filter({ has: page.getByText(testPackage) });
       await Promise.all([
         expect(page.getByText(repoArch)).toHaveCount(8),
-        expect(page.getByText('cheetah')).toBeVisible(),
-        expect(page.getByText(repoVersion).first()).toBeVisible(),
-        expect(page.getByText(repoRelease).first()).toBeVisible(),
-        expect(page.getByText(repoArch).first()).toBeVisible(),
+        expect(row.getByText(testPackage)).toBeVisible(),
+        expect(row.getByText(repoVersion)).toBeVisible(),
+        expect(row.getByText(repoRelease)).toBeVisible(),
+        expect(row.getByText(repoArch)).toBeVisible(),
       ]);
     });
   });

--- a/_playwright-tests/UI/IntrospectRepo.spec.ts
+++ b/_playwright-tests/UI/IntrospectRepo.spec.ts
@@ -1,11 +1,15 @@
 import { test, expect } from '@playwright/test';
 import { navigateToRepositories } from './helpers/navHelpers';
-import { closePopupsIfExist, getRowByName } from './helpers/helpers';
+import { clearFilters, closePopupsIfExist, getRowByName } from './helpers/helpers';
 import { deleteAllRepos } from './helpers/deleteRepositories';
 
 test.describe('Introspect Repositories', () => {
   const repoName = 'introspection-test';
   const repoUrl = 'https://fedorapeople.org/groups/katello/fakerepos/zoo/';
+  const repoPackageCount = '8';
+  const repoVersion = '0.3';
+  const repoRelease = '0.8';
+  const repoArch = 'noarch';
 
   test.beforeEach(async ({ page }) => {
     await test.step('Navigate to the repository page', async () => {
@@ -51,17 +55,17 @@ test.describe('Introspect Repositories', () => {
   test('Check introspected repository packages', async ({ page }) => {
     await test.step('Open the packages modal', async () => {
       const row = await getRowByName(page, repoName);
-      await row.getByRole('gridcell', { name: '8', exact: true }).locator('a').click();
+      await row.getByRole('gridcell', { name: repoPackageCount, exact: true }).locator('a').click();
       await expect(page.getByText('View list of packages')).toBeVisible();
     });
 
     await test.step('Check the modal for expected content', async () => {
       await Promise.all([
-        expect(page.getByText('noarch')).toHaveCount(8),
+        expect(page.getByText(repoArch)).toHaveCount(8),
         expect(page.getByText('cheetah')).toBeVisible(),
-        expect(page.getByText('0.3').first()).toBeVisible(),
-        expect(page.getByText('0.8').first()).toBeVisible(),
-        expect(page.getByText('noarch').first()).toBeVisible(),
+        expect(page.getByText(repoVersion).first()).toBeVisible(),
+        expect(page.getByText(repoRelease).first()).toBeVisible(),
+        expect(page.getByText(repoArch).first()).toBeVisible(),
       ]);
     });
   });
@@ -69,7 +73,7 @@ test.describe('Introspect Repositories', () => {
   test('Delete introspected repository', async ({ page }) => {
     await test.step('Delete created repository', async () => {
       const row = await getRowByName(page, repoName);
-      await row.getByLabel('Kebab toggle').first().click();
+      await row.getByLabel('Kebab toggle').click();
       await row.getByRole('menuitem', { name: 'Delete' }).click();
       await expect(page.getByText('Remove repositories?')).toBeVisible();
 
@@ -80,6 +84,9 @@ test.describe('Introspect Repositories', () => {
         ),
         page.getByRole('button', { name: 'Remove' }).click(),
       ]);
+
+      await clearFilters(page);
+      await expect(page.getByText(repoName)).not.toBeVisible();
     });
   });
 });

--- a/_playwright-tests/UI/IntrospectRepo.spec.ts
+++ b/_playwright-tests/UI/IntrospectRepo.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { navigateToRepositories } from './helpers/navHelpers';
-import { clearFilters, closePopupsIfExist, getRowByName } from './helpers/helpers';
+import { closePopupsIfExist, getRowByName, getRowCellByHeader } from './helpers/helpers';
 import { deleteAllRepos } from './helpers/deleteRepositories';
 
 test.describe('Introspect Repositories', () => {
@@ -44,9 +44,7 @@ test.describe('Introspect Repositories', () => {
         expect(page.getByText('Add custom repositories')).not.toBeVisible(),
       ]);
     });
-  });
 
-  test('Wait for valid introspection status', async ({ page }) => {
     await test.step('Wait for status to be "Valid"', async () => {
       const row = await getRowByName(page, repoName);
       await expect(row.getByText('Valid')).toBeVisible();
@@ -64,10 +62,10 @@ test.describe('Introspect Repositories', () => {
       const row = page.getByRole('row').filter({ has: page.getByText(testPackage) });
       await Promise.all([
         expect(page.getByText(repoArch)).toHaveCount(8),
-        expect(row.getByText(testPackage)).toBeVisible(),
-        expect(row.getByText(repoVersion)).toBeVisible(),
-        expect(row.getByText(repoRelease)).toBeVisible(),
-        expect(row.getByText(repoArch)).toBeVisible(),
+        expect((await getRowCellByHeader(row, 'Name')).getByText(testPackage)).toBeVisible(),
+        expect((await getRowCellByHeader(row, 'Version')).getByText(repoVersion)).toBeVisible(),
+        expect((await getRowCellByHeader(row, 'Release')).getByText(repoRelease)).toBeVisible(),
+        expect((await getRowCellByHeader(row, 'Arch')).getByText(repoArch)).toBeVisible(),
       ]);
     });
   });
@@ -87,8 +85,9 @@ test.describe('Introspect Repositories', () => {
         page.getByRole('button', { name: 'Remove' }).click(),
       ]);
 
-      await clearFilters(page);
-      await expect(page.getByText(repoName)).not.toBeVisible();
+      await expect(
+        page.getByText('No custom repositories match the filter criteria'),
+      ).toBeVisible();
     });
   });
 });

--- a/_playwright-tests/UI/helpers/deleteRepositories.ts
+++ b/_playwright-tests/UI/helpers/deleteRepositories.ts
@@ -1,8 +1,8 @@
 import { expect, type Page } from '@playwright/test';
 
-export const deleteAllRepos = async ({ request }: Page) => {
+export const deleteAllRepos = async ({ request }: Page, filter?: string) => {
   const response = await request.get(
-    '/api/content-sources/v1/repositories/?origin=external,upload',
+    `/api/content-sources/v1/repositories/?origin=external,upload${filter}`,
   );
 
   // Ensure the request was successful
@@ -32,7 +32,5 @@ export const deleteAllRepos = async ({ request }: Page) => {
       console.error('Failed to delete repositories:', error);
       throw error; // Optionally re-throw the error if you need to fail the test
     }
-  } else {
-    console.log('No repositories to delete.');
   }
 };

--- a/_playwright-tests/UI/helpers/helpers.ts
+++ b/_playwright-tests/UI/helpers/helpers.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import { Page } from '@playwright/test';
 
 export const closePopupsIfExist = async (page: Page) => {
   const locatorsToCheck = [
@@ -14,11 +14,22 @@ export const closePopupsIfExist = async (page: Page) => {
     });
   }
 };
+export const filterByName = async (page: Page, name: string) => {
+  await page.getByPlaceholder(/^Filter by name.*$/).fill(name);
+};
+
+export const clearFilters = async (page: Page) => {
+  try {
+    await page.getByRole('button', { name: 'Clear filters' }).waitFor({ timeout: 5000 });
+  } catch {
+    return Promise<void>;
+  }
+
+  await page.getByRole('button', { name: 'Clear filters' }).click();
+};
 
 export const getRowByName = async (page: Page, name: string) => {
-  if (await page.getByRole('button', { name: 'Clear filters' }).isVisible()) {
-    await page.getByRole('button', { name: 'Clear filters' }).click();
-  }
-  await page.getByPlaceholder(/^Filter by name.*$/).fill(name);
+  await clearFilters(page);
+  await filterByName(page, name);
   return page.getByRole('row').filter({ has: page.getByText(name) });
 };

--- a/_playwright-tests/UI/helpers/helpers.ts
+++ b/_playwright-tests/UI/helpers/helpers.ts
@@ -22,7 +22,7 @@ export const clearFilters = async (page: Page) => {
   try {
     await page.getByRole('button', { name: 'Clear filters' }).waitFor({ timeout: 5000 });
   } catch {
-    return Promise<void>;
+    return;
   }
 
   await page.getByRole('button', { name: 'Clear filters' }).click();

--- a/_playwright-tests/UI/helpers/helpers.ts
+++ b/_playwright-tests/UI/helpers/helpers.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import { Page, Locator } from '@playwright/test';
 
 export const closePopupsIfExist = async (page: Page) => {
   const locatorsToCheck = [
@@ -32,4 +32,27 @@ export const getRowByName = async (page: Page, name: string) => {
   await clearFilters(page);
   await filterByName(page, name);
   return page.getByRole('row').filter({ has: page.getByText(name) });
+};
+
+export const getRowCellByHeader = async (row: Locator, name: string) => {
+  const table = row.locator('xpath=ancestor::*[@role="grid" or @role="table"][1]');
+  const headers = table.getByRole('columnheader');
+  const headerCount = await headers.count();
+
+  let index = -1;
+  for (let i = 0; i < headerCount; i++) {
+    let headerContent = (await headers.nth(i).textContent()) || '';
+    headerContent = headerContent.trim();
+
+    if (headerContent.includes(name)) {
+      index = i;
+      break;
+    }
+  }
+
+  if (index == -1) {
+    throw new Error(`Header "${name}" not found in the table/grid.`);
+  }
+
+  return row.getByRole('gridcell').nth(index);
 };

--- a/_playwright-tests/UI/helpers/helpers.ts
+++ b/_playwright-tests/UI/helpers/helpers.ts
@@ -14,3 +14,11 @@ export const closePopupsIfExist = async (page: Page) => {
     });
   }
 };
+
+export const getRowByName = async (page: Page, name: string) => {
+  if (await page.getByRole('button', { name: 'Clear filters' }).isVisible()) {
+    await page.getByRole('button', { name: 'Clear filters' }).click();
+  }
+  await page.getByPlaceholder(/^Filter by name.*$/).fill(name);
+  return page.getByRole('row').filter({ has: page.getByText(name) });
+};

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,12 +20,12 @@ export default defineConfig({
         ['./ci-reporter'],
       ]
     : 'list',
-  globalTimeout: 29.5 * 60 * 1000, // Set because of codebuild, we want PW to timeout before CB to get the results.
-  timeout: 10 * 60 * 1000,
-  expect: { timeout: process.env.CI ? 30_000 : 20_000 },
+  globalTimeout: 29.5 * 60 * 1000, // 29.5m, Set because of codebuild, we want PW to timeout before CB to get the results.
+  timeout: 10 * 60 * 1000, // 10m
+  expect: { timeout: 30_000 }, // 30s
   use: {
-    actionTimeout: 30_000,
-    navigationTimeout: 30_000,
+    actionTimeout: 30_000, // 30s
+    navigationTimeout: 30_000, // 30s
     launchOptions: {
       args: ['--use-fake-device-for-media-stream'],
     },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,8 +20,8 @@ export default defineConfig({
         ['./ci-reporter'],
       ]
     : 'list',
-  timeout: process.env.CI ? 60000 : 30000,
-  expect: { timeout: process.env.CI ? 30000 : 20000 },
+  timeout: 900_000,
+  expect: { timeout: process.env.CI ? 30_000 : 20_000 },
   use: {
     launchOptions: {
       args: ['--use-fake-device-for-media-stream'],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,9 +20,12 @@ export default defineConfig({
         ['./ci-reporter'],
       ]
     : 'list',
-  timeout: 900_000,
+  globalTimeout: 29.5 * 60 * 1000, // Set because of codebuild, we want PW to timeout before CB to get the results.
+  timeout: 10 * 60 * 1000,
   expect: { timeout: process.env.CI ? 30_000 : 20_000 },
   use: {
+    actionTimeout: 30_000,
+    navigationTimeout: 30_000,
     launchOptions: {
       args: ['--use-fake-device-for-media-stream'],
     },


### PR DESCRIPTION
## Summary
This PR adds PW tests for introspect only repositories. Also adds new helper `getRowByName()` that simplifies getting a locator for a specific row. Small change to `deleteAllRepos()` helper to minimize repeating ourselves. 

## Testing steps
- Verify that all tests in `IntrospectRepo.spec.ts` pass and test the necessary stuff listed in the related issue description.
