### PR TITLE
Fix: add missing invalidation for snapshot list

### DIFF
--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -311,6 +311,7 @@ export const useEditContentQuery = (request: EditContentRequestItem) => {
 
       queryClient.invalidateQueries(CONTENT_LIST_KEY);
       queryClient.invalidateQueries(CONTENT_ITEM_KEY);
+      queryClient.invalidateQueries(LIST_SNAPSHOTS_KEY);
       queryClient.invalidateQueries(ADMIN_TASK_LIST_KEY);
       queryClient.invalidateQueries(POPULAR_REPOSITORIES_LIST_KEY);
     },
@@ -705,6 +706,7 @@ export const useTriggerSnapshot = (queryClient: QueryClient) => {
         title: 'Snapshot triggered successfully',
         id: 'trigger-snapshot-success',
       });
+      queryClient.invalidateQueries(LIST_SNAPSHOTS_KEY);
       queryClient.invalidateQueries(CONTENT_LIST_KEY);
     },
     onError: (err) => {
@@ -767,6 +769,8 @@ export const useIntrospectRepositoryMutate = (
           id: 'introspect-repository-success',
         });
       }
+      queryClient.invalidateQueries(CONTENT_ITEM_KEY);
+      queryClient.invalidateQueries(LIST_SNAPSHOTS_KEY);
       queryClient.invalidateQueries(ADMIN_TASK_LIST_KEY);
     },
     // If the mutation fails, use the context returned from onMutate to roll back


### PR DESCRIPTION
## Summary
This fixes an issues where after editing a repo, the snapshot list wasn't correctly updated.

## Testing steps
1. Create a snapshot repo.
2. Wait for valid status, check that there is 1 snapshot.
3. Edit the created repo and change the URL to a repo with different packages.
4. Wait for valid status, check that there are 2 snapshots. (**without** refreshing the page)
