### PR TITLE
Test: update snapshot test to wait for first snapshot to finish

### DIFF
--- a/_playwright-tests/UI/SnapshotRepo.spec.ts
+++ b/_playwright-tests/UI/SnapshotRepo.spec.ts
@@ -63,6 +63,7 @@ test.describe('Snapshot Repositories', () => {
 
     await test.step('Trigger snapshot manually', async () => {
       const edited_row = await getRowByNameOrUrl(page, editedRepoName);
+      await expect(edited_row.getByText('Valid')).toBeVisible({ timeout: 60000 });
       await edited_row.getByLabel('Kebab toggle').click();
       // Trigger a snapshot manually
       await page.getByRole('menuitem', { name: 'Trigger snapshot' }).click();


### PR DESCRIPTION
## Summary

With this backend [PR](https://github.com/content-services/content-sources-backend/pull/1134), a snapshot is triggered when a repo is changed from introspection to snapshotting, so this adjusts the snapshot test to wait for the first snapshot to finish

## Testing steps

Tests pass

#testwith https://github.com/content-services/content-sources-backend/pull/1134