### PR TITLE
Test: Fix style guide typos and end-of-line whitespace

### DIFF
--- a/_playwright-tests/style_guide.md
+++ b/_playwright-tests/style_guide.md
@@ -5,7 +5,7 @@ This style guide outlines the standards and best practices for writing Playwrigh
 Most of the things here are in-line with the [official Playwright best practices/guidelines](https://playwright.dev/docs/best-practices).
 
 > [!TIP]
-> The official Playwright documentation is **awesome** and should be your first stop for any questions you have about Playwright. Often this will pay of more than jumping into AI chat-bots first.
+> The official Playwright documentation is **awesome** and should be your first stop for any questions you have about Playwright. Often this will pay off more than jumping into AI chat-bots first.
 
 ## Table of Contents 📜
 
@@ -22,16 +22,16 @@ Most of the things here are in-line with the [official Playwright best practices
    Each test should be independent and shouldn't rely on state from other tests.
 
 2. **Test idempotency**: \
-   Each test should be idempotent, i.e.: be able to run on repeat with the same _(successful)_ outcome.
+   Each test should be idempotent, i.e. be able to run on repeat with the same _(successful)_ outcome.
 
 3. **Parallelization**: \
-   Structure tests to run in parallel for faster execution. Optimize or be vary of the length of tests, as you want a speedy feedback loop.
+   Structure tests to run in parallel for faster execution. Optimize and review the length of tests, as you want a speedy feedback loop.
 
 4. **Use playwright's capturing features**: \
-   Configure Playwright to take screenshots, videos and record test traces on test failures. And ideally use some tool to collect and visualize them.
+   Configure Playwright to take screenshots, videos, and record test traces on test failures. Ideally use some tool to collect and visualize them.
 
 5. **Don't try to reinvent the wheel**: \
-   Simplicity is king, test can be simple. Only reach for custom (complicated/hard to maintain) things if there isn't a good solution out of the box. _(for vast majority of things there is)_
+   Simplicity is king, tests can be simple. Only reach for custom (complicated and hard to maintain) things if there isn't a good solution out of the box. _(for vast majority of things there is)_
 
 6. **Keep abstractions to minimum**: \
    To keep tests readable and maintainable, define selectors directly within the test where they are used. Avoid abstracting selectors into separate files and don't use page objects. The test should be easy to understand and readable as an article, after which you know what it does and don't have more questions than answers.
@@ -43,13 +43,13 @@ Most of the things here are in-line with the [official Playwright best practices
    - Bad examples: page objects, clicking on a button, filling in a form (that's the core of the test, if you want to use that for setting up the test environment use the API).
 
 8. **Use the built-in Playwright auto-waiting functionality and not sleep:**
-   Playwright provides [auto-waiting](https://playwright.dev/docs/actionability) for actions inside tests (ex.: clicking a button is an action). That performs a range of actionability checks on the elements before making actions to ensure these actions behave as expected.
+   Playwright provides [auto-waiting](https://playwright.dev/docs/actionability) for actions inside tests (e.g. clicking a button is an action). These perform a range of actionability checks on the elements before making actions to ensure these actions behave as expected.
    This eliminates the need to use manual wait or sleep statements that make tests flaky and slow.
 
 9. **Describe tests**:
 
-   - Use clear, descriptive test names that explain what you're testing.
-   - Group tests in describes if they relate to the overarching feature.
+   - Use clear descriptive test names that explain what you're testing.
+   - Group tests in describe blocks if they relate to the overarching feature.
    - Use steps to describe what the test does in more detail, these show up in the test report.
    - Don't use comments to describe the test, as they will not be visible in the report (only use them if you need to explain the code further, not the test).
 
@@ -60,7 +60,7 @@ Most of the things here are in-line with the [official Playwright best practices
 
 A good test structure makes it easier to locate, run, and maintain tests. Consider organizing your tests by feature or page.
 
-Recommended folder/file structure:
+Recommended directory and file structure:
 
 ```sh
 /_playwright-tests
@@ -102,12 +102,12 @@ test.describe('Feature Name', () => {
 
 ## Selectors 🎯
 
-In order of preference, use these selector strategies (and ideally just stick to the first two):
+In order of preference, use these selector strategies (ideally just stick to the first two):
 
 1. **Roles with name**
 
    This is highly preferred, because this selector actually reflects how
-   users and assistive technology perceive the page, i.e.: tests user-visible behavior.
+   users and assistive technology perceive the page, i.e. tests user-visible behavior.
    Keep in mind that the name is an [accessible name](https://w3c.github.io/accname/#dfn-accessible-name), not just the HTML 'name' attribute.
 
    ```typescript
@@ -164,7 +164,7 @@ Negative assertions: `await expect(page.getByText('Error')).not.toBeVisible();`
 
 ### Non-DOM Assertions
 
-For checks that don't involve the DOM (e.g., API responses, or other async operations that don't have a UI expression), you can use `expect.poll`.
+For checks that don't involve the DOM (e.g. API responses, or other async operations that don't have a UI expression), you can use `expect.poll`.
 
 ```typescript
 await expect
@@ -181,7 +181,7 @@ await expect
   .toBe(200);
 ```
 
-For assertion of one out of many or multiple checks at once, you can also use the `race` and `all` from the JS promises.
+For assertion of one out of many, or multiple checks at once, you can also use the `race` and `all` from the JS promises.
 Example:
 
 ```typescript
@@ -195,12 +195,12 @@ await Promise.all([
 
 ## Debugging 🐛
 
-Playwright offers several powerful tools for debugging your tests (ex.: headed/debug mode, trace/ viewer, codegen). These tools can be accessed through Playwright's CLI or IDE extension. Some examples:
+Playwright offers several powerful tools for debugging your tests (ex. headed and debug mode, trace viewer, codegen). These tools can be accessed through Playwright's CLI or IDE extension. Some examples:
 
 ### Playwright Inspector
 
 The Inspector is a GUI tool that helps you step through your tests, see what Playwright is doing, and explore selectors.
-The editable selector explorer at the bottom of the page can be really usefull for crafting good selectors. 💡
+The editable selector explorer at the bottom of the page can be really useful for creating good selectors.💡
 
 Run your tests with the `--debug` flag to open the Inspector:
 
@@ -237,13 +237,13 @@ Insert `await page.pause()` into your test to pause execution and open a browser
 ### VS Code Extension
 
 The official [Playwright Test for VS Code](https://playwright.dev/docs/getting-started-vs-code) extension offers a great debugging experience directly within your editor, including running tests with a single click, setting breakpoints, and live debugging.
-But don't worry, the vast majority if not everything can be achieved through the CLI, so you can use your preffered editor of choice.
+But don't worry, the vast majority if not everything can be achieved through the CLI, so you can use your preferred editor of choice.
 
 ## Caveats, gotchas and things to be aware of ⚠
 
-- When working with PF modals/wizards/dialogs, there is a problem where they can incorrectly 'hide'/disable the page behind them.
+- When working with PF modals, wizards, and dialogs, there is a problem where they can incorrectly 'hide' or disable the page behind them.
 
-  - This can cause issues with Playwright, as it might try to interact with elements that are/should not visible or enabled.
+  - This can cause issues with Playwright, as it might try to interact with elements that are and should not visible or enabled.
   - To work around this, you can target the dialog and save it to a variable, then use that variable to interact with any elements inside the dialog.
 
     ```typescript
@@ -252,5 +252,5 @@ But don't worry, the vast majority if not everything can be achieved through the
     ```
 
 - Navigation inside Insights (stage and proxy especially) can be flaky.
-  - This can be caused by multiple reasons (stage/proxy instability, sentry errors, cache failures, slooow loads 🐌).
-  - If you are experiencing this, try to add retry logic to auth/navigation.
+  - This can be caused by multiple reasons (stage or proxy instability, sentry errors, cache failures, slow loading).
+  - If you are experiencing this, try to add retry logic to auth and navigation steps.

--- a/_playwright-tests/style_guide.md
+++ b/_playwright-tests/style_guide.md
@@ -38,16 +38,14 @@ Most of the things here are in-line with the [official Playwright best practices
 
 7. **Helpers and fixtures**: \
    Extend Playwright with custom functionality only when the abstracted thing is generic enough.
-
    - Good examples: cleanup of resources before and after a test, navigation to your app with auto retrying, locating a row in a table.
    - Bad examples: page objects, clicking on a button, filling in a form (that's the core of the test, if you want to use that for setting up the test environment use the API).
 
-8. **Use the built-in Playwright auto-waiting functionality and not sleep:**
+8. **Use the built-in Playwright auto-waiting functionality and not sleep:** \
    Playwright provides [auto-waiting](https://playwright.dev/docs/actionability) for actions inside tests (e.g. clicking a button is an action). These perform a range of actionability checks on the elements before making actions to ensure these actions behave as expected.
    This eliminates the need to use manual wait or sleep statements that make tests flaky and slow.
 
 9. **Describe tests**:
-
    - Use clear descriptive test names that explain what you're testing.
    - Group tests in describe blocks if they relate to the overarching feature.
    - Use steps to describe what the test does in more detail, these show up in the test report.
@@ -242,7 +240,6 @@ But don't worry, the vast majority if not everything can be achieved through the
 ## Caveats, gotchas and things to be aware of ⚠
 
 - When working with PF modals, wizards, and dialogs, there is a problem where they can incorrectly 'hide' or disable the page behind them.
-
   - This can cause issues with Playwright, as it might try to interact with elements that are and should not visible or enabled.
   - To work around this, you can target the dialog and save it to a variable, then use that variable to interact with any elements inside the dialog.
 


### PR DESCRIPTION
## Summary

Fixed some typos
Using gvim I found some end-of-line whitespace

## Testing steps

tests passs
