### PR TITLE
Build: Use labels correctly in FormGroup

### DIFF
--- a/_playwright-tests/UI/CustomRepo.spec.ts
+++ b/_playwright-tests/UI/CustomRepo.spec.ts
@@ -52,10 +52,8 @@ const addRepository = async (page: Page, name: string, url: string) => {
   await expect(repositoryModal).toBeVisible();
 
   // Fill in the repository details
-  const nameInput = page.getByPlaceholder('Enter name');
-  const urlInput = page.getByPlaceholder('https://');
-  await nameInput.fill(name);
-  await urlInput.fill(url);
+  await page.getByLabel('Name').fill(name);
+  await page.getByLabel('URL').fill(url);
 
   // Filter by architecture
   const architectureFilterButton = page.getByRole('button', { name: 'filter architecture' });

--- a/_playwright-tests/UI/IntrospectRepo.spec.ts
+++ b/_playwright-tests/UI/IntrospectRepo.spec.ts
@@ -30,8 +30,8 @@ test.describe('Introspect Repositories', () => {
     });
 
     await test.step('Fill the create repository form', async () => {
-      await page.getByPlaceholder('Enter name').fill(repoName);
-      await page.getByPlaceholder('https://').fill(repoUrl);
+      await page.getByLabel('Name').fill(repoName);
+      await page.getByLabel('URL').fill(repoUrl);
     });
 
     await test.step('Submit the form and wait for modal to disappear', async () => {

--- a/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
@@ -443,7 +443,7 @@ const AddContent = ({ isEdit = false }: Props) => {
         <Loader />
       ) : (
         <Form>
-          <FormGroup label='Name' isRequired fieldId='namegroup'>
+          <FormGroup label='Name' isRequired fieldId='name'>
             <TextInput
               isRequired
               id='name'
@@ -575,7 +575,7 @@ const AddContent = ({ isEdit = false }: Props) => {
                 <OutlinedQuestionCircleIcon className='pf-u-ml-xs' color={global_Color_200.value} />
               </Tooltip>
             }
-            fieldId='arch'
+            fieldId='archSelection'
           >
             <DropdownSelect
               onSelect={(_, val) =>
@@ -610,9 +610,10 @@ const AddContent = ({ isEdit = false }: Props) => {
                 <OutlinedQuestionCircleIcon className='pf-u-ml-xs' color={global_Color_200.value} />
               </Tooltip>
             }
-            fieldId='version'
+            fieldId='versionSelection'
           >
             <DropdownSelect
+              id='version'
               onSelect={(_, val) => {
                 setVersionSelected(
                   versions.includes(val as string)
@@ -688,7 +689,7 @@ const AddContent = ({ isEdit = false }: Props) => {
                 <OutlinedQuestionCircleIcon className='pf-u-ml-xs' color={global_Color_200.value} />
               </Tooltip>
             }
-            fieldId='gpgKey'
+            fieldId='gpgKey-uploader'
           >
             <FileUpload
               className={classes.gpgKeyInput}

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotSelector.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotSelector.tsx
@@ -53,6 +53,7 @@ export function SnapshotSelector() {
         fieldId='snapshot'
       >
         <DropdownSelect
+          id='snapshot'
           onSelect={(_, val) => setSelected(val as string)}
           selected={uuidMapper[snapshotUUID]}
           menuToggleProps={{


### PR DESCRIPTION
We were not able to target some elements by label. This showed to be actually bug in our code which made some elements inaccessible. According to documentation [1]:
  fieldId: ID of an individual field or a group of multiple fields.
           Required when a role of "group" or "radiogroup" is passed in.
           If _only one field_ is included, its ID attribute and this prop _must be the same_.

[1] https://www.patternfly.org/components/forms/form/#formgroup