### PR TITLE
RHINENG-18926: Add patch tests and helper

### DIFF
--- a/_playwright-tests/UI/ExportSystem.spec.ts
+++ b/_playwright-tests/UI/ExportSystem.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from 'test-utils';
+import { navigateToSystems } from './helpers/navHelpersPatch';
+
+test.describe('Export Systems List', () => {
+  test('Navigate to systems, export list to CSV and JSON', async ({ page }) => {
+    await navigateToSystems(page);
+    await test.step('export list to CSV', async () => {
+      await page.getByRole('button', { name: 'Export' }).click();
+      await page.getByRole('menuitem', { name: 'Export to CSV' }).click();
+      const preparingAlert = page.getByText(/Preparing export of CSV format/i, { exact: false });
+      await expect(preparingAlert).toBeVisible({ timeout: 10_000 });
+      await page.getByRole('button', { name: 'close' }).first().click();
+      const successAlert = page.getByText(/The exported CSV file is being downloaded/i, {
+        exact: false,
+      });
+      await expect(successAlert).toBeVisible({ timeout: 30_000 });
+      await page.getByRole('button', { name: 'close' }).first().click();
+    });
+
+    await test.step('export list to JSON', async () => {
+      await page.getByRole('button', { name: 'Export' }).click();
+      await page.getByRole('menuitem', { name: 'Export to JSON' }).click();
+      const jsonPreparing = page.getByText(/Preparing export of JSON format/i, { exact: false });
+      await expect(jsonPreparing).toBeVisible({ timeout: 10_000 });
+      await page.getByRole('button', { name: 'close' }).first().click();
+      const jsonSuccess = page.getByText(/The exported JSON file is being downloaded/i, {
+        exact: false,
+      });
+      await expect(jsonSuccess).toBeVisible({ timeout: 30_000 });
+      await page.getByRole('button', { name: 'close' }).first().click();
+    });
+  });
+});

--- a/_playwright-tests/UI/PatchBasic.spec.ts
+++ b/_playwright-tests/UI/PatchBasic.spec.ts
@@ -1,0 +1,13 @@
+import { test } from 'test-utils';
+import { navigateToSystems } from './helpers/navHelpersPatch';
+import { closePopupsIfExist } from './helpers/helpers';
+
+test.describe('Systems Remediation Plan Disabled', () => {
+  test('Navigate to systems, ensure the Plan remediation button cannot be clicked', async ({
+    page,
+  }) => {
+    await navigateToSystems(page);
+    await closePopupsIfExist(page);
+    await page.getByRole('button', { name: 'Plan remediation' }).isDisabled();
+  });
+});

--- a/_playwright-tests/UI/helpers/navHelpersPatch.ts
+++ b/_playwright-tests/UI/helpers/navHelpersPatch.ts
@@ -1,0 +1,27 @@
+import { type Page } from '@playwright/test';
+import { test } from 'test-utils';
+import { retry } from './helpers';
+
+const navigateToSystemsFunc = async (page: Page) => {
+  await page.goto('/insights/patch/systems', { timeout: 10000 });
+  const systemText = page.getByText('Systems up to date');
+  await systemText.waitFor({ state: 'visible', timeout: 90000 });
+};
+
+export const navigateToSystems = async (page: Page) => {
+  await test.step(
+    `Navigating to Systems`,
+    async () => {
+      try {
+        const systemsNavLink = page.getByRole('navigation').getByRole('link', { name: 'Systems' });
+        await systemsNavLink.waitFor({ state: 'visible', timeout: 1500 });
+        await systemsNavLink.click();
+      } catch {
+        await retry(page, navigateToSystemsFunc, 5);
+      }
+    },
+    {
+      box: true,
+    },
+  );
+};


### PR DESCRIPTION
## Summary

1. Patch test for exporting System.
2. Patch test Plan remediation button can not be clicked when no system is selected 

## Testing steps
1. Navigate to the Systems all page.
2. Export by CSV/JSON.
expected_results:
2. Exported data will be downloaded.

Remediation button test
1. Navigate to the Systems all page.
2. plan remediation button can not be clicked

