### PR TITLE
Test: Don't assume order of reporters

### DIFF
--- a/.github/workflows/playwright-actions.yml
+++ b/.github/workflows/playwright-actions.yml
@@ -191,7 +191,7 @@ jobs:
 
       - name: Store test summary
         if: ${{ !cancelled() }}
-        run: tail -2 pw-output | head -1 > playwright-report/summary
+        run: grep "test(s)" pw-output > playwright-report/summary
 
       - name: Publish front-end Test Report
         uses: ctrf-io/github-test-reporter@v1


### PR DESCRIPTION
When using multiple reporters the order in which they log their output is not guaranteed. Rather match for pattern to find the expected message.

To avoid situations like these:
![Screenshot from 2025-02-12 15-21-37](https://github.com/user-attachments/assets/15c0ef3f-bc7c-4288-a030-6b51f262924a)

