### PR TITLE
HMS-8934: add resumable parameter for uploads

### DIFF
--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -557,6 +557,7 @@ export const createUpload: (size: number, sha256: string) => Promise<UploadRespo
     size,
     sha256,
     chunk_size: MAX_CHUNK_SIZE,
+    resumable: true,
   });
   return data;
 };


### PR DESCRIPTION
## Summary
Following the changes in the backend, to keep the frontend as it has been working, resumable=true was added for the /repositories/uploads api. Passing the same sha256 and chunk_size, it will still resume upload on the existing UUID.

#testwith https://github.com/content-services/content-sources-backend/pull/1176



