### PR TITLE
Test: stop prettier checking style guide

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 _playwright-tests/test-utils/**/*
+_playwright-tests/style_guide.md


### PR DESCRIPTION
## Summary

stop prettier checking style guide

because it logs "warn" in PR test runs.

## Testing steps

tests pass