### PR TITLE
Test: Allow triggering pw manually

### DIFF
--- a/.github/workflows/playwright-actions.yml
+++ b/.github/workflows/playwright-actions.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/playwright-actions.yml
+++ b/.github/workflows/playwright-actions.yml
@@ -2,6 +2,7 @@ name: build-playwright-test
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, labeled, unlabeled]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This would allow us to test changes to `playwright-actions.yml`

Note: This will only allow us to trigger it manually. I have sneaky suspicion that it won't work yet as we check for some PR specific items. I will then debug it and condition these things only for triggers coming from PRs.
