### PR TITLE
Test: Run slack notification even when test fails

### DIFF
--- a/.github/workflows/nightly-stage-test-action.yml
+++ b/.github/workflows/nightly-stage-test-action.yml
@@ -86,7 +86,7 @@ jobs:
           retention-days: 10
 
       - name: Slack Notification
-        if: github.event_name != 'pull_request'
+        if: ${{ github.event_name != 'pull_request' && !cancelled() }}
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_COLOR: ${{ job.status }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Refine Slack Notification condition to trigger for non-pull_request events unless the job is cancelled