### PR TITLE
HMS-5574: Remove flags for popular repo and upload repo changes

### DIFF
--- a/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
@@ -56,7 +56,6 @@ import useRootPath from 'Hooks/useRootPath';
 import CustomHelperText from 'components/CustomHelperText/CustomHelperText';
 import { ADD_ROUTE, REPOSITORIES_ROUTE, UPLOAD_ROUTE } from 'Routes/constants';
 import { useFormik, type FormikValues } from 'formik';
-import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import Loader from 'components/Loader';
 import DropdownSelect from 'components/DropdownSelect/DropdownSelect';
 
@@ -101,14 +100,11 @@ const AddContent = ({ isEdit = false }: Props) => {
   const { repoUUID: uuid } = useParams();
   const navigate = useNavigate();
   const rootPath = useRootPath();
-  const { isProd, isBeta } = useChrome();
-  const isInProd = useMemo(() => isProd(), []);
-  const isInBeta = useMemo(() => isBeta(), []);
   const [errors, setErrors] = useState<Record<string, string>>({});
 
   const { data, isLoading: isLoadingInitialContent, isSuccess } = useFetchContent(uuid!, isEdit);
 
-  const [values, setValues] = useState(getDefaultValues(isInProd ? { snapshot: false } : {}));
+  const [values, setValues] = useState(getDefaultValues({}));
   const [changeVerified, setChangeVerified] = useState(false);
 
   useEffect(() => {
@@ -495,11 +491,7 @@ const AddContent = ({ isEdit = false }: Props) => {
                   }
                 />
               </Hide>
-              <Hide
-                hide={
-                  (isInProd && !isInBeta) || (isEdit && contentOrigin === ContentOrigin.EXTERNAL)
-                }
-              >
+              <Hide hide={isEdit && contentOrigin === ContentOrigin.EXTERNAL}>
                 <ConditionalTooltip
                   show={isEdit && contentOrigin === ContentOrigin.UPLOAD}
                   setDisabled={isEdit && contentOrigin === ContentOrigin.UPLOAD}

--- a/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.tsx
@@ -61,7 +61,6 @@ import {
   DropdownToggle,
   DropdownToggleAction,
 } from '@patternfly/react-core/deprecated';
-import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { DELETE_ROUTE } from 'Routes/constants';
 import { Outlet, useNavigate, useOutletContext } from 'react-router-dom';
 import useArchVersion from 'Hooks/useArchVersion';
@@ -144,9 +143,6 @@ const PopularRepositoriesTable = () => {
   const debouncedSearchValue = useDebounce(searchValue);
   const [perPage, setPerPage] = useState(storedPerPage);
   const [isActionOpen, setIsActionOpen] = useState(false);
-  const { isProd, isBeta } = useChrome();
-  const isInProd = useMemo(() => isProd() === true, []);
-  const isInBeta = useMemo(() => isBeta() === true, []);
 
   const {
     archesDisplay,
@@ -334,30 +330,16 @@ const PopularRepositoriesTable = () => {
 
   const countIsZero = !data?.data?.length;
 
-  const dropdownItems = useMemo(() => {
-    if (isInProd && !isInBeta) {
-      return [
-        <DropdownItem
-          key='action'
-          component='button'
-          onClick={() => addSelected(true)}
-          ouiaId='add-selected-repos-with-snap'
-        >
-          {`Add ${checkedRepositoriesToAdd.size} repositories with snapshotting`}
-        </DropdownItem>,
-      ];
-    } else
-      return [
-        <DropdownItem
-          key='action'
-          component='button'
-          onClick={() => addSelected(false)}
-          ouiaId='add-selected-repos-no-snap'
-        >
-          {`Add ${checkedRepositoriesToAdd.size} repositories without snapshotting`}
-        </DropdownItem>,
-      ];
-  }, [isInProd, isInBeta, checkedRepositoriesToAdd.size]);
+  const dropdownItems = [
+    <DropdownItem
+      key='action'
+      component='button'
+      onClick={() => addSelected(false)}
+      ouiaId='add-selected-repos-no-snap'
+    >
+      {`Add ${checkedRepositoriesToAdd.size} repositories without snapshotting`}
+    </DropdownItem>,
+  ];
 
   return (
     <>
@@ -405,69 +387,36 @@ const PopularRepositoriesTable = () => {
                       const isDisabled = !rbac?.repoWrite || !atLeastOneRepoToAddChecked;
                       if (features?.snapshots?.enabled && features.snapshots.accessible) {
                         const className = isDisabled ? classes.disabledDropdownButton : undefined;
-                        // temporarily disable snapshotting by default for popular repos
-                        if (isInProd && !isInBeta) {
-                          return (
-                            <Dropdown
-                              onSelect={onDropdownSelect}
-                              className={classes.addRepositoriesButton}
-                              ouiaId='add-selected-toggle-dropdown'
-                              toggle={
-                                <DropdownToggle
-                                  ouiaId='add-selected-dropdown-toggle-no-snap'
-                                  className={className}
-                                  splitButtonItems={[
-                                    <DropdownToggleAction
-                                      key='action'
-                                      data-ouia-component-id='add_checked_repos-without-snap'
-                                      onClick={() => addSelected(false)}
-                                      className={className}
-                                    >
-                                      {defaultText}
-                                    </DropdownToggleAction>,
-                                  ]}
-                                  toggleVariant='primary'
-                                  splitButtonVariant='action'
-                                  onToggle={onDropdownToggle}
-                                  isDisabled={isDisabled}
-                                />
-                              }
-                              isOpen={isActionOpen}
-                            >
-                              {dropdownItems}
-                            </Dropdown>
-                          );
-                        } else
-                          return (
-                            <Dropdown
-                              onSelect={onDropdownSelect}
-                              className={classes.addRepositoriesButton}
-                              ouiaId='add-selected-toggle-dropdown'
-                              toggle={
-                                <DropdownToggle
-                                  ouiaId='add-selected-dropdown-toggle-no-snap'
-                                  className={className}
-                                  splitButtonItems={[
-                                    <DropdownToggleAction
-                                      key='action'
-                                      data-ouia-component-id='add_checked_repos-with-snap'
-                                      onClick={() => addSelected(true)}
-                                      className={className}
-                                    >
-                                      {defaultText}
-                                    </DropdownToggleAction>,
-                                  ]}
-                                  toggleVariant='primary'
-                                  splitButtonVariant='action'
-                                  onToggle={onDropdownToggle}
-                                  isDisabled={isDisabled}
-                                />
-                              }
-                              isOpen={isActionOpen}
-                            >
-                              {dropdownItems}
-                            </Dropdown>
-                          );
+                        return (
+                          <Dropdown
+                            onSelect={onDropdownSelect}
+                            className={classes.addRepositoriesButton}
+                            ouiaId='add-selected-toggle-dropdown'
+                            toggle={
+                              <DropdownToggle
+                                ouiaId='add-selected-dropdown-toggle-no-snap'
+                                className={className}
+                                splitButtonItems={[
+                                  <DropdownToggleAction
+                                    key='action'
+                                    data-ouia-component-id='add_checked_repos-with-snap'
+                                    onClick={() => addSelected(true)}
+                                    className={className}
+                                  >
+                                    {defaultText}
+                                  </DropdownToggleAction>,
+                                ]}
+                                toggleVariant='primary'
+                                splitButtonVariant='action'
+                                onToggle={onDropdownToggle}
+                                isDisabled={isDisabled}
+                              />
+                            }
+                            isOpen={isActionOpen}
+                          >
+                            {dropdownItems}
+                          </Dropdown>
+                        );
                       } else {
                         return (
                           <Button

--- a/src/Pages/Repositories/PopularRepositoriesTable/components/AddRepo.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/components/AddRepo.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@patternfly/react-core';
 
 import { useAppContext } from 'middleware/AppContext';
@@ -10,7 +10,6 @@ import {
   DropdownToggle,
   DropdownToggleAction,
 } from '@patternfly/react-core/deprecated';
-import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 const useStyles = createUseStyles({
   disabledButton: {
@@ -28,9 +27,6 @@ export const AddRepo = ({ isDisabled, addRepo }: Props) => {
   const { features } = useAppContext();
   const classes = useStyles();
   const [isActionOpen, setIsActionOpen] = useState(false);
-  const { isProd, isBeta } = useChrome();
-  const isInProd = useMemo(() => isProd() === true, []);
-  const isInBeta = useMemo(() => isBeta() === true, []);
 
   const onActionToggle = (_, isActionOpen: boolean) => {
     setIsActionOpen(isActionOpen);
@@ -46,94 +42,49 @@ export const AddRepo = ({ isDisabled, addRepo }: Props) => {
     onActionFocus();
   };
 
-  const dropdownItems = useMemo(() => {
-    if (isInProd && !isInBeta) {
-      return [
-        <DropdownItem
-          data-ouia-component-id='add-popular_repo_with-snapshotting'
-          key='action'
-          component='button'
-          onClick={() => addRepo(true)}
-        >
-          Add with snapshotting
-        </DropdownItem>,
-      ];
-    } else
-      return [
-        <DropdownItem
-          data-ouia-component-id='add-popular_repo_without-snapshotting'
-          key='action'
-          component='button'
-          onClick={() => addRepo(false)}
-        >
-          Add without snapshotting
-        </DropdownItem>,
-      ];
-  }, [isInProd]);
+  const dropdownItems = [
+    <DropdownItem
+      data-ouia-component-id='add-popular_repo_without-snapshotting'
+      key='action'
+      component='button'
+      onClick={() => addRepo(false)}
+    >
+      Add without snapshotting
+    </DropdownItem>,
+  ];
 
   if (features?.snapshots?.enabled && features.snapshots.accessible) {
     const className = isDisabled ? classes.disabledButton : undefined;
-    // temporarily disable snapshotting by default for popular repos
-    if (isInProd && !isInBeta) {
-      return (
-        <Dropdown
-          onSelect={onActionSelect}
-          toggle={
-            <DropdownToggle
-              id='toggle-add'
-              className={className}
-              ouiaId='add_popular_repo_toggle'
-              splitButtonItems={[
-                <DropdownToggleAction
-                  data-ouia-component-id='add_popular_repo'
-                  key='action'
-                  onClick={() => addRepo(false)}
-                  className={className}
-                >
-                  Add
-                </DropdownToggleAction>,
-              ]}
-              toggleVariant='primary'
-              splitButtonVariant='action'
-              onToggle={onActionToggle}
-              isDisabled={isDisabled}
-            />
-          }
-          isOpen={isActionOpen}
-        >
-          {dropdownItems}
-        </Dropdown>
-      );
-    } else
-      return (
-        <Dropdown
-          onSelect={onActionSelect}
-          toggle={
-            <DropdownToggle
-              id='toggle-add'
-              className={className}
-              ouiaId='add_popular_repo_toggle'
-              splitButtonItems={[
-                <DropdownToggleAction
-                  data-ouia-component-id='add_popular_repo'
-                  key='action'
-                  onClick={() => addRepo(true)}
-                  className={className}
-                >
-                  Add
-                </DropdownToggleAction>,
-              ]}
-              toggleVariant='primary'
-              splitButtonVariant='action'
-              onToggle={onActionToggle}
-              isDisabled={isDisabled}
-            />
-          }
-          isOpen={isActionOpen}
-        >
-          {dropdownItems}
-        </Dropdown>
-      );
+
+    return (
+      <Dropdown
+        onSelect={onActionSelect}
+        toggle={
+          <DropdownToggle
+            id='toggle-add'
+            className={className}
+            ouiaId='add_popular_repo_toggle'
+            splitButtonItems={[
+              <DropdownToggleAction
+                data-ouia-component-id='add_popular_repo'
+                key='action'
+                onClick={() => addRepo(true)}
+                className={className}
+              >
+                Add
+              </DropdownToggleAction>,
+            ]}
+            toggleVariant='primary'
+            splitButtonVariant='action'
+            onToggle={onActionToggle}
+            isDisabled={isDisabled}
+          />
+        }
+        isOpen={isActionOpen}
+      >
+        {dropdownItems}
+      </Dropdown>
+    );
   } else {
     return (
       <Button


### PR DESCRIPTION
## Summary
Removes prod/beta flags related to the following functionality:

- Makes it so production no longer reverses the public repository split button functionality
- Shows upload repository option in production.

## Testing steps

I saw a bunch of sentry errors that should not be related to my changes, but just in case they are due to the node module updates (this was just dependency updates via a regular yarn install). 

Please be sure to "yarn install"  on the correct node version prior to testing.
