### PR TITLE
HMS-5923: add support for rhel10

### DIFF
--- a/_playwright-tests/UI/PopularRepo.spec.ts
+++ b/_playwright-tests/UI/PopularRepo.spec.ts
@@ -3,6 +3,7 @@ import { navigateToRepositories } from './helpers/navHelpers';
 import { closePopupsIfExist, getRowByNameOrUrl } from './helpers/helpers';
 import { deleteAllPopularRepos } from './helpers/deletePopularRepositories';
 
+const repoName10 = 'EPEL 10 Everything x86_64';
 const repoName9 = 'EPEL 9 Everything x86_64';
 const repoName8 = 'EPEL 8 Everything x86_64';
 
@@ -21,25 +22,40 @@ test.describe('Popular Repositories', () => {
       await expect(page.getByRole('button', { name: 'Add selected repositories' })).toBeVisible();
     });
 
-    await test.step('Select EPEL 9', async () => {
+     await test.step('Select EPEL 10', async () => {
       await page
-        .getByRole('row', { name: repoName9 })
+        .getByRole('row', { name: repoName10 })
         .getByLabel('Select row 0', { exact: true })
         .click();
       await page.getByTestId('add-selected-dropdown-toggle-no-snap');
       await page.getByRole('menuitem', { name: 'Add 1 repositories without snapshotting' });
     });
 
+    await test.step('Select EPEL 9', async () => {
+      await page
+        .getByRole('row', { name: repoName9 })
+        .getByLabel('Select row 1', { exact: true })
+        .click();
+      await page.getByTestId('add-selected-dropdown-toggle-no-snap');
+      await page.getByRole('menuitem', { name: 'Add 2 repositories without snapshotting' });
+    });
+
     await test.step('Select EPEL 8 and add both repos', async () => {
       await page
         .getByRole('row', { name: repoName8 })
-        .getByLabel('Select row 1', { exact: true })
+        .getByLabel('Select row 2', { exact: true })
         .click();
       await page.getByTestId('add-selected-dropdown-toggle-no-snap').click();
-      await page.getByRole('menuitem', { name: 'Add 2 repositories without snapshotting' }).click();
+      await page.getByRole('menuitem', { name: 'Add 3 repositories without snapshotting' }).click();
     });
 
     await test.step('Check buttons have changed from Add to Remove', async () => {
+      await expect(
+        page
+          .getByRole('row', { name: repoName10 })
+          .getByTestId('remove_popular_repo')
+          .getByText('Remove'),
+      ).toBeVisible();
       await expect(
         page
           .getByRole('row', { name: repoName8 })
@@ -83,6 +99,20 @@ test.describe('Popular Repositories', () => {
     await test.step('Use kebab menu to delete a repo', async () => {
       const row = await getRowByNameOrUrl(page, repoName9);
       await row.getByRole('checkbox', { name: 'Select row' }).check();
+
+      await page.getByTestId('custom_repositories_kebab_toggle').click();
+      await page.getByRole('menuitem', { name: 'Remove 1 repositories' }).click();
+      // Confirm the removal in the pop-up
+      await page
+        .getByRole('dialog', { name: 'Remove repositories?' })
+        .getByRole('button', { name: 'Remove' })
+        .click();
+    });
+
+    await test.step('Use kebab menu to delete a repo', async () => {
+      const row = await getRowByNameOrUrl(page, repoName10);
+      await row.getByRole('checkbox', { name: 'Select row' }).check();
+
       await page.getByTestId('custom_repositories_kebab_toggle').click();
       await page.getByRole('menuitem', { name: 'Remove 1 repositories' }).click();
       // Confirm the removal in the pop-up

--- a/_playwright-tests/UI/PopularRepo.spec.ts
+++ b/_playwright-tests/UI/PopularRepo.spec.ts
@@ -22,7 +22,7 @@ test.describe('Popular Repositories', () => {
       await expect(page.getByRole('button', { name: 'Add selected repositories' })).toBeVisible();
     });
 
-     await test.step('Select EPEL 10', async () => {
+    await test.step('Select EPEL 10', async () => {
       await page
         .getByRole('row', { name: repoName10 })
         .getByLabel('Select row 0', { exact: true })

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/AddTemplate.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/AddTemplate.tsx
@@ -143,7 +143,7 @@ const AddTemplateBase = () => {
               </WizardStep>,
               <WizardStep
                 isDisabled={checkIfCurrentStepValid(2)}
-                name='Custom Repositories'
+                name='Custom repositories'
                 id='custom_repositories'
                 key='custom_repositories_key'
                 footer={{ ...sharedFooterProps, isNextDisabled: checkIfCurrentStepValid(3) }}

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/DefineContentStep.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/DefineContentStep.tsx
@@ -45,7 +45,7 @@ export default function DefineContentStep() {
     .map(({ label, name }) => ({ value: label, children: name }));
 
   const allowedDistributionVersions = distribution_versions
-    .filter(({ label }) => ['8', '9'].includes(label))
+    .filter(({ label }) => ['8', '9', '10'].includes(label))
     .map(({ label, name }) => ({ value: label, children: name }));
 
   return (

--- a/src/Pages/Templates/TemplatesTable/components/templateHelpers.ts
+++ b/src/Pages/Templates/TemplatesTable/components/templateHelpers.ts
@@ -16,6 +16,11 @@ export const hardcodeRedHatReposByArchAndVersion = (
         'https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os',
         'https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os',
       ];
+    case arch === 'x86_64' && version === '10':
+      return [
+        'https://cdn.redhat.com/content/dist/rhel10/10/x86_64/appstream/os',
+        'https://cdn.redhat.com/content/dist/rhel10/10/x86_64/baseos/os',
+      ];
     case arch === 'aarch64' && version === '8':
       return [
         'https://cdn.redhat.com/content/dist/rhel8/8/aarch64/appstream/os',
@@ -25,6 +30,11 @@ export const hardcodeRedHatReposByArchAndVersion = (
       return [
         'https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os',
         'https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os',
+      ];
+    case arch === 'aarch64' && version === '10':
+      return [
+        'https://cdn.redhat.com/content/dist/rhel10/10/aarch64/appstream/os',
+        'https://cdn.redhat.com/content/dist/rhel10/10/aarch64/baseos/os',
       ];
 
     default:


### PR DESCRIPTION
## Summary

Adds filters and preselected repositories in the template modal to support RHEL10 repos

## Testing steps

1. Checkout this [backend PR](https://github.com/content-services/content-sources-backend/pull/1085)
2. Run `make repos-import && go run cmd/external-repos/main.go process-repos` to import and snapshot all repos
3. You should see the RHEL10 repos listed in the UI
4. Create a template with RHEL10 repos, this should work the same as with RHEL8 and 9
5. Filtering templates and repos on version 10 and sorting by version should also work as expected
6. EPEL10 should be listed on the Popular Repositories tab and should be able to be introspected / snapshotted

#testwith content-services/content-sources-backend#1085
