### PR TITLE
Test: configure proxy for rhc in stage

### DIFF
--- a/_playwright-tests/Integration/helpers/rhsmClient.ts
+++ b/_playwright-tests/Integration/helpers/rhsmClient.ts
@@ -47,8 +47,9 @@ export class RHSMClient {
    */
   async ConfigureRHCForStage() {
     const command = [
-      'echo',
-      `"proxy=${process.env.PROXY}" >> /etc/insights-client/insights-client.conf`,
+      'sh',
+      '-c',
+      `echo "proxy=${process.env.PROXY}" >> /etc/insights-client/insights-client.conf`,
     ];
     return runCommand(this.name, command);
   }


### PR DESCRIPTION
## Summary
The proxy was not correctly being appended to the insights-client config when registering rhc in stage

## Testing steps
