### PR TITLE
Build: add PR head refs to github checkout actions

### DIFF
--- a/.github/workflows/content-sources-actions.yml
+++ b/.github/workflows/content-sources-actions.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache - node_modules
         if: always()
@@ -46,6 +48,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache - node_modules
         if: always()
@@ -75,6 +79,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache - node_modules
         if: always()
@@ -104,6 +110,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache - node_modules
         if: always()


### PR DESCRIPTION
## Summary
This adds PR head refs to all GH checkout actions that currently don't have those, this is needed so that the actions run on the same code you are pushing and they don't have different results.