### PR TITLE
HMS-5261: rename "Remove" to "Delete" where applicable

### DIFF
--- a/_playwright-tests/UI/CustomRepoCRUD.spec.ts
+++ b/_playwright-tests/UI/CustomRepoCRUD.spec.ts
@@ -77,8 +77,8 @@ test.describe('Custom Repositories CRUD', () => {
       const row = await getRowByNameOrUrl(page, `${repoName}-Edited`);
       await row.getByRole('button', { name: 'Kebab toggle' }).click();
       await page.getByRole('menuitem', { name: 'Delete' }).click();
-      await expect(page.getByText('Remove repositories?')).toBeVisible();
-      await page.getByRole('button', { name: 'Remove' }).click();
+      await expect(page.getByText('Delete repositories?')).toBeVisible();
+      await page.getByRole('button', { name: 'Delete' }).click();
       await expect(page.getByRole('row', { name: repoName })).not.toBeVisible();
     });
   });

--- a/_playwright-tests/UI/IntrospectRepo.spec.ts
+++ b/_playwright-tests/UI/IntrospectRepo.spec.ts
@@ -71,14 +71,14 @@ test.describe('Introspect Repositories', () => {
       const row = await getRowByNameOrUrl(page, repoName);
       await row.getByRole('button', { name: 'Kebab toggle' }).click();
       await page.getByRole('menuitem', { name: 'Delete' }).click();
-      await expect(page.getByText('Remove repositories?')).toBeVisible();
+      await expect(page.getByText('Delete repositories?')).toBeVisible();
 
       await Promise.all([
         page.waitForResponse(
           (resp) =>
             resp.url().includes('bulk_delete') && resp.status() >= 200 && resp.status() < 300,
         ),
-        page.getByRole('button', { name: 'Remove' }).click(),
+        page.getByRole('button', { name: 'Delete' }).click(),
       ]);
       // Ensure the specific row is removed
       await expect(row).not.toBeVisible();

--- a/_playwright-tests/UI/PopularRepo.spec.ts
+++ b/_playwright-tests/UI/PopularRepo.spec.ts
@@ -42,13 +42,13 @@ test.describe('Popular Repositories', () => {
       await page.getByRole('menuitem', { name: 'Add 3 repositories without snapshotting' }).click();
     });
 
-    await test.step('Check buttons have changed from Add to Remove', async () => {
+    await test.step('Check buttons have changed from Add to Delete', async () => {
       for (const repoName of repos) {
         await expect(
           page
             .getByRole('row', { name: repoName })
             .getByTestId('remove_popular_repo')
-            .getByText('Remove'),
+            .getByText('Delete'),
         ).toBeVisible();
       }
     });
@@ -80,11 +80,11 @@ test.describe('Popular Repositories', () => {
 
         await page.getByTestId('delete-kebab').click();
       }
-      await page.getByRole('menuitem', { name: 'Remove 3 repositories' }).click();
+      await page.getByRole('menuitem', { name: 'Delete 3 repositories' }).click();
       // Confirm the removal in the pop-up
       await page
-        .getByRole('dialog', { name: 'Remove repositories?' })
-        .getByRole('button', { name: 'Remove' })
+        .getByRole('dialog', { name: 'Delete repositories?' })
+        .getByRole('button', { name: 'Delete' })
         .click();
     });
   });

--- a/_playwright-tests/UI/SnapshotRepo.spec.ts
+++ b/_playwright-tests/UI/SnapshotRepo.spec.ts
@@ -90,13 +90,13 @@ test.describe('Snapshot Repositories', () => {
       const edited_row = await getRowByNameOrUrl(page, repoUrl);
       await edited_row.getByLabel('Kebab toggle').click();
       await page.getByRole('menuitem', { name: 'Delete' }).click();
-      await expect(page.getByText('Remove repositories?')).toBeVisible();
+      await expect(page.getByText('Delete repositories?')).toBeVisible();
 
       await Promise.all([
         page.waitForResponse(
           (resp) => resp.url().includes('delete') && resp.status() >= 200 && resp.status() < 300,
         ),
-        page.getByRole('button', { name: 'Remove' }).click(),
+        page.getByRole('button', { name: 'Delete' }).click(),
       ]);
 
       await expect(edited_row).not.toBeVisible();
@@ -202,8 +202,8 @@ test.describe('Snapshot Repositories', () => {
         .getByLabel('Kebab toggle')
         .click();
       await page.getByRole('menuitem', { name: 'Delete' }).click();
-      await expect(page.getByText('Remove snapshots?')).toBeVisible();
-      await page.getByText('Remove', { exact: true }).click();
+      await expect(page.getByText('Delete snapshots?')).toBeVisible();
+      await page.getByText('Delete', { exact: true }).click();
       await expect(page.getByRole('button', { name: '1 - 3 of 3' }).first()).toBeVisible({
         timeout: 60000,
       });
@@ -225,8 +225,8 @@ test.describe('Snapshot Repositories', () => {
       // Therefore uncheck the first snapshot
       await page.getByRole('checkbox', { name: 'Select row 0' }).uncheck();
       await page.getByTestId('remove_snapshots_bulk').click();
-      await expect(page.getByText('Remove snapshots?')).toBeVisible();
-      await page.getByText('Remove', { exact: true }).click();
+      await expect(page.getByText('Delete snapshots?')).toBeVisible();
+      await page.getByText('Delete', { exact: true }).click();
       await expect(page.getByRole('button', { name: '1 - 1 of 1' }).first()).toBeVisible({
         timeout: 60000,
       });

--- a/_playwright-tests/UI/TemplateCRUD.spec.ts
+++ b/_playwright-tests/UI/TemplateCRUD.spec.ts
@@ -90,8 +90,8 @@ test.describe('Templates CRUD', () => {
       await expect(rowTemplate.getByText('Valid')).toBeVisible({ timeout: 60000 });
       await rowTemplate.getByLabel('Kebab toggle').click();
       await page.getByRole('menuitem', { name: 'Delete' }).click();
-      await expect(page.getByText('Remove template?')).toBeVisible();
-      await page.getByRole('button', { name: 'Remove' }).click();
+      await expect(page.getByText('Delete template?')).toBeVisible();
+      await page.getByRole('button', { name: 'Delete' }).click();
       await expect(rowTemplate.getByText('Valid')).not.toBeVisible();
     });
   });

--- a/_playwright-tests/UI/UploadRepo.spec.ts
+++ b/_playwright-tests/UI/UploadRepo.spec.ts
@@ -79,17 +79,17 @@ test.describe('Upload Repositories', () => {
       await row.getByRole('button', { name: 'Kebab toggle' }).click();
       await page.getByRole('menuitem', { name: 'Delete' }).click();
 
-      // Click on the 'Remove' button
+      // Click on the 'Delete' button
       await Promise.all([
-        // Verify the 'Remove repositories?' dialog is visible
-        expect(page.getByText('Remove repositories?')).toBeVisible(),
+        // Verify the 'Delete repositories?' dialog is visible
+        expect(page.getByText('Delete repositories?')).toBeVisible(),
         // Wait for the successful API call
         page.waitForResponse(
           (resp) =>
             resp.url().includes('bulk_delete') && resp.status() >= 200 && resp.status() < 300,
         ),
-        // Click the 'Remove' button
-        page.getByRole('button', { name: 'Remove' }).click(),
+        // Click the 'Delete' button
+        page.getByRole('button', { name: 'Delete' }).click(),
         await expect(row).not.toBeVisible(),
       ]);
     });

--- a/_playwright-tests/style_guide.md
+++ b/_playwright-tests/style_guide.md
@@ -9,12 +9,20 @@ Most of the things here are in-line with the [official Playwright best practices
 
 ## Table of Contents 📜
 
-- [Best Practices ✨](#best-practices)
-- [Test Structure 🏗](#test-structure)
-- [Selectors 🎯](#selectors)
-- [Assertions 🔍](#assertions)
-- [Debugging 🐛](#debugging)
-- [Caveats, gotchas and things to be aware of ⚠](#caveats-gotchas-and-things-to-be-aware-of)
+- [Playwright Style Guide 💅](#playwright-style-guide-)
+  - [Table of Contents 📜](#table-of-contents-)
+  - [Best Practices ✨](#best-practices-)
+  - [Test Structure 🏗](#test-structure-)
+  - [Selectors 🎯](#selectors-)
+  - [Assertions 🔍](#assertions-)
+    - [Common Assertions](#common-assertions)
+    - [Non-DOM Assertions](#non-dom-assertions)
+  - [Debugging 🐛](#debugging-)
+    - [Playwright Inspector](#playwright-inspector)
+    - [Trace Viewer](#trace-viewer)
+    - [`page.pause()`](#pagepause)
+    - [VS Code Extension](#vs-code-extension)
+  - [Caveats, gotchas and things to be aware of ⚠](#caveats-gotchas-and-things-to-be-aware-of-)
 
 ## Best Practices ✨
 

--- a/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
@@ -155,16 +155,16 @@ export default function DeleteContentModal() {
       titleIconVariant='warning'
       position='top'
       variant={ModalVariant.large}
-      title='Remove repositories?'
+      title='Delete repositories?'
       ouiaId='delete_custom_repositories'
       description={
         <>
           <Hide hide={templates.data.length <= 0}>
             <Alert variant='warning' isInline title='Some repositories have associated templates.'>
-              Removing these repositories will remove that content from their associated templates.
+              Deleting these repositories will delete that content from their associated templates.
             </Alert>
           </Hide>
-          <Content component='p'>Are you sure you want to remove these repositories?</Content>
+          <Content component='p'>Are you sure you want to delete these repositories?</Content>
         </>
       }
       isOpen
@@ -180,7 +180,7 @@ export default function DeleteContentModal() {
               isDisabled={actionTakingPlace}
               onClick={onSave}
             >
-              Remove
+              Delete
             </Button>
             <Button key='cancel' variant='link' onClick={onClose} ouiaId='delete_modal_cancel'>
               Cancel

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/DeleteSnapshotsModal/DeleteSnapshotsModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/DeleteSnapshotsModal/DeleteSnapshotsModal.tsx
@@ -117,18 +117,18 @@ export default function DeleteSnapshotsModal() {
       titleIconVariant='warning'
       position='top'
       variant={ModalVariant.large}
-      title='Remove snapshots?'
+      title='Delete snapshots?'
       ouiaId='delete_snapshots'
       description={
         <>
           <Hide hide={!affectsTemplates}>
             <Alert variant='warning' isInline title='Some snapshots have associated templates.'>
-              Removing these snapshots will change content in their associated templates. Templates
+              Deleting these snapshots will change content in their associated templates. Templates
               will switch to a snapshot taken closest to the deleted one.
             </Alert>
           </Hide>
           <Content component='p' className={classes.description}>
-            Are you sure you want to remove these snapshots?
+            Are you sure you want to delete these snapshots?
           </Content>
         </>
       }
@@ -145,7 +145,7 @@ export default function DeleteSnapshotsModal() {
               isDisabled={actionTakingPlace}
               onClick={onSave}
             >
-              Remove
+              Delete
             </Button>
             <Button
               key='cancel'

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
@@ -254,10 +254,10 @@ const SnapshotListModal = () => {
                         onClick={() => navigate(DELETE_ROUTE)}
                       >
                         {!checkedSnapshots.size || !rbac?.repoWrite
-                          ? 'Remove selected snapshots'
+                          ? 'Delete selected snapshots'
                           : checkedSnapshots.size == count
-                            ? `Can't remove all snapshots`
-                            : `Remove ${checkedSnapshots.size} snapshots`}
+                            ? `Can't delete all snapshots`
+                            : `Delete ${checkedSnapshots.size} snapshots`}
                       </Button>
                     </ConditionalTooltip>
                   </FlexItem>

--- a/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.test.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.test.tsx
@@ -59,7 +59,7 @@ it('expect PopularRepositoriesTable to render with remove one item', () => {
   (usePopularRepositoriesQuery as jest.Mock).mockImplementation(() => ({
     isLoading: false,
     data: {
-      data: [{ ...defaultPopularRepository, uuid: 'ifThisExistsThanButtonIsRemove' }],
+      data: [{ ...defaultPopularRepository, uuid: 'ifThisExistsThanButtonIsDelete' }],
       meta: { count: 1, limit: 20, offset: 0 },
     },
   }));
@@ -72,7 +72,7 @@ it('expect PopularRepositoriesTable to render with remove one item', () => {
 
   expect(queryByText(defaultPopularRepository.suggested_name)).toBeInTheDocument();
   expect(queryByText(defaultPopularRepository.url)).toBeInTheDocument();
-  expect(queryByText('Remove')).toBeInTheDocument();
+  expect(queryByText('Delete')).toBeInTheDocument();
 });
 
 it('Render a loading state checking search disabled', () => {

--- a/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.tsx
@@ -530,7 +530,7 @@ const PopularRepositoriesTable = () => {
                               variant='danger'
                               ouiaId='remove_popular_repo'
                             >
-                              Remove
+                              Delete
                             </Button>
                           ) : (
                             <AddRepo

--- a/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.test.tsx
@@ -3,6 +3,7 @@ import { ReactQueryTestWrapper, defaultSystemsListItem, defaultTemplateItem } fr
 
 import DeleteTemplateModal from './DeleteTemplateModal';
 import { useListSystemsByTemplateId } from 'services/Systems/SystemsQueries';
+import { useFetchTemplate } from 'services/Templates/TemplateQueries';
 
 jest.mock('react-query', () => ({
   ...jest.requireActual('react-query'),
@@ -24,6 +25,7 @@ jest.mock('services/Systems/SystemsQueries', () => ({
 
 jest.mock('services/Templates/TemplateQueries', () => ({
   useDeleteTemplateItemMutate: () => ({ mutate: () => undefined, isLoading: false }),
+  useFetchTemplate: jest.fn(),
 }));
 
 jest.mock('middleware/AppContext', () => ({ useAppContext: () => ({}) }));
@@ -36,6 +38,10 @@ it('Render delete modal where there are no systems', () => {
       count: 0,
     },
   }));
+  (useFetchTemplate as jest.Mock).mockImplementation(() => ({
+    isLoading: false,
+    data: { name: 'test' },
+  }));
 
   const { queryByText } = render(
     <ReactQueryTestWrapper>
@@ -44,7 +50,10 @@ it('Render delete modal where there are no systems', () => {
   );
 
   expect(queryByText('This template is in use.')).toBeNull();
-  expect(queryByText('Are you sure you want to remove this template?')).toBeInTheDocument();
+  expect(
+    queryByText('Template and all its data will be deleted. This action cannot be undone.'),
+  ).toBeInTheDocument();
+  expect(queryByText('test')).toBeInTheDocument();
 });
 
 it('Render delete modal where template has one system', () => {
@@ -63,5 +72,8 @@ it('Render delete modal where template has one system', () => {
   );
 
   expect(queryByText('This template is in use.')).toBeInTheDocument();
-  expect(queryByText('Are you sure you want to remove this template?')).toBeInTheDocument();
+  expect(
+    queryByText('Template and all its data will be deleted. This action cannot be undone.'),
+  ).toBeInTheDocument();
+  expect(queryByText('test')).toBeInTheDocument();
 });

--- a/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.tsx
@@ -15,7 +15,11 @@ import Hide from 'components/Hide/Hide';
 import { useQueryClient } from 'react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 import useRootPath from 'Hooks/useRootPath';
-import { GET_TEMPLATES_KEY, useDeleteTemplateItemMutate } from 'services/Templates/TemplateQueries';
+import {
+  GET_TEMPLATES_KEY,
+  useDeleteTemplateItemMutate,
+  useFetchTemplate,
+} from 'services/Templates/TemplateQueries';
 import { DETAILS_ROUTE, SYSTEMS_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
 import { useListSystemsByTemplateId } from 'services/Systems/SystemsQueries';
 
@@ -39,6 +43,8 @@ export default function DeleteTemplateModal() {
   const queryClient = useQueryClient();
 
   const { templateUUID: uuid } = useParams();
+
+  const { data: templateData, isLoading: isTemplateLoading } = useFetchTemplate(uuid!);
 
   const { mutateAsync: deleteTemplate, isLoading: isDeleting } =
     useDeleteTemplateItemMutate(queryClient);
@@ -64,7 +70,7 @@ export default function DeleteTemplateModal() {
       titleIconVariant='warning'
       position='top'
       variant={ModalVariant.medium}
-      title='Remove template?'
+      title='Delete template?'
       ouiaId='delete_template'
       isOpen
       onClose={onClose}
@@ -79,7 +85,7 @@ export default function DeleteTemplateModal() {
               isDisabled={actionTakingPlace}
               onClick={onSave}
             >
-              Remove
+              Delete
             </Button>
             <Button key='cancel' variant='link' onClick={onClose} ouiaId='delete_modal_cancel'>
               Cancel
@@ -88,7 +94,7 @@ export default function DeleteTemplateModal() {
         </Stack>
       }
     >
-      <Hide hide={!isLoading}>
+      <Hide hide={!isLoading && !isTemplateLoading}>
         <Bullseye>
           <Spinner />
         </Bullseye>
@@ -104,16 +110,19 @@ export default function DeleteTemplateModal() {
               {systems.data.length === 1 ? 'system' : 'systems'}.
             </a>
             <span>
-              Removing this template will cause all associated systems to stop receiving custom
+              Deleting this template will cause all associated systems to stop receiving custom
               content and snapshotted Red Hat content; they will still receive the latest Red Hat
               content updates.
             </span>
           </Flex>
         </Alert>
       </Hide>
-      <Content component='p' className={classes.description}>
-        Are you sure you want to remove this template?
-      </Content>
+      <Hide hide={isLoading || isTemplateLoading}>
+        <Content component='p' className={classes.description}>
+          Template <b>{templateData?.name}</b> and all its data will be deleted. This action cannot
+          be undone.
+        </Content>
+      </Hide>
     </Modal>
   );
 }

--- a/src/components/DeleteKebab/DeleteKebab.test.tsx
+++ b/src/components/DeleteKebab/DeleteKebab.test.tsx
@@ -18,7 +18,7 @@ it('Render no checked repos', async () => {
   const kebab = getByRole('button', { name: 'plain kebab' });
   await userEvent.click(kebab as Element);
 
-  const deleteButton = getByRole('menuitem', { name: 'Remove selected repositories' });
+  const deleteButton = getByRole('menuitem', { name: 'Delete selected repositories' });
   expect(deleteButton).toBeInTheDocument();
   expect(deleteButton).toHaveAttribute('disabled');
 });
@@ -32,7 +32,7 @@ it('Render with checked repos', async () => {
   const kebab = document.getElementById('delete-kebab');
   await userEvent.click(kebab as Element);
 
-  const deleteButton = queryByText(`Remove ${repos} repositories`);
+  const deleteButton = queryByText(`Delete ${repos} repositories`);
   expect(deleteButton).toBeInTheDocument();
   expect(deleteButton).not.toHaveAttribute('disabled');
 });

--- a/src/components/DeleteKebab/DeleteKebab.tsx
+++ b/src/components/DeleteKebab/DeleteKebab.tsx
@@ -55,8 +55,8 @@ const DeleteKebab = ({ atLeastOneRepoChecked, numberOfReposChecked, isDisabled }
         >
           <DropdownItem onClick={() => navigate(DELETE_ROUTE)}>
             {atLeastOneRepoChecked
-              ? `Remove ${numberOfReposChecked} repositories`
-              : 'Remove selected repositories'}
+              ? `Delete ${numberOfReposChecked} repositories`
+              : 'Delete selected repositories'}
           </DropdownItem>
         </ConditionalTooltip>
       </DropdownList>


### PR DESCRIPTION
## Summary
Rename "Remove" to "Delete" and change wordings in deletion modal to have better clarity about the performed action

## Testing steps
Check wording (delete buttons and modal titles) in:
- DeleteContentModal
- DeleteSnapshotModal
- PopularRepositoriesTable - Delete selected repositories dropdown
- DeleteTemplateModal
  - Wording change, includes name of the affected template
  - Delete button and modal title
- DeleteKebab - dropdown option