### PR TITLE
Test: Only attach "closePopupsIfExist" once per test

### DIFF
--- a/_playwright-tests/UI/Templates.spec.ts
+++ b/_playwright-tests/UI/Templates.spec.ts
@@ -33,7 +33,6 @@ test.describe('Templates', () => {
 
     await test.step('Navigate to the templates page', async () => {
       await navigateToTemplates(page);
-      await closePopupsIfExist(page);
     });
 
     await test.step(`Click the 'Learn more about templates' link and verify the destination`, async () => {

--- a/_playwright-tests/UI/UploadRepo.spec.ts
+++ b/_playwright-tests/UI/UploadRepo.spec.ts
@@ -77,7 +77,6 @@ test.describe('Upload Repositories', () => {
 
   test('Delete one upload repository', async ({ page }) => {
     await navigateToRepositories(page);
-    await closePopupsIfExist(page);
     const row = await getRowByNameOrUrl(page, uploadRepoName);
     // Check if the 'Kebab toggle' button is disabled
     await row.getByLabel('Kebab toggle').click();


### PR DESCRIPTION
Having generic close functions can close pop-ups that we don't count with and cause unexpected behavior.

**Testing** what popups we still need to close.
