### PR TITLE
Fix Red Hat tab locator

### DIFF
--- a/_playwright-tests/UI/RedHatRepo.spec.ts
+++ b/_playwright-tests/UI/RedHatRepo.spec.ts
@@ -12,7 +12,7 @@ test.describe('Red Hat Repositories', () => {
     });
 
     await test.step('Navigate to Red Hat repositories', async () => {
-      await page.getByRole('button', { name: 'Red Hat' }).click();
+      await page.getByRole('button', { name: 'Red Hat', exact: true }).click();
     });
   });
 


### PR DESCRIPTION
## Summary

Locator was resolving to "Red Hat Insights" (top left sidebar) not just "Red Hat" tab as expected.

## Testing steps

Tests pass