### PR TITLE
HMS-6039: migrate fec-notifications from v5 to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@patternfly/react-table": "^6.3.0-prerelease.2",
     "@redhat-cloud-services/frontend-components": "^6.0.7",
     "@redhat-cloud-services/frontend-components-config": "^6.5.7",
-    "@redhat-cloud-services/frontend-components-notifications": "^5.0.6",
+    "@redhat-cloud-services/frontend-components-notifications": "^6.1.0",
     "@redhat-cloud-services/frontend-components-utilities": "^6.0.5",
     "@testing-library/dom": "^10.4.0",
     "@types/dockerode": "^3.3.34",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import '@redhat-cloud-services/frontend-components-utilities/styles/_all';
 import 'react18-json-view/src/style.css';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
-import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
+import { NotificationsProvider } from '@redhat-cloud-services/frontend-components-notifications';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
@@ -67,10 +67,9 @@ export default function App() {
   }
 
   return (
-    <>
+    <NotificationsProvider>
       <div data-ouia-safe={pageSafe} />
-      <NotificationsPortal />
       <Routes />
-    </>
+    </NotificationsProvider>
   );
 }

--- a/src/Hooks/useNotification.tsx
+++ b/src/Hooks/useNotification.tsx
@@ -1,19 +1,26 @@
 import { AlertVariant } from '@patternfly/react-core';
 import type { PortalNotificationConfig } from '@redhat-cloud-services/frontend-components-notifications/Portal';
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
-import { useDispatch } from 'react-redux';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications';
 
 export interface NotificationPayload {
   title: React.ReactNode | string;
   variant: AlertVariant;
   description?: React.ReactNode | string;
-  id: string | number;
+  id?: string | number;
   dismissable?: boolean;
 }
 
 export default function useNotification() {
-  const dispatch = useDispatch();
-  const notify = (payload: PortalNotificationConfig) => dispatch(addNotification(payload));
+  const addNotification = useAddNotification();
+
+  const notify = (payload: NotificationPayload) => {
+    const v6Payload: PortalNotificationConfig = {
+      ...payload,
+      id: crypto.randomUUID(),
+    };
+
+    return addNotification(v6Payload);
+  };
 
   return { notify };
 }

--- a/src/Pages/Repositories/ContentListTable/components/AddContent/helpers.ts
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/helpers.ts
@@ -180,6 +180,5 @@ export const failedFileUpload = (
     variant: AlertVariant.danger,
     title: 'There was an problem uploading the file.',
     description,
-    id: 'file-upload-error',
   });
 };

--- a/src/Pages/Templates/TemplateDetails/components/AddSystems/AddSystemModal.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/AddSystems/AddSystemModal.tsx
@@ -183,7 +183,6 @@ export default function AddSystemModal() {
         description:
           'An error occurred when creating the environment. Cannot assign this template to a system.',
         variant: AlertVariant.danger,
-        id: 'rhsm-environment-error',
         dismissable: true,
       });
     }

--- a/src/middleware/AppContext.tsx
+++ b/src/middleware/AppContext.tsx
@@ -1,7 +1,5 @@
 import { createContext, ReactNode, useContext, useEffect, useState } from 'react';
 import { Features } from 'services/Features/FeatureApi';
-import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
-import { getRegistry as _getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
 import PackageJson from '../../package.json';
 import { useFetchFeaturesQuery } from 'services/Features/FeatureQueries';
 import { ContentOrigin } from 'services/Content/ContentApi';
@@ -11,7 +9,6 @@ import getRBAC from '@redhat-cloud-services/frontend-components-utilities/RBAC';
 import { Subscriptions } from 'services/Subscriptions/SubscriptionApi';
 import { useFetchSubscriptionsQuery } from 'services/Subscriptions/SubscriptionQueries';
 
-const getRegistry = _getRegistry as unknown as () => { register: ({ notifications }) => void };
 const { appname } = PackageJson.insights;
 
 // Add permissions here
@@ -48,10 +45,6 @@ export const ContextProvider = ({ children }: { children: ReactNode }) => {
   const { data: subscriptions, isLoading: isFetchingSubscriptions } = useFetchSubscriptionsQuery();
 
   useEffect(() => {
-    // Get chrome and register app
-    const registry = getRegistry();
-    registry.register({ notifications: notificationsReducer });
-
     if (chrome && !rbac) {
       // Get permissions and store them in context
       chrome.auth.getUser().then(async () =>

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -177,7 +177,6 @@ export const useAddContentQuery = (request: CreateContentRequest) => {
                 ? 'Repository introspection in progress'
                 : 'Repository introspection data already available',
             }),
-        id: 'add-content-success',
       });
 
       queryClient.invalidateQueries(CONTENT_LIST_KEY);
@@ -210,7 +209,6 @@ export const useAddUploadsQuery = (request: AddUploadRequest) => {
             ? `${uploadCount} rpms successfully uploaded to ${data.object_name}`
             : `One rpm successfully uploaded to ${data.object_name}`,
         description: 'This repository will be snapshotted shortly',
-        id: 'add-upload-success',
       });
 
       queryClient.invalidateQueries(CONTENT_LIST_KEY);
@@ -273,7 +271,6 @@ export const useAddPopularRepositoryQuery = (
         description: hasPending
           ? 'Repository introspection in progress'
           : 'Repository introspection data already available',
-        id: 'add-popular-repo-success',
       });
 
       queryClient.invalidateQueries(CONTENT_LIST_KEY);
@@ -306,7 +303,6 @@ export const useEditContentQuery = (request: EditContentRequestItem) => {
       notify({
         variant: AlertVariant.success,
         title: `Successfully edited repository ${request.name}`,
-        id: 'edit-content-success',
       });
 
       queryClient.invalidateQueries(CONTENT_LIST_KEY);
@@ -704,7 +700,6 @@ export const useTriggerSnapshot = (queryClient: QueryClient) => {
       notify({
         variant: AlertVariant.success,
         title: 'Snapshot triggered successfully',
-        id: 'trigger-snapshot-success',
       });
       queryClient.invalidateQueries(LIST_SNAPSHOTS_KEY);
       queryClient.invalidateQueries(CONTENT_LIST_KEY);
@@ -766,7 +761,6 @@ export const useIntrospectRepositoryMutate = (
         notify({
           variant: AlertVariant.success,
           title: 'Repository introspection in progress',
-          id: 'introspect-repository-success',
         });
       }
       queryClient.invalidateQueries(CONTENT_ITEM_KEY);

--- a/src/services/Systems/SystemsQueries.ts
+++ b/src/services/Systems/SystemsQueries.ts
@@ -78,7 +78,6 @@ export const useAddTemplateToSystemsQuery = (
       notify({
         variant: AlertVariant.success,
         title: `Template successfully added to ${systemUUIDs.length} system${systemUUIDs.length > 1 ? 's' : ''}`,
-        id: 'add-template-to-system-success',
       });
 
       queryClient.invalidateQueries(GET_TEMPLATE_SYSTEMS_KEY);

--- a/src/services/Templates/TemplateQueries.ts
+++ b/src/services/Templates/TemplateQueries.ts
@@ -40,7 +40,6 @@ export const useEditTemplateQuery = (queryClient: QueryClient, request: EditTemp
       notify({
         variant: AlertVariant.success,
         title: `Successfully edited template '${request.name}'`,
-        id: 'edit-template-success',
       });
 
       queryClient.invalidateQueries(GET_TEMPLATES_KEY);
@@ -219,7 +218,6 @@ export const useCreateTemplateQuery = (queryClient: QueryClient, request: Templa
       notify({
         variant: AlertVariant.success,
         title: `Content Template "${request?.name}" created`,
-        id: 'create-template-success',
       });
 
       queryClient.invalidateQueries(GET_TEMPLATES_KEY);

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Middleware } from 'redux';
 import { ReducerRegistry } from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry/index';
-import { notifications } from '@redhat-cloud-services/frontend-components-notifications';
 
 let registry: any;
 
@@ -20,14 +19,7 @@ export const initStore = <State, Reducer extends Record<string, any>>(
 
   registry = new ReducerRegistry(initialState ?? {}, [...middleware]);
 
-  if (reducer && Object.keys(reducer).includes('notifications')) {
-    throw new Error(
-      'Invalid reducer with `notifications` key. This key is reserved for frontend-components-notifications',
-    );
-  }
-
   registry.register({
-    notifications,
     ...(reducer ?? {}),
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1373,14 +1373,13 @@
     webpack-dev-server "5.1.0"
     yargs "^17.6.2"
 
-"@redhat-cloud-services/frontend-components-notifications@^5.0.6":
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-5.0.7.tgz#f15c823d4a6d7c27d9db4f92d2ff5643a2978c3f"
-  integrity sha512-CCkioaXuz/gCK4qbBOIEle14C2EM1Qj77uyEnD0m0zpF68VRAT1xDIUO6eWFpWGTbSpklLy/Iz+5iGcSDIBxuw==
+"@redhat-cloud-services/frontend-components-notifications@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-6.1.0.tgz#9f40656ea15fb4de2a9d637bd8a2eb74e1fbb540"
+  integrity sha512-8jsS5VfuZvfCHQDRqW6vKvukBt7Oral3nCO/hhNv1WxxN9fZvLZbPV8OvYFK/50ekLvK5upFoXYFRU9Lbawb8w==
   dependencies:
     "@redhat-cloud-services/frontend-components" "^6.0.0"
     "@redhat-cloud-services/frontend-components-utilities" "^6.0.0"
-    redux-promise-middleware "6.1.3"
 
 "@redhat-cloud-services/frontend-components-utilities@^6.0.0":
   version "6.0.4"
@@ -8863,11 +8862,6 @@ redent@^3.0.0:
   dependencies:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
-
-redux-promise-middleware@6.1.3:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/redux-promise-middleware/-/redux-promise-middleware-6.1.3.tgz#315f6a9fcabe1f02a9c2f30fa615f838d7b01b66"
-  integrity sha512-B/Hi5Ct5d9y5d/KG0f6MZUXKA0nrQh5583mHCx13HY3Avte8KfpoRH/TB5QT6k/FcjT6JCxjv7jedymidy2A1A==
 
 redux@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
## Summary

- This migrates frontend-components-notifications from v5 to v6. Migration docs [here](https://github.com/RedHatInsights/frontend-components/blob/master/packages/notifications/doc/migration.md) 
- The migration also fixed the duplicate close button we were seeing on the toast notifications

## Testing steps

- Toast notifications still work 
- Tests pass
