### PR TITLE
Test: merge incorrectly split tests, improve speed

### DIFF
--- a/_playwright-tests/UI/GPG_keys.spec.ts
+++ b/_playwright-tests/UI/GPG_keys.spec.ts
@@ -38,7 +38,7 @@ test.describe('Test GPG keys', () => {
       await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeDisabled();
       await page.getByText('Package verification only').click();
       // Save button would be disabled for bad or incorrect gpg key
-      await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeEnabled;
+      await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeEnabled();
       await page.getByPlaceholder('Paste GPG key or URL here').fill('I am not a GPG Key');
       await expect(page.getByText('Error validating signature:')).toBeVisible();
       await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeDisabled();

--- a/_playwright-tests/UI/RedHatRepo.spec.ts
+++ b/_playwright-tests/UI/RedHatRepo.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { navigateToRepositories } from './helpers/navHelpers';
-import { closePopupsIfExist } from './helpers/helpers';
+import { closePopupsIfExist, getRowByNameOrUrl } from './helpers/helpers';
 
 test.describe('Red Hat Repositories', () => {
   const smallRHRepo = 'Red Hat CodeReady Linux Builder for RHEL 9 ARM 64 (RPMs)';
@@ -16,24 +16,13 @@ test.describe('Red Hat Repositories', () => {
     });
   });
 
-  test('Wait for repository status to be "Valid"', async ({ page }) => {
-    const status = page
-      .getByRole('row')
-      .filter({ hasText: smallRHRepo })
-      .getByRole('gridcell')
-      .filter({ hasText: 'Valid' });
-
-    await test.step('Filter repos by name', async () => {
-      await page.getByPlaceholder('Filter by name/url').fill(smallRHRepo);
+  test('Verify snapshotting of Red Hat repositories', async ({ page }) => {
+    await test.step('Wait for status to be "Valid"', async () => {
+      const row = await getRowByNameOrUrl(page, smallRHRepo);
+      await expect(row.getByText('Valid')).toBeVisible({ timeout: 600_000 });
     });
 
-    await test.step('Wait for a valid status', async () => {
-      await status.waitFor({ state: 'visible', timeout: 600_000 });
-    });
-  });
-
-  test('Check repository snapshots', async ({ page }) => {
-    await test.step('Open the snapshots list modal', async () => {
+    await test.step('Check repository snapshots', async () => {
       await page
         .getByRole('row')
         .filter({ hasText: smallRHRepo })

--- a/_playwright-tests/UI/UploadRepo.spec.ts
+++ b/_playwright-tests/UI/UploadRepo.spec.ts
@@ -7,97 +7,100 @@ import { deleteAllRepos } from './helpers/deleteRepositories';
 const uploadRepoName = 'Upload Repo!';
 
 test.describe('Upload Repositories', () => {
-  test('Clean - Delete any current repos that exist', async ({ page }) => {
-    await deleteAllRepos(page, `&search=${uploadRepoName}`);
-  });
+  test('Upload repo creation and deletion', async ({ page }) => {
+    await test.step('Clean - Delete any current repos that exist', async () => {
+      await deleteAllRepos(page, `&search=${uploadRepoName}`);
+    });
 
-  test('Create upload repository', async ({ page }) => {
-    await closePopupsIfExist(page);
-    await navigateToRepositories(page);
+    await test.step('Create upload repository', async () => {
+      await closePopupsIfExist(page);
+      await navigateToRepositories(page);
 
-    // Click 'Add repositories' button
-    await page.getByRole('button', { name: 'Add repositories' }).first().click();
+      // Click 'Add repositories' button
+      await page.getByRole('button', { name: 'Add repositories' }).first().click();
 
-    // Wait for the modal to be visible
-    await expect(page.locator('div[id^="pf-modal-part"]').first()).toBeVisible();
+      // Wait for the modal to be visible
+      await expect(page.locator('div[id^="pf-modal-part"]').first()).toBeVisible();
 
-    // Fill in the 'Enter name' input
-    const nameInput = page.getByPlaceholder('Enter name');
-    await nameInput.click();
-    await nameInput.fill(uploadRepoName);
+      // Fill in the 'Enter name' input
+      const nameInput = page.getByPlaceholder('Enter name');
+      await nameInput.click();
+      await nameInput.fill(uploadRepoName);
 
-    // Check the 'Upload' checkbox
-    await page.getByLabel('Upload', { exact: true }).check();
+      // Check the 'Upload' checkbox
+      await page.getByLabel('Upload', { exact: true }).check();
 
-    // Filter by architecture
-    await page.getByRole('button', { name: 'filter architecture' }).click();
-    await page.getByRole('option', { name: 'x86_64' }).click();
+      // Filter by architecture
+      await page.getByRole('button', { name: 'filter architecture' }).click();
+      await page.getByRole('option', { name: 'x86_64' }).click();
 
-    // Filter by version
-    const versionFilterButton = page.getByRole('button', { name: 'filter version' });
-    await versionFilterButton.click();
-    await page.getByRole('menuitem', { name: 'el9' }).locator('label').click();
-    await page.getByRole('menuitem', { name: 'el8' }).locator('label').click();
-    await versionFilterButton.click(); // Close the filter dropdown
+      // Filter by version
+      const versionFilterButton = page.getByRole('button', { name: 'filter version' });
+      await versionFilterButton.click();
+      await page.getByRole('menuitem', { name: 'el9' }).locator('label').click();
+      await page.getByRole('menuitem', { name: 'el8' }).locator('label').click();
+      await versionFilterButton.click(); // Close the filter dropdown
 
-    // Wait for the successful API call
-    const errorElement = page.locator('.pf-v5-c-helper-text__item.pf-m-error');
-
-    if (await errorElement.isVisible()) {
-      throw new Error('Error message in element is visible');
-    }
-
-    // Click 'Save and upload content'
-    await Promise.all([
-      page.getByRole('button', { name: 'Save and upload content' }).click(),
-      page.waitForResponse(
-        (resp) =>
-          resp.url().includes('/bulk_create/') && resp.status() >= 200 && resp.status() < 300,
-      ),
-    ]);
-
-    const dragBoxSelector = page.locator('#pf-modal-part-1  > div');
-
-    // Handle the file chooser and upload the file
-    await dragBoxSelector
-      .locator('input[type=file]')
-      .setInputFiles(path.join(__dirname, './fixtures/libreOffice.rpm'));
-
-    // Verify the upload completion message
-    await expect(page.getByText('All uploads completed!')).toBeVisible();
-
-    // Confirm changes
-    await page.getByRole('button', { name: 'Confirm changes' }).click();
-
-    // There might be many rows at this point, we need to ensure that we filter the repo
-    const row = await getRowByNameOrUrl(page, uploadRepoName);
-    // Verify the 'In progress' status
-    await expect(row.getByText('In progress')).toBeVisible();
-  });
-
-  test('Delete one upload repository', async ({ page }) => {
-    await navigateToRepositories(page);
-    await closePopupsIfExist(page);
-    const row = await getRowByNameOrUrl(page, uploadRepoName);
-    // Check if the 'Kebab toggle' button is disabled
-    await row.getByLabel('Kebab toggle').click();
-    await row.getByRole('menuitem', { name: 'Delete' }).click();
-
-    // Click on the 'Remove' button
-    await Promise.all([
-      // Verify the 'Remove repositories?' dialog is visible
-      expect(page.getByText('Remove repositories?')).toBeVisible(),
       // Wait for the successful API call
-      page.waitForResponse(
-        (resp) => resp.url().includes('bulk_delete') && resp.status() >= 200 && resp.status() < 300,
-      ),
-      // Click the 'Remove' button
-      page.getByRole('button', { name: 'Remove' }).click(),
-      await expect(row).not.toBeVisible(),
-    ]);
-  });
+      const errorElement = page.locator('.pf-v5-c-helper-text__item.pf-m-error');
 
-  test('Clean - Double check upload repo for deletion', async ({ page }) => {
-    await deleteAllRepos(page, `&search=${uploadRepoName}`);
+      if (await errorElement.isVisible()) {
+        throw new Error('Error message in element is visible');
+      }
+
+      // Click 'Save and upload content'
+      await Promise.all([
+        page.getByRole('button', { name: 'Save and upload content' }).click(),
+        page.waitForResponse(
+          (resp) =>
+            resp.url().includes('/bulk_create/') && resp.status() >= 200 && resp.status() < 300,
+        ),
+      ]);
+
+      const dragBoxSelector = page.locator('#pf-modal-part-1  > div');
+
+      // Handle the file chooser and upload the file
+      await dragBoxSelector
+        .locator('input[type=file]')
+        .setInputFiles(path.join(__dirname, './fixtures/libreOffice.rpm'));
+
+      // Verify the upload completion message
+      await expect(page.getByText('All uploads completed!')).toBeVisible();
+
+      // Confirm changes
+      await page.getByRole('button', { name: 'Confirm changes' }).click();
+
+      // There might be many rows at this point, we need to ensure that we filter the repo
+      const row = await getRowByNameOrUrl(page, uploadRepoName);
+      // Verify the 'In progress' status
+      await expect(row.getByText('In progress')).toBeVisible();
+    });
+
+    await test.step('Delete one upload repository', async () => {
+      await navigateToRepositories(page);
+      await closePopupsIfExist(page);
+      const row = await getRowByNameOrUrl(page, uploadRepoName);
+      // Check if the 'Kebab toggle' button is disabled
+      await row.getByLabel('Kebab toggle').click();
+      await row.getByRole('menuitem', { name: 'Delete' }).click();
+
+      // Click on the 'Remove' button
+      await Promise.all([
+        // Verify the 'Remove repositories?' dialog is visible
+        expect(page.getByText('Remove repositories?')).toBeVisible(),
+        // Wait for the successful API call
+        page.waitForResponse(
+          (resp) =>
+            resp.url().includes('bulk_delete') && resp.status() >= 200 && resp.status() < 300,
+        ),
+        // Click the 'Remove' button
+        page.getByRole('button', { name: 'Remove' }).click(),
+        await expect(row).not.toBeVisible(),
+      ]);
+    });
+
+    await test.step('Clean - Double check upload repo for deletion', async () => {
+      await deleteAllRepos(page, `&search=${uploadRepoName}`);
+    });
   });
 });

--- a/_playwright-tests/UI/helpers/navHelpers.ts
+++ b/_playwright-tests/UI/helpers/navHelpers.ts
@@ -26,7 +26,15 @@ const navigateToRepositoriesFunc = async (page: Page) => {
 };
 
 export const navigateToRepositories = async (page: Page) => {
-  await retry(page, navigateToRepositoriesFunc);
+  try {
+    const repositoriesNavLink = page
+      .getByRole('navigation')
+      .getByRole('link', { name: 'Repositories' });
+    await repositoriesNavLink.waitFor({ state: 'visible', timeout: 1500 });
+    await repositoriesNavLink.click();
+  } catch {
+    await retry(page, navigateToRepositoriesFunc, 5);
+  }
 };
 
 const navigateToTemplatesFunc = async (page: Page) => {
@@ -39,5 +47,11 @@ const navigateToTemplatesFunc = async (page: Page) => {
 };
 
 export const navigateToTemplates = async (page: Page) => {
-  await retry(page, navigateToTemplatesFunc);
+  try {
+    const templatesNavLink = page.getByRole('navigation').getByRole('link', { name: 'Templates' });
+    await templatesNavLink.waitFor({ state: 'visible', timeout: 1500 });
+    await templatesNavLink.click();
+  } catch {
+    await retry(page, navigateToTemplatesFunc, 5);
+  }
 };


### PR DESCRIPTION
## Summary
This merges test that were incorrectly split into multiple and substitutes the separation with more steps. 🧹  
Also make a small change to navigation helpers to hopefully make them a little faster. ⚡ 

## Testing steps
Tests pass and hopefully don't time out in CI + should be less flaky due to decreased number of navigations and increased retries 🙏🏼 