### PR TITLE
Test: fix get row cell by header helper

### DIFF
--- a/_playwright-tests/UI/IntrospectRepo.spec.ts
+++ b/_playwright-tests/UI/IntrospectRepo.spec.ts
@@ -63,10 +63,10 @@ test.describe('Introspect Repositories', () => {
       const row = page.getByRole('row').filter({ has: page.getByText(testPackage) });
       await Promise.all([
         expect(page.getByText(repoArch)).toHaveCount(8),
-        expect((await getRowCellByHeader(row, 'Name')).getByText(testPackage)).toBeVisible(),
-        expect((await getRowCellByHeader(row, 'Version')).getByText(repoVersion)).toBeVisible(),
-        expect((await getRowCellByHeader(row, 'Release')).getByText(repoRelease)).toBeVisible(),
-        expect((await getRowCellByHeader(row, 'Arch')).getByText(repoArch)).toBeVisible(),
+        expect((await getRowCellByHeader(page, row, 'Name')).getByText(testPackage)).toBeVisible(),
+        expect((await getRowCellByHeader(page, row, 'Version')).getByText(repoVersion)).toBeVisible(),
+        expect((await getRowCellByHeader(page, row, 'Release')).getByText(repoRelease)).toBeVisible(),
+        expect((await getRowCellByHeader(page, row, 'Arch')).getByText(repoArch)).toBeVisible(),
       ]);
     });
   });

--- a/_playwright-tests/UI/helpers/helpers.ts
+++ b/_playwright-tests/UI/helpers/helpers.ts
@@ -1,4 +1,4 @@
-import { Page, Locator } from '@playwright/test';
+import { Page, Locator, expect } from '@playwright/test';
 
 export const closePopupsIfExist = async (page: Page) => {
   const locatorsToCheck = [
@@ -34,7 +34,8 @@ export const getRowByName = async (page: Page, name: string) => {
   return page.getByRole('row').filter({ has: page.getByText(name) });
 };
 
-export const getRowCellByHeader = async (row: Locator, name: string) => {
+export const getRowCellByHeader = async (page: Page, row: Locator, name: string) => {
+  await expect(page.getByRole('columnheader', { name: name })).toBeVisible()
   const table = row.locator('xpath=ancestor::*[@role="grid" or @role="table"][1]');
   const headers = table.getByRole('columnheader');
   const headerCount = await headers.count();


### PR DESCRIPTION
## Summary
This adds a `toBeVisible` expect to the `getRowCellByHeader` helper which should help with preventing the current flakiness of this helper, caused by slow loading and the presence of the skeleton/zero-state table.