### PR TITLE
Test: small helper reliability improvements

### DIFF
--- a/_playwright-tests/UI/helpers/helpers.ts
+++ b/_playwright-tests/UI/helpers/helpers.ts
@@ -53,10 +53,13 @@ export const getRowByNameOrUrl = async (
   name: string,
   forceFilter: boolean = false,
 ): Promise<Locator> => {
-  await clearFilters(locator);
-  const target = locator.getByRole('row').filter({ hasText: name });
   // First check if the row is visible, if so don't filter, and just return the target
+  const target = locator.getByRole('row').filter({ hasText: name });
+  if (await target.isVisible()) return target;
+
+  await clearFilters(locator);
   if (!forceFilter && (await target.isVisible())) return target;
+
   // Now run the filter
   await filterByNameOrUrl(locator, name);
   return target;

--- a/_playwright-tests/auth.setup.ts
+++ b/_playwright-tests/auth.setup.ts
@@ -7,7 +7,6 @@ import {
   logInWithReadOnlyUser,
   logInWithAdminUser,
 } from './helpers/loginHelpers';
-import { closePopupsIfExist } from './UI/helpers/helpers';
 
 import { existsSync, mkdirSync } from 'fs';
 import path from 'path';
@@ -25,8 +24,6 @@ setup.describe('Setup Authentication States', async () => {
 
   setup('Authenticate Read-Only User and Save State', async ({ page }) => {
     setup.setTimeout(60_000);
-
-    await closePopupsIfExist(page);
 
     // Login read-only user
     await logInWithReadOnlyUser(page);


### PR DESCRIPTION
## Summary
This makes small improvements to the getRowByNameOrUrl helper, by adding another early return check at the start, before the filters are cleared. This helps to prevent an issue where the filters are cleared and set too quickly so the search doesn't actually search again. And removes the use of the closePopupsIfExist helper from auth setup, it's not needed there and it was making the logout step flaky.