### PR TITLE
Build: drop incorrect TOKEN env var in nightly CI

### DIFF
--- a/.github/workflows/nightly-stage-test-action.yml
+++ b/.github/workflows/nightly-stage-test-action.yml
@@ -56,7 +56,6 @@ jobs:
           echo "INTEGRATION=true" >> .env
           echo "BASE_URL=$BASE_URL" >> .env
           echo "PROXY=$PROXY" >> .env
-          echo "TOKEN=apple" >> .env
           echo "ADMIN_USERNAME=$ADMIN_USERNAME" >> .env
           echo "ADMIN_PASSWORD=$ADMIN_PASSWORD" >> .env
           echo "READONLY_USERNAME=$READONLY_USERNAME" >> .env


### PR DESCRIPTION
## Summary
This removes a incorrectly set environment variable from nightly stage tests, which breaks auth setup.

## Testing steps
Nightly stage test action passes.