### PR TITLE
Remove "first()" to enable multiple popup closing

### DIFF
--- a/_playwright-tests/UI/helpers/helpers.ts
+++ b/_playwright-tests/UI/helpers/helpers.ts
@@ -18,7 +18,7 @@ export const closePopupsIfExist = async (page: Page) => {
     await page.addLocatorHandler(locator, async () => {
       try {
         await page.getByRole('dialog').waitFor({ state: 'hidden', timeout: 1000 });
-        await locator.first().click({ timeout: 10_000, noWaitAfter: true }); // There can be multiple toast pop-ups
+        await locator.click({ timeout: 10_000, noWaitAfter: true }); // There can be multiple toast pop-ups
       } catch {
         return;
       }

--- a/_playwright-tests/helpers/loginHelpers.ts
+++ b/_playwright-tests/helpers/loginHelpers.ts
@@ -68,7 +68,7 @@ export const storeStorageStateAndToken = async (page: Page) => {
 };
 
 export const throwIfMissingEnvVariables = () => {
-  const ManditoryEnvVariables = [
+  const MandatoryEnvVariables = [
     'ADMIN_USERNAME',
     'ADMIN_PASSWORD',
     'BASE_URL',
@@ -76,7 +76,7 @@ export const throwIfMissingEnvVariables = () => {
   ];
 
   const missing: string[] = [];
-  ManditoryEnvVariables.forEach((envVar) => {
+  MandatoryEnvVariables.forEach((envVar) => {
     if (!process.env[envVar]) {
       missing.push(envVar);
     }


### PR DESCRIPTION
## Summary

We should not use `fits()` in this context with `noWaitAfter: true`

It was failing to close multiple popups which matched `button[id^="pendo-close-guide-"`

## Testing steps
Tests pass