### PR TITLE
Test: add default reporter to jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   preset: 'ts-jest',
   maxWorkers: '50%',
   testResultsProcessor: 'jest-junit',
-  reporters: ['jest-junit'],
+  reporters: ['default', 'jest-junit'],
   testEnvironment: 'jsdom',
   transform: {
     '^.+\\.(t)s$': 'ts-jest',


### PR DESCRIPTION
## Summary

This makes it so we can see results for the unit tests again, the default reporter may have been getting overridden before

## Testing steps

Unit test results are visible in the console locally and in CI
