### PR TITLE
HMS-6049: added missing task types

### DIFF
--- a/src/Pages/Repositories/AdminTaskTable/components/AdminTaskFilters.tsx
+++ b/src/Pages/Repositories/AdminTaskTable/components/AdminTaskFilters.tsx
@@ -45,10 +45,13 @@ const statusValues = ['Running', 'Failed', 'Completed', 'Canceled', 'Pending'];
 const typeValues = [
   'snapshot',
   'delete-repository-snapshots',
+  'delete-snapshots',
   'introspect',
   'delete-templates',
   'update-template-content',
   'update-repository',
+  'add-uploads-repository',
+  'update-latest-snapshot',
 ];
 
 const filters = ['Account ID', 'Org ID', 'Status', 'Type'];


### PR DESCRIPTION
## Summary
Fix in UI - missing task types added to filter list on Admin tasks tab when filtering by type.

