### PR TITLE
HMS-8883: spinner behavior triggered only on data fetching

### DIFF
--- a/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
@@ -68,9 +68,6 @@ const useStyles = createUseStyles({
   bottomContainer: {
     justifyContent: 'space-between',
   },
-  invisible: {
-    opacity: 0,
-  },
   checkboxMinWidth: {
     minWidth: '45px!important',
   },
@@ -111,7 +108,6 @@ const ContentListTable = () => {
   const {
     archesDisplay,
     versionDisplay,
-    isLoading: repositoryParamsLoading,
     isError: repositoryParamsIsError,
     error: repositoryParamsError,
   } = useArchVersion();
@@ -177,6 +173,8 @@ const ContentListTable = () => {
     data = { data: [], meta: { count: 0, limit: 20, offset: 0 } },
   } = useContentListQuery(page, perPage, filterData, sortString, contentOrigin, true, polling);
 
+  const actionTakingPlace = isFetching;
+
   useEffect(() => {
     if (isError) {
       setPolling(false);
@@ -200,15 +198,14 @@ const ContentListTable = () => {
     return setPolling(containsPending);
   }, [data?.data]);
 
-  const { mutateAsync: introspectRepository, isLoading: isIntrospecting } =
-    useIntrospectRepositoryMutate(
-      queryClient,
-      page,
-      perPage,
-      contentOrigin,
-      filterData,
-      sortString,
-    );
+  const { mutateAsync: introspectRepository } = useIntrospectRepositoryMutate(
+    queryClient,
+    page,
+    perPage,
+    contentOrigin,
+    filterData,
+    sortString,
+  );
 
   const introspectRepoForUuid = (uuid: string): Promise<void> =>
     introspectRepository({ uuid: uuid, reset_count: true } as IntrospectRepositoryRequestItem);
@@ -219,7 +216,7 @@ const ContentListTable = () => {
     triggerSnapshotMutation(uuid);
   };
 
-  const { isLoading: isDeletingItems } = useBulkDeleteContentItemMutate(
+  useBulkDeleteContentItemMutate(
     queryClient,
     checkedRepositories,
     page,
@@ -234,10 +231,6 @@ const ContentListTable = () => {
     await introspectRepoForUuid(repoUuid);
     await triggerSnapshot(repoUuid);
   };
-
-  // Other update actions will be added to this later.
-  const actionTakingPlace =
-    isFetching || repositoryParamsLoading || isIntrospecting || isDeletingItems;
 
   const onSetPage = (_, newPage) => setPage(newPage);
 
@@ -582,7 +575,7 @@ const ContentListTable = () => {
                         ),
                       )}
                       <Th aria-label='loading-spinner'>
-                        <Spinner size='md' className={actionTakingPlace ? '' : classes.invisible} />
+                        {actionTakingPlace && <Spinner size='md' />}
                       </Th>
                     </Tr>
                   </Thead>


### PR DESCRIPTION
## Summary
Changing spinner's behavior:

- Spinner's behavior placed in the top right corner of repositories table was triggered on 4 occasions (isFetching, repositoryParamsLoading, isIntrospecting, isDeletingItems). 
- Plus even when there was no action, spinner animation kept running. 
- Except for isFetching, the other actions have different UX feedback tied to them and triggering the spinner was redundant for them.

This is now changed that spinner appears only when:
-  there is content list query data fetching going on, 
-  or content list query is polling data. 

It appears mainly on a slow connection when a user navigates between filters of the table.


For the future it would be great to redefine the placement of the spinner and the whole UX associated with it. 

## Testing steps
Throttle your connection and navigate between filters of the table (custom, redhat repos).