### PR TITLE
HMS-5678: check for use latest on warning in the set up date step

### DIFF
--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
@@ -155,7 +155,7 @@ export default function SetUpDateStep() {
           />
         </Hide>
       </FormGroup>
-      <Hide hide={!hasIsAfter || !dateIsValid}>
+      <Hide hide={templateRequest.use_latest || !hasIsAfter || !dateIsValid}>
         <FormAlert>
           <Alert
             variant='warning'


### PR DESCRIPTION
## Summary
This fixes a bug where the warning about snapshots before the selected date was displayed in the set up date step inside of the template add modal even when use latest was selected.

## Testing steps
When creating or editing a template the warning should not be displayed if the use latest option is selected in the set up date step.