### PR TITLE
HMS-5828: add shared epel and remove popular repos

### DIFF
--- a/.github/workflows/playwright-actions.yml
+++ b/.github/workflows/playwright-actions.yml
@@ -196,6 +196,10 @@ jobs:
         working-directory: content-sources-backend
         run: OPTIONS_REPOSITORY_IMPORT_FILTER=small make repos-import
 
+      - name: Import the shared EPEL10 repo
+        working-directory: content-sources-backend
+        run: OPTIONS_REPOSITORY_IMPORT_FILTER=epel10 make repos-import
+
       - name: Run snapshot for redhat repo
         working-directory: content-sources-backend
         run: go run cmd/external-repos/main.go snapshot --url https://cdn.redhat.com/content/dist/rhel9/9/aarch64/codeready-builder/os/ --force

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ export default function App() {
       storedPerPage,
       filterData,
       '',
-      [ContentOrigin.EXTERNAL, ContentOrigin.UPLOAD, ContentOrigin.COMMUNITY],
+      [ContentOrigin.EXTERNAL, ContentOrigin.UPLOAD],
       isDefaultRoute && zeroState, // We only check if the route is correct and zerostate is true (defaults to true)
     );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ export default function App() {
       storedPerPage,
       filterData,
       '',
-      ContentOrigin.CUSTOM,
+      [ContentOrigin.EXTERNAL, ContentOrigin.UPLOAD, ContentOrigin.COMMUNITY],
       isDefaultRoute && zeroState, // We only check if the route is correct and zerostate is true (defaults to true)
     );
 

--- a/src/Pages/Repositories/ContentListTable/ContentListTable.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.test.tsx
@@ -25,7 +25,7 @@ jest.mock('middleware/AppContext', () => ({
   useAppContext: () => ({
     features: { snapshots: { accessible: true } },
     rbac: { repoWrite: true, repoRead: true },
-    contentOrigin: ContentOrigin.CUSTOM,
+    contentOrigin: [ContentOrigin.EXTERNAL, ContentOrigin.UPLOAD],
     setContentOrigin: () => {},
   }),
 }));

--- a/src/Pages/Repositories/ContentListTable/components/ContentListFilters.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/ContentListFilters.test.tsx
@@ -3,7 +3,7 @@ import { testRepositoryParamsResponse } from 'testingHelpers';
 import AddContent from './AddContent/AddContent';
 import ContentListFilters from './ContentListFilters';
 import { useQueryClient } from 'react-query';
-import { ContentOrigin } from 'services/Content/ContentApi';
+import { ContentItem, ContentOrigin } from 'services/Content/ContentApi';
 
 jest.mock('./AddContent/AddContent');
 
