### PR TITLE
HMS-5268: Clean the Template table widgets when the state is empty

### DIFF
--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.tsx
@@ -198,61 +198,63 @@ export default function TemplateSystemsTab() {
 
   return (
     <Grid className={classes.mainContainer}>
-      <InputGroup className={classes.topContainer}>
-        <Flex gap={{ default: 'gapMd' }}>
-          <InputGroupItem>
-            <TextInput
-              id='search'
-              ouiaId='name_search'
-              placeholder='Filter by name'
-              value={searchQuery}
-              onChange={(_event, value) => setSearchQuery(value)}
-            />
-            <InputGroupText id='search-icon'>
-              <SearchIcon />
-            </InputGroupText>
-          </InputGroupItem>
-          <FlexItem className={classes.ctions}>
+      <Hide hide={!total_items}>
+        <InputGroup className={classes.topContainer}>
+          <Flex gap={{ default: 'gapMd' }}>
+            <InputGroupItem>
+              <TextInput
+                id='search'
+                ouiaId='name_search'
+                placeholder='Filter by name'
+                value={searchQuery}
+                onChange={(_event, value) => setSearchQuery(value)}
+              />
+              <InputGroupText id='search-icon'>
+                <SearchIcon />
+              </InputGroupText>
+            </InputGroupItem>
+            <FlexItem className={classes.ctions}>
+              <ConditionalTooltip
+                content={`You do not have the required ${missingRequirements} to perform this action.`}
+                show={isMissingRequirements}
+                setDisabled
+              >
+                <Button
+                  id='assignTemplateToSystems'
+                  ouiaId='assign_template_to_systems'
+                  variant='primary'
+                  isDisabled={fetchingOrLoading}
+                  onClick={() => navigate('add')}
+                >
+                  Assign template to systems
+                </Button>
+              </ConditionalTooltip>
+            </FlexItem>
             <ConditionalTooltip
               content={`You do not have the required ${missingRequirements} to perform this action.`}
               show={isMissingRequirements}
               setDisabled
             >
-              <Button
-                id='assignTemplateToSystems'
-                ouiaId='assign_template_to_systems'
-                variant='primary'
-                isDisabled={fetchingOrLoading}
-                onClick={() => navigate('add')}
-              >
-                Assign template to systems
-              </Button>
+              <SystemsDeleteKebab
+                deleteFromSystems={deleteFromSystems}
+                deselectAll={deselectAll}
+                isDisabled={!rbac?.templateWrite}
+                selected={selected}
+              />
             </ConditionalTooltip>
-          </FlexItem>
-          <ConditionalTooltip
-            content={`You do not have the required ${missingRequirements} to perform this action.`}
-            show={isMissingRequirements}
-            setDisabled
-          >
-            <SystemsDeleteKebab
-              deleteFromSystems={deleteFromSystems}
-              deselectAll={deselectAll}
-              isDisabled={!rbac?.templateWrite}
-              selected={selected}
-            />
-          </ConditionalTooltip>
-        </Flex>
-        <Pagination
-          id='top-pagination-id'
-          widgetId='topPaginationWidgetId'
-          itemCount={total_items}
-          perPage={perPage}
-          page={page}
-          onSetPage={onSetPage}
-          isCompact
-          onPerPageSelect={onPerPageSelect}
-        />
-      </InputGroup>
+          </Flex>
+          <Pagination
+            id='top-pagination-id'
+            widgetId='topPaginationWidgetId'
+            itemCount={total_items}
+            perPage={perPage}
+            page={page}
+            onSetPage={onSetPage}
+            isCompact
+            onPerPageSelect={onPerPageSelect}
+          />
+        </InputGroup>
+      </Hide>
       <Hide hide={!!total_items}>
         <Bullseye data-ouia-component-id='systems_list_page'>
           <EmptyTableState
@@ -295,21 +297,23 @@ export default function TemplateSystemsTab() {
           setSelected={(id) => handleSelectItem(id)}
         />
       </Hide>
-      <Flex className={classes.bottomContainer}>
-        <FlexItem />
-        <FlexItem>
-          <Pagination
-            id='bottom-pagination-id'
-            widgetId='bottomPaginationWidgetId'
-            itemCount={total_items}
-            perPage={perPage}
-            page={page}
-            onSetPage={onSetPage}
-            variant={PaginationVariant.bottom}
-            onPerPageSelect={onPerPageSelect}
-          />
-        </FlexItem>
-      </Flex>
+      <Hide hide={!total_items}>
+        <Flex className={classes.bottomContainer}>
+          <FlexItem />
+          <FlexItem>
+            <Pagination
+              id='bottom-pagination-id'
+              widgetId='bottomPaginationWidgetId'
+              itemCount={total_items}
+              perPage={perPage}
+              page={page}
+              onSetPage={onSetPage}
+              variant={PaginationVariant.bottom}
+              onPerPageSelect={onPerPageSelect}
+            />
+          </FlexItem>
+        </Flex>
+      </Hide>
       <Outlet />
     </Grid>
   );


### PR DESCRIPTION
- Hide template table, pagination and input widgets when there is no template present.
- Fix: Unit test failure related to the empty state
       - Its because the mock data isn't empty in the last test in current file.

## Testing steps:

- Verify that the template model in its empty state displays only the 'Add Template' widget on the page.

- Additionally, ensure that the input box is present and there is no pagination, either at the top or bottom of the page


