### PR TITLE
Test: process single repo instead of all in pw ci

### DIFF
--- a/.github/workflows/playwright-actions.yml
+++ b/.github/workflows/playwright-actions.yml
@@ -192,9 +192,9 @@ jobs:
         working-directory: content-sources-backend
         run: OPTIONS_REPOSITORY_IMPORT_FILTER=small make repos-import
 
-      - name: Run nightly job to trigger snapshot for redhat repos
+      - name: Run snapshot for redhat repo
         working-directory: content-sources-backend
-        run: go run cmd/external-repos/main.go process-repos
+        run: go run cmd/external-repos/main.go snapshot https://cdn.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os/
 
       - name: Backend run
         working-directory: content-sources-backend


### PR DESCRIPTION
## Summary
This changes GH action `playwright-actions` to snapshot only a single repo instead of running process-repos command for all repos. This is needed as the process-repos bogs down the test runner and tests fail/timeout because of that.