@@ -28,7 +28,7 @@ beforeAll(() => {
 it('Render loading state (disabled)', () => {
   const { getByRole } = render(
     <ContentListFilters
-      contentOrigin={ContentOrigin.CUSTOM}
+      contentOrigin={[ContentOrigin.CUSTOM]}
       setContentOrigin={() => null}
       isLoading={true}
       setFilterData={() => null}
@@ -40,6 +40,7 @@ it('Render loading state (disabled)', () => {
       }}
       atLeastOneRepoChecked={false}
       numberOfReposChecked={0}
+      checkedRepositories={new Map<string, ContentItem>()}
     />,
   );
 
@@ -50,7 +51,7 @@ it('Render loading state (disabled)', () => {
 it('Select a filter of each type and ensure chips are present contentlistfilters', () => {
   const { queryByText, getByRole, getByLabelText } = render(
     <ContentListFilters
-      contentOrigin={ContentOrigin.CUSTOM}
+      contentOrigin={[ContentOrigin.CUSTOM]}
       setContentOrigin={() => null}
       setFilterData={() => null}
       filterData={{
@@ -61,6 +62,7 @@ it('Select a filter of each type and ensure chips are present contentlistfilters
       }}
       atLeastOneRepoChecked={false}
       numberOfReposChecked={0}
+      checkedRepositories={new Map<string, ContentItem>()}
     />,
   );
 

--- a/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContent.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContent.test.tsx
@@ -41,7 +41,7 @@ jest.mock('../../ContentListTable', () => ({
 jest.mock('../../../PopularRepositoriesTable/PopularRepositoriesTable', () => ({
   usePopularListOutletContext: () => ({
     deletionContext: {
-      checkedRepositoriesToDelete: new Set<string>('some-uuid'),
+      checkedRepositories: new Set<string>('some-uuid'),
     },
   }),
 }));

--- a/src/Pages/Repositories/ContentListTable/components/PackageModal/PackageModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/PackageModal/PackageModal.tsx
@@ -84,7 +84,9 @@ export default function PackageModal() {
   const onClose = () =>
     navigate(
       `${rootPath}/${REPOSITORIES_ROUTE}` +
-        (contentOrigin === ContentOrigin.REDHAT ? `?origin=${contentOrigin}` : ''),
+        (contentOrigin.length === 1 && contentOrigin[0] === ContentOrigin.REDHAT
+          ? `?origin=${contentOrigin}`
+          : ''),
     );
 
   const {

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.tsx
@@ -55,7 +55,9 @@ export default function SnapshotDetailsModal() {
   const onClose = () =>
     navigate(
       `${rootPath}/${REPOSITORIES_ROUTE}` +
-        (contentOrigin === ContentOrigin.REDHAT ? `?origin=${contentOrigin}` : ''),
+        (contentOrigin.length === 1 && contentOrigin[0] === ContentOrigin.REDHAT
+          ? `?origin=${contentOrigin}`
+          : ''),
     );
 
   const onBackClick = () => navigate(rootPath + `/${REPOSITORIES_ROUTE}/${repoUUID}/snapshots`);

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataTab.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataTab.tsx
@@ -105,7 +105,12 @@ export function SnapshotErrataTab() {
   };
 
   const onClose = () =>
-    navigate(rootPath + (contentOrigin === ContentOrigin.REDHAT ? `?origin=${contentOrigin}` : ''));
+    navigate(
+      rootPath +
+        (contentOrigin.length === 1 && contentOrigin[0] === ContentOrigin.REDHAT
+          ? `?origin=${contentOrigin}`
+          : ''),
+    );
 
   const {
     data: errataList = [],

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotPackagesTab.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotPackagesTab.tsx
@@ -78,7 +78,12 @@ export function SnapshotPackagesTab() {
   };
 
   const onClose = () =>
-    navigate(rootPath + (contentOrigin === ContentOrigin.REDHAT ? `?origin=${contentOrigin}` : ''));
+    navigate(
+      rootPath +
+        (contentOrigin.length === 1 && contentOrigin[0] === ContentOrigin.REDHAT
+          ? `?origin=${contentOrigin}`
+          : ''),
+    );
 
   const {
     data: packagesList = [],

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.test.tsx
@@ -7,6 +7,7 @@ import {
   defaultSnapshotItem,
 } from 'testingHelpers';
 import { useFetchContent, useGetSnapshotList } from 'services/Content/ContentQueries';
+import { ContentOrigin } from 'services/Content/ContentApi';
 
 jest.mock('Hooks/useRootPath', () => () => 'someUrl');
 
@@ -26,7 +27,10 @@ jest.mock('react-router-dom', () => ({
 }));
 
 jest.mock('middleware/AppContext', () => ({
-  useAppContext: () => ({ rbac: { read: true, write: true } }),
+  useAppContext: () => ({
+    rbac: { read: true, write: true },
+    contentOrigin: [ContentOrigin.EXTERNAL, ContentOrigin.UPLOAD],
+  }),
 }));
 
 it('Render 1 item', () => {

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
@@ -127,7 +127,9 @@ const SnapshotListModal = () => {
   const onClose = () =>
     navigate(
       `${rootPath}/${REPOSITORIES_ROUTE}` +
-        (contentOrigin === ContentOrigin.REDHAT ? `?origin=${contentOrigin}` : ''),
+        (contentOrigin.length === 1 && contentOrigin[0] === ContentOrigin.REDHAT
+          ? `?origin=${contentOrigin}`
+          : ''),
     );
 
   const onSelectSnapshot = (uuid: string, value: boolean) => {
@@ -179,7 +181,8 @@ const SnapshotListModal = () => {
 
   const loadingOrZeroCount = fetchingOrLoading || !count;
 
-  const isRedHatRepository = contentOrigin === ContentOrigin.REDHAT;
+  const isRedHatRepository =
+    contentOrigin.length === 1 && contentOrigin[0] === ContentOrigin.REDHAT;
 
   const latestSnapshotUUID = snapshotsList[0]?.uuid;
 

--- a/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.tsx
@@ -97,10 +97,10 @@ const PopularRepositoriesTable = () => {
   const [checkedRepositoriesToAdd, setCheckedRepositoriesToAdd] = useState<
     Map<string, CreateContentRequestItem>
   >(new Map());
-  // Set of uuids which are required for bulk delete
-  const [checkedRepositoriesToDelete, setCheckedRepositoriesToDelete] = useState<Set<string>>(
-    new Set(),
-  );
+  // Map of uuids and repos which are required for bulk delete
+  const [checkedRepositoriesToDelete, setCheckedRepositoriesToDelete] = useState<
+    Map<string, PopularRepository>
+  >(new Map());
   const [selectedData, setSelectedData] = useState<CreateContentRequest>([]);
   const [selectedUUID, setSelectedUUID] = useState<string>('');
 
@@ -153,31 +153,31 @@ const PopularRepositoriesTable = () => {
 
   const clearCheckedRepositories = () => {
     setCheckedRepositoriesToAdd(new Map());
-    setCheckedRepositoriesToDelete(new Set());
+    setCheckedRepositoriesToDelete(new Map());
   };
 
   const selectAllRepos = (_, checked: boolean) => {
-    const newSet = new Set(checkedRepositoriesToDelete);
-    const newMap = new Map(checkedRepositoriesToAdd);
+    const newDeleteMap = new Map(checkedRepositoriesToDelete);
+    const newAddMap = new Map(checkedRepositoriesToAdd);
     if (checked) {
       popularData.forEach((repo) => {
         if (repo.uuid) {
-          newSet.add(repo.uuid);
+          newDeleteMap.set(repo.uuid, repo);
         } else {
-          newMap.set(repo.url, repoToRequestItem(repo));
+          newAddMap.set(repo.url, repoToRequestItem(repo));
         }
       });
     } else {
       popularData.forEach((repo) => {
         if (repo.uuid) {
-          newSet.delete(repo.uuid);
+          newDeleteMap.delete(repo.uuid);
         } else {
-          newMap.delete(repo.url);
+          newAddMap.delete(repo.url);
         }
       });
     }
-    setCheckedRepositoriesToDelete(newSet);
-    setCheckedRepositoriesToAdd(newMap);
+    setCheckedRepositoriesToDelete(newDeleteMap);
+    setCheckedRepositoriesToAdd(newAddMap);
   };
 
   const atLeastOneRepoToDeleteChecked = useMemo(
@@ -203,13 +203,13 @@ const PopularRepositoriesTable = () => {
 
   const onSelectRepo = (repo: PopularRepository, value: boolean) => {
     if (repo.uuid) {
-      const newSet = new Set(checkedRepositoriesToDelete);
+      const newMap = new Map(checkedRepositoriesToDelete);
       if (value) {
-        newSet.add(repo.uuid);
+        newMap.set(repo.uuid, repo);
       } else {
-        newSet.delete(repo.uuid);
+        newMap.delete(repo.uuid);
       }
-      setCheckedRepositoriesToDelete(newSet);
+      setCheckedRepositoriesToDelete(newMap);
     } else {
       const newMap = new Map(checkedRepositoriesToAdd);
       if (value) {
@@ -249,7 +249,7 @@ const PopularRepositoriesTable = () => {
     checkedRepositoriesToDelete,
     page,
     perPage,
-    ContentOrigin.CUSTOM,
+    [ContentOrigin.CUSTOM],
     { searchQuery: debouncedSearchValue } as FilterData,
     undefined, // sort string
   );
@@ -584,7 +584,7 @@ const PopularRepositoriesTable = () => {
 export const usePopularListOutletContext = () =>
   useOutletContext<{
     deletionContext: {
-      checkedRepositoriesToDelete: Set<string>;
+      checkedRepositoriesToDelete: Map<string, PopularRepository>;
     };
   }>();
 

--- a/src/Pages/Repositories/RepositoryLayout.tsx
+++ b/src/Pages/Repositories/RepositoryLayout.tsx
@@ -42,11 +42,15 @@ export default function RepositoryLayout() {
   const tabs = useMemo(
     () => [
       { title: 'Your repositories', route: '', key: REPOSITORIES_ROUTE },
-      {
-        title: 'Popular repositories',
-        route: POPULAR_REPOSITORIES_ROUTE,
-        key: POPULAR_REPOSITORIES_ROUTE,
-      },
+      ...(!features?.communityrepos?.enabled
+        ? [
+            {
+              title: 'Popular repositories',
+              route: POPULAR_REPOSITORIES_ROUTE,
+              key: POPULAR_REPOSITORIES_ROUTE,
+            },
+          ]
+        : []),
       ...(features?.admintasks?.enabled && features.admintasks?.accessible
         ? [
             {
@@ -72,24 +76,27 @@ export default function RepositoryLayout() {
         ouiaId='custom_repositories_description'
         paragraph='View all repositories within your organization.'
       />
-      <Tabs ouiaId='routed-tabs' activeKey={currentRoute}>
-        {tabs.map(({ title, route, key }) => (
-          <Tab
-            className={classes.tab}
-            keyParams={route}
-            key={key}
-            tabIndex={-1} // This prevents the tab from being targetable by accessibility features.
-            eventKey={key}
-            aria-label={title}
-            ouiaId={title}
-            title={
-              <Link className={classes.link} accessKey={key} key={key} to={route}>
-                <TabTitleText>{title}</TabTitleText>
-              </Link>
-            }
-          />
-        ))}
-      </Tabs>
+      {(features?.admintasks?.enabled && features.admintasks?.accessible) ||
+      !features?.communityrepos?.enabled ? (
+        <Tabs ouiaId='routed-tabs' activeKey={currentRoute}>
+          {tabs.map(({ title, route, key }) => (
+            <Tab
+              className={classes.tab}
+              keyParams={route}
+              key={key}
+              tabIndex={-1} // This prevents the tab from being targetable by accessibility features.
+              eventKey={key}
+              aria-label={title}
+              ouiaId={title}
+              title={
+                <Link className={classes.link} accessKey={key} key={key} to={route}>
+                  <TabTitleText>{title}</TabTitleText>
+                </Link>
+              }
+            />
+          ))}
+        </Tabs>
+      ) : null}
       <RepositoryQuickStart />
       {/* Render the app routes via the Layout Outlet */}
       <Grid className={classes.containerMargin}>

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/AddTemplateContext.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/AddTemplateContext.tsx
@@ -80,7 +80,7 @@ export const AddTemplateContextProvider = ({ children }: { children: ReactNode }
     10,
     { urls: hardcodedRedhatRepositories },
     '',
-    ContentOrigin.REDHAT,
+    [ContentOrigin.REDHAT],
     !!hardcodedRedhatRepositories.length,
   );
 
@@ -89,7 +89,7 @@ export const AddTemplateContextProvider = ({ children }: { children: ReactNode }
     10,
     { uuids: editTemplateData?.repository_uuids },
     '',
-    ContentOrigin.ALL,
+    [ContentOrigin.ALL],
     !!uuid && !!editTemplateData?.repository_uuids.length,
   );
 

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/CustomRepositoriesStep.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/CustomRepositoriesStep.tsx
@@ -121,7 +121,7 @@ export default function CustomRepositoriesStep() {
       uuids: toggled ? [...selectedCustomRepos] : undefined,
     },
     sortString(),
-    ContentOrigin.CUSTOM,
+    [ContentOrigin.CUSTOM],
   );
 
   const {

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/RedhatRepositoriesStep.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/RedhatRepositoriesStep.tsx
@@ -119,7 +119,7 @@ export default function RedhatRepositoriesStep() {
         uuids: toggled ? [...selectedRedhatRepos] : undefined,
       },
       sortString(),
-      ContentOrigin.REDHAT,
+      [ContentOrigin.REDHAT],
     );
 
   const {

--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
@@ -89,7 +89,7 @@ export default function SetUpDateStep() {
         uuids: itemsAfterDate.map(({ repository_uuid }) => repository_uuid),
       },
       '',
-      ContentOrigin.ALL,
+      [ContentOrigin.ALL],
     );
 
   return (

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -36,7 +36,6 @@ import DeleteContentModal from 'Pages/Repositories/ContentListTable/components/D
 import SnapshotListModal from 'Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal';
 import SnapshotDetailsModal from 'Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal';
 import PackageModal from 'Pages/Repositories/ContentListTable/components/PackageModal/PackageModal';
-import PopularRepositoriesTable from 'Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable';
 import AdminTaskTable from 'Pages/Repositories/AdminTaskTable/AdminTaskTable';
 import ViewPayloadModal from 'Pages/Repositories/AdminTaskTable/components/ViewPayloadModal/ViewPayloadModal';
 import DeleteTemplateModal from 'Pages/Templates/TemplatesTable/components/DeleteTemplateModal';
@@ -44,6 +43,7 @@ import TemplateRepositoriesTab from 'Pages/Templates/TemplateDetails/components/
 import UploadContent from 'Pages/Repositories/ContentListTable/components/UploadContent/UploadContent';
 import DeleteSnapshotsModal from 'Pages/Repositories/ContentListTable/components/SnapshotListModal/DeleteSnapshotsModal/DeleteSnapshotsModal';
 import AdminFeaturesTable from 'Pages/Repositories/AdminFeaturesTable/AdminFeaturesTable';
+import PopularRepositoriesTable from 'Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable';
 
 export default function RepositoriesRoutes() {
   const key = useMemo(() => Math.random(), []);
@@ -105,13 +105,25 @@ export default function RepositoriesRoutes() {
               element={<PackageModal />}
             />
           </Route>
-          <Route path={POPULAR_REPOSITORIES_ROUTE} element={<PopularRepositoriesTable />}>
-            {rbac?.repoWrite ? (
-              <Route key={DELETE_ROUTE} path={DELETE_ROUTE} element={<DeleteContentModal />} />
-            ) : (
-              ''
-            )}
-          </Route>
+          {...!features?.communityrepos?.enabled
+            ? [
+                <Route
+                  key={POPULAR_REPOSITORIES_ROUTE}
+                  path={POPULAR_REPOSITORIES_ROUTE}
+                  element={<PopularRepositoriesTable />}
+                >
+                  {rbac?.repoWrite ? (
+                    <Route
+                      key={DELETE_ROUTE}
+                      path={DELETE_ROUTE}
+                      element={<DeleteContentModal />}
+                    />
+                  ) : (
+                    ''
+                  )}
+                </Route>,
+              ]
+            : []}
           {...features?.admintasks?.enabled && features.admintasks?.accessible
             ? [
                 <Route

--- a/src/components/ZeroState/ZeroState.tsx
+++ b/src/components/ZeroState/ZeroState.tsx
@@ -38,7 +38,7 @@ const useStyles = createUseStyles({
 export const ZeroState = () => {
   const classes = useStyles();
   const navigate = useNavigate();
-  const { setZeroState } = useAppContext();
+  const { setZeroState, features } = useAppContext();
   const path = useHref('content');
   const pathname = path.split('content')[0] + 'content';
 
@@ -55,14 +55,18 @@ export const ZeroState = () => {
         navigate(`${pathname}/${REPOSITORIES_ROUTE}?origin=red_hat`);
       },
     },
-    {
-      title: 'Popular repositories',
-      description: 'Add popular repositories with a single click.',
-      onClick: () => {
-        setZeroState(false);
-        navigate(`${pathname}/${REPOSITORIES_ROUTE}/${POPULAR_REPOSITORIES_ROUTE}`);
-      },
-    },
+    ...(!features?.communityrepos?.enabled
+      ? [
+          {
+            title: 'Popular repositories',
+            description: 'Add popular repositories with a single click.',
+            onClick: () => {
+              setZeroState(false);
+              navigate(`${pathname}/${REPOSITORIES_ROUTE}/${POPULAR_REPOSITORIES_ROUTE}`);
+            },
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/src/middleware/AppContext.tsx
+++ b/src/middleware/AppContext.tsx
@@ -27,8 +27,8 @@ export interface AppContextInterface {
   features: Features | null;
   isFetchingPermissions: boolean;
   subscriptions?: Subscriptions;
-  contentOrigin: ContentOrigin;
-  setContentOrigin: (contentOrigin: ContentOrigin) => void;
+  contentOrigin: ContentOrigin[];
+  setContentOrigin: React.Dispatch<React.SetStateAction<ContentOrigin[]>>;
   chrome?: ChromeAPI;
   zeroState: boolean;
   setZeroState: (zeroState: boolean) => void;
@@ -43,7 +43,10 @@ export const ContextProvider = ({ children }: { children: ReactNode }) => {
   const [zeroState, setZeroState] = useState(true);
   const [features, setFeatures] = useState<Features | null>(null);
   const chrome = useChrome();
-  const [contentOrigin, setContentOrigin] = useState<ContentOrigin>(ContentOrigin.CUSTOM);
+  const [contentOrigin, setContentOrigin] = useState<ContentOrigin[]>([
+    ContentOrigin.EXTERNAL,
+    ContentOrigin.UPLOAD,
+  ]);
   const { fetchFeatures, isLoading: isFetchingFeatures } = useFetchFeaturesQuery();
   const { data: subscriptions, isLoading: isFetchingSubscriptions } = useFetchSubscriptionsQuery();
 
@@ -71,6 +74,14 @@ export const ContextProvider = ({ children }: { children: ReactNode }) => {
     (async () => {
       const fetchedFeatures = await fetchFeatures();
       setFeatures(fetchedFeatures);
+
+      if (fetchedFeatures?.communityrepos?.enabled) {
+        setContentOrigin((prev) =>
+          prev.includes(ContentOrigin.COMMUNITY) ? prev : [...prev, ContentOrigin.COMMUNITY],
+        );
+      } else {
+        setContentOrigin((prev) => prev.filter((origin) => origin !== ContentOrigin.COMMUNITY));
+      }
     })();
   }, [!!chrome]);
 

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -304,6 +304,7 @@ export enum ContentOrigin {
   'REDHAT' = 'red_hat',
   'EXTERNAL' = 'external',
   'UPLOAD' = 'upload',
+  'COMMUNITY' = 'community',
   'CUSTOM' = 'external,upload',
   'ALL' = 'red_hat,external,upload',
 }
@@ -313,7 +314,7 @@ export const getContentList: (
   limit: number,
   filterData: FilterData,
   sortBy: string,
-  contentOrigin: ContentOrigin,
+  contentOrigin: string[],
 ) => Promise<ContentListResponse> = async (page, limit, filterData, sortBy, contentOrigin) => {
   const search = filterData.searchQuery;
   const versionParam = filterData.versions?.join(',');
@@ -323,7 +324,7 @@ export const getContentList: (
   const uuidsParam = filterData.uuids?.join(',');
   const { data } = await axios.get(
     `/api/content-sources/v1/repositories/?${objectToUrlParams({
-      origin: contentOrigin,
+      origin: contentOrigin.length ? contentOrigin.join(',') : undefined,
       offset: ((page - 1) * limit).toString(),
       limit: limit?.toString(),
       search,

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -42,6 +42,7 @@ import {
   type AddUploadRequest,
   deleteSnapshots,
   getLatestRepoConfigFile,
+  PopularRepository,
 } from './ContentApi';
 import { ADMIN_TASK_LIST_KEY } from '../Admin/AdminTaskQueries';
 import useErrorNotification from 'Hooks/useErrorNotification';
@@ -72,10 +73,10 @@ const buildContentListKey = (
   page: number,
   limit: number,
   sortBy?: string,
-  contentOrigin?: ContentOrigin,
+  contentOrigin?: ContentOrigin[],
   filterData?: Partial<FilterData>,
 ) =>
-  `${page}${limit}${sortBy}${contentOrigin}${filterData?.arches?.join(
+  `${page}${limit}${sortBy}${contentOrigin?.sort().join(',')}${filterData?.arches?.join(
     '',
   )}${filterData?.versions?.join('')}${filterData?.urls?.join('')}${filterData?.uuids?.join(
     '',
@@ -128,7 +129,7 @@ export const useContentListQuery = (
   limit: number,
   filterData: FilterData,
   sortBy: string,
-  contentOrigin: ContentOrigin = ContentOrigin.CUSTOM,
+  contentOrigin: ContentOrigin[],
   enabled: boolean = true,
   polling: boolean = false,
 ) => {
@@ -403,8 +404,8 @@ export const useDeleteContentItemMutate = (
   queryClient: QueryClient,
   page: number,
   perPage: number,
+  contentOrigin: ContentOrigin[],
   filterData?: FilterData,
-  contentOrigin?: ContentOrigin,
   sortString?: string,
 ) => {
   // Below MUST match the "useContentList" key found above or updates will fail.
@@ -470,77 +471,84 @@ export const useDeleteContentItemMutate = (
   });
 };
 
-export const useBulkDeleteContentItemMutate = (
+type DeletableItem = ContentItem | PopularRepository;
+
+export const useBulkDeleteContentItemMutate = <T extends DeletableItem>(
   queryClient: QueryClient,
-  selected: Set<string>,
+  selected: Map<string, T>,
   page: number,
   perPage: number,
-  contentOrigin: ContentOrigin,
+  contentOrigin: ContentOrigin[],
   filterData?: FilterData,
   sortString?: string,
 ) => {
-  const uuids = Array.from(selected);
   // Below MUST match the "useContentList" key found above or updates will fail.
   const contentListKeyArray = [
     CONTENT_LIST_KEY,
     buildContentListKey(page, perPage, sortString, contentOrigin, filterData),
   ];
   const errorNotifier = useErrorNotification();
-  return useMutation(() => deleteContentListItems(uuids), {
-    onMutate: async (checkedRepositories: Set<string>) => {
-      // Cancel any outgoing refetches (so they don't overwrite our optimistic update)
-      await queryClient.cancelQueries(contentListKeyArray);
-      // Snapshot the previous value
-      const previousData: Partial<ContentListResponse> =
-        queryClient.getQueryData(contentListKeyArray) || {};
-
-      const newMeta = previousData.meta
-        ? {
-            ...previousData.meta,
-            count: previousData.meta.count ? previousData.meta.count - checkedRepositories.size : 1,
-          }
-        : undefined;
-
-      // Optimistically update to the new value
-      queryClient.setQueryData(contentListKeyArray, () => ({
-        ...previousData,
-        data: previousData.data?.filter((data) => !checkedRepositories.has(data.uuid)),
-        meta: newMeta,
-      }));
-      // Return a context object with the snapshotted value
-      return { previousData, newMeta, queryClient };
+  return useMutation(
+    (selected: Map<string, ContentItem>) => {
+      const uuids = Array.from(selected.keys());
+      return deleteContentListItems(uuids);
     },
-    onSuccess: (_data, _variables, context) => {
-      // Update all of the existing calls "count" to prevent number jumping on pagination
-      const { newMeta } = context as {
-        newMeta: Meta;
-      };
-      queryClient.setQueriesData(CONTENT_LIST_KEY, (data: Partial<ContentListResponse> = {}) => {
-        if (data?.meta?.count) {
-          data.meta.count = newMeta?.count;
-        }
-        return data;
-      });
-      queryClient.invalidateQueries(CONTENT_LIST_KEY);
-      queryClient.invalidateQueries(ADMIN_TASK_LIST_KEY);
-      queryClient.invalidateQueries(POPULAR_REPOSITORIES_LIST_KEY);
-    },
-    // If the mutation fails, use the context returned from onMutate to roll back
-    onError: (err: { response?: { data: ErrorResponse } }, _newData, context) => {
-      if (context) {
-        const { previousData } = context as {
-          previousData: ContentListResponse;
+    {
+      onMutate: async (selected: Map<string, ContentItem>) => {
+        // Cancel any outgoing refetches (so they don't overwrite our optimistic update)
+        await queryClient.cancelQueries(contentListKeyArray);
+        // Snapshot the previous value
+        const previousData: Partial<ContentListResponse> =
+          queryClient.getQueryData(contentListKeyArray) || {};
+
+        const newMeta = previousData.meta
+          ? {
+              ...previousData.meta,
+              count: previousData.meta.count ? previousData.meta.count - selected.size : 1,
+            }
+          : undefined;
+
+        // Optimistically update to the new value
+        queryClient.setQueryData(contentListKeyArray, () => ({
+          ...previousData,
+          data: previousData.data?.filter((data) => !selected.has(data.uuid)),
+          meta: newMeta,
+        }));
+        // Return a context object with the snapshotted value
+        return { previousData, newMeta, queryClient };
+      },
+      onSuccess: (_data, _variables, context) => {
+        // Update all of the existing calls "count" to prevent number jumping on pagination
+        const { newMeta } = context as {
+          newMeta: Meta;
         };
-        queryClient.setQueryData(contentListKeyArray, previousData);
-      }
-      errorNotifier(
-        'Error deleting items from content list',
-        'An error occurred',
-        err,
-        'bulk-delete-error',
-      );
+        queryClient.setQueriesData(CONTENT_LIST_KEY, (data: Partial<ContentListResponse> = {}) => {
+          if (data?.meta?.count) {
+            data.meta.count = newMeta?.count;
+          }
+          return data;
+        });
+        queryClient.invalidateQueries(CONTENT_LIST_KEY);
+        queryClient.invalidateQueries(ADMIN_TASK_LIST_KEY);
+        queryClient.invalidateQueries(POPULAR_REPOSITORIES_LIST_KEY);
+      },
+      // If the mutation fails, use the context returned from onMutate to roll back
+      onError: (err: { response?: { data: ErrorResponse } }, _newData, context) => {
+        if (context) {
+          const { previousData } = context as {
+            previousData: ContentListResponse;
+          };
+          queryClient.setQueryData(contentListKeyArray, previousData);
+        }
+        errorNotifier(
+          'Error deleting items from content list',
+          'An error occurred',
+          err,
+          'bulk-delete-error',
+        );
+      },
     },
-  });
+  );
 };
 
 export const useGetSnapshotsByDates = (uuids: string[], date: string) => {
@@ -724,7 +732,7 @@ export const useIntrospectRepositoryMutate = (
   queryClient: QueryClient,
   page: number,
   perPage: number,
-  contentOrigin: ContentOrigin,
+  contentOrigin: ContentOrigin[],
   filterData?: FilterData,
   sortString?: string,
 ) => {

--- a/src/services/Features/FeatureApi.ts
+++ b/src/services/Features/FeatureApi.ts
@@ -8,6 +8,7 @@ export interface Feature {
 export interface Features {
   snapshots?: Feature;
   admintasks?: Feature;
+  communityrepos?: Feature;
 }
 
 export const getFeatures: () => Promise<Features> = async () => {


### PR DESCRIPTION
## Summary

* Dependent on [this backend PR](https://github.com/content-services/content-sources-backend/pull/1117)
* Adds an EPEL toggle and changes toggle behavior to be multi-select for Custom, EPEL, and Red Hat repositories
* Visibility of the Popular repositories tab and EPEL toggle is controlled with the [community repos feature](https://github.com/content-services/content-sources-backend/blob/main/configs/config.yaml.example#L173)

## Testing steps

1. Set the [community repos feature](https://github.com/content-services/content-sources-backend/blob/main/configs/config.yaml.example#L173) to true
2. Run `make repos-import && ./release/external-repos process-repos`
3. Verify selecting/deselecting the Custom, EPEL, and Red Hat toggles shows the expected content
4. Verify the shared EPEL and Red Hat repos cannot be edited or deleted
5. When navigating to the repositories page from the zero state, the Custom and EPEL toggles should be selected by default 
6. Deleting repositories should work correctly (confirm this works regardless of which number page you're on)
7. Set the community repos feature to false. The Popular repositories tab should still be visible, the EPEL toggle should not be, and the zero state should still have a route to the Popular repositories tab
