### PR TITLE
Test: Do not check for bulk delete URL when deleting a single repo

### DIFF
--- a/_playwright-tests/UI/SnapshotRepo.spec.ts
+++ b/_playwright-tests/UI/SnapshotRepo.spec.ts
@@ -94,8 +94,7 @@ test.describe('Snapshot Repositories', () => {
 
       await Promise.all([
         page.waitForResponse(
-          (resp) =>
-            resp.url().includes('bulk_delete') && resp.status() >= 200 && resp.status() < 300,
+          (resp) => resp.url().includes('delete') && resp.status() >= 200 && resp.status() < 300,
         ),
         page.getByRole('button', { name: 'Remove' }).click(),
       ]);


### PR DESCRIPTION
## Summary

This step is deleting a single repo not doing a bulk delete.

The URL will look like this for a single repo if you access the delete modal using the kebab menu:
`content/repositories/delete?repoUUID=2582bfac-7319-4a6e-bf13-34f6e01aab28`

However if you select the row and then use the dropdrown menu, the URL will just be:
`insights/content/repositories/delete`


## Testing steps

tests pass


