### PR TITLE
HMS 5475, HMS-5503: Fixe copy for use template, small add-repo modal design/copy changes.

### DIFF
--- a/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
@@ -468,7 +468,7 @@ const AddContent = ({ isEdit = false }: Props) => {
                   label='Snapshotting'
                   description={
                     values.snapshot && values.origin === ContentOrigin.EXTERNAL
-                      ? 'Enable snapshotting for an external repository, allowing you to build images with historical snapshots.'
+                      ? 'Enable snapshotting for an external repository, allowing you to build images and use templates with historical snapshots'
                       : ''
                   }
                   name='snapshot-radio'

--- a/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
@@ -654,10 +654,21 @@ const AddContent = ({ isEdit = false }: Props) => {
               ouiaId='restrict_to_os_version'
             />
           </FormGroup>
-          <FormGroup fieldId='enable_module_hotfixes'>
+          <FormGroup
+            fieldId='enable_module_hotfixes'
+            label={
+              modularityFilteringEnabled
+                ? 'Modularity filtering enabled'
+                : 'Modularity filtering disabled'
+            }
+            aria-label='module_hotfix_formgroup'
+            labelIcon={
+              <Tooltip content='When enabled, modularity filtering prevents updates to packages contained within an enabled module'>
+                <OutlinedQuestionCircleIcon className='pf-u-ml-xs' color={global_Color_200.value} />
+              </Tooltip>
+            }
+          >
             <Switch
-              label='Modularity filtering enabled'
-              labelOff='Modularity filtering disabled'
               ouiaId={`module_hotfixes_switch_${modularityFilteringEnabled ? 'on' : 'off'}`}
               aria-label='enable_module_hotfixes'
               hasCheckIcon
@@ -670,9 +681,6 @@ const AddContent = ({ isEdit = false }: Props) => {
                 });
               }}
             />
-            <Tooltip content='When enabled, modularity filtering prevents updates to packages contained within an enabled module'>
-              <OutlinedQuestionCircleIcon className='pf-u-ml-xs' color={global_Color_200.value} />
-            </Tooltip>
           </FormGroup>
           <FormGroup
             label='GPG key'

--- a/src/Pages/Templates/TemplateDetails/components/UseTemplate/AnsibleTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/UseTemplate/AnsibleTab.tsx
@@ -35,7 +35,7 @@ const playbook1 = `---
   tasks:
     - name: Download template.repo
       ansible.builtin.get_url:
-        url: https://console.redhat.com/api/content-sources/v1/templates/`;
+        url: https://cert.console.redhat.com/api/content-sources/v1/templates/`;
 const playbook2 = `/config.repo
         dest: /etc/yum.repos.d/template.repo
         mode: '0444'

--- a/src/Pages/Templates/TemplateDetails/components/UseTemplate/CurlTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/UseTemplate/CurlTab.tsx
@@ -79,7 +79,7 @@ const CurlTab = ({ tabContentRef }: Props) => {
               clickTip='Copied'
               variant={ClipboardCopyVariant.expansion}
             >
-              {'curl -o /etc/yum.repos.d/template.repo  https://console.redhat.com/api/content-sources/v1/templates/' +
+              {'curl -o /etc/yum.repos.d/template.repo  https://cert.console.redhat.com/api/content-sources/v1/templates/' +
                 templateUUID +
                 '/config.repo'}
             </ClipboardCopy>

--- a/src/Pages/Templates/TemplateDetails/components/UseTemplate/InsightsTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/UseTemplate/InsightsTab.tsx
@@ -70,7 +70,7 @@ const InsightsTab = ({ tabContentRef }: Props) => {
               clickTip='Copied'
               variant={ClipboardCopyVariant.expansion}
             >
-              {'curl --cert /etc/pki/consumer/cert.pem  --key /etc/pki/consumer/key.pem -X PATCH https://console.redhat.com/api/patch/v3/templates/' +
+              {'curl --cert /etc/pki/consumer/cert.pem  --key /etc/pki/consumer/key.pem -X PATCH https://cert.console.redhat.com/api/patch/v3/templates/' +
                 templateUUID +
                 '/subscribed-systems'}
             </ClipboardCopy>


### PR DESCRIPTION
## Summary
- Updates some copy for the add repo modal to include mention templates 
- Updates 3 url references in the use template modal to use correct cert url.
- Standardizes design for module hotfix input/form-group (fixes spacing as well).

## Testing steps
- View updates to design/copy in add-repo modal
- View changes in use template modal.