### PR TITLE
HMS-8904: Stable_sam_stage user config and Pulp fixture repo introspection

### DIFF
--- a/.github/workflows/nightly-stage-test-action.yml
+++ b/.github/workflows/nightly-stage-test-action.yml
@@ -74,6 +74,8 @@ jobs:
           echo "LAYERED_REPO_ACCESS_ORG_ID=$LAYERED_REPO_ACCESS_ORG_ID" >> .env
           echo "LAYERED_REPO_ACCESS_ACTIVATION_KEY=$LAYERED_REPO_ACCESS_ACTIVATION_KEY" >> .env
           echo "DOCKER_SOCKET=/var/run/docker.sock" >> .env
+          echo "STABLE_SAM_STAGE_USERNAME=$STABLE_SAM_STAGE_USERNAME" >> .env
+          echo "STABLE_SAM_STAGE_PASSWORD=$STABLE_SAM_STAGE_PASSWORD" >> .env
 
       - name: Set up Node.js
         uses: actions/setup-node@v2

--- a/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
+++ b/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
@@ -4,16 +4,10 @@ import { test, expect, RepositoriesApi, FeaturesApi } from 'test-utils';
  * Pulp Fixture Repository Introspection Test using stable_sam_stage user
  * This test validates that existing Pulp project fixture repositories can be successfully
  * introspected via the API. The stable_sam_stage user already has access to these repositories.
+ * Need to pass headers to the API calls to authenticate the request.
  */
 
 test.describe('Pulp Fixture Repository Introspection', () => {
-  test.use({
-    storageState: '.auth/stable_sam_stage.json',
-    extraHTTPHeaders: process.env.STABLE_SAM_STAGE_TOKEN
-      ? { Authorization: process.env.STABLE_SAM_STAGE_TOKEN }
-      : {},
-  });
-
   test('should validate pulp fixture repository introspection for stable_sam_stage user', async ({
     client,
   }) => {
@@ -26,7 +20,11 @@ test.describe('Pulp Fixture Repository Introspection', () => {
     const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().split('T')[0];
 
     await test.step('Check if stable_sam_stage user has snapshot support', async () => {
-      const features = await featuresApi.listFeatures();
+      const features = await featuresApi.listFeatures({
+        headers: {
+          Authorization: process.env.STABLE_SAM_STAGE_TOKEN || '',
+        },
+      });
 
       console.log('Available features:', Object.keys(features));
 
@@ -43,44 +41,27 @@ test.describe('Pulp Fixture Repository Introspection', () => {
     });
 
     // Get pulp repositories once and reuse across steps
-    const pulpReposResponse = await repositoriesApi.listRepositories({
-      search: 'fixtures.pulpproject.org',
-    });
+    const pulpReposResponse = await repositoriesApi.listRepositories(
+      { search: 'fixtures.pulpproject.org' },
+      {
+        headers: {
+          Authorization: process.env.STABLE_SAM_STAGE_TOKEN || '',
+        },
+      },
+    );
     console.log('pulpReposResponse', pulpReposResponse.data?.length);
     const existingPulpRepos = pulpReposResponse.data || [];
 
     await test.step('Validate existing pulp repositories count', async () => {
       expect(pulpReposResponse.data).toBeDefined();
       console.log('existingPulpRepos.length', existingPulpRepos.length);
-      //   expect(existingPulpRepos.length).toBe(36);
+      expect(existingPulpRepos.length).toBe(36);
       console.log(`Found ${existingPulpRepos.length} existing pulp fixture repositories`);
-    });
-
-    await test.step('Ensure pulp fixture repositories are created', async () => {
-      for (const repo of existingPulpRepos) {
-        if (repo.url && repo.name) {
-          console.log(`Processing existing repository: ${repo.name} with URL: ${repo.url}`);
-
-          // Create repository with snapshot enabled if it doesn't already exist in our organization
-          try {
-            await repositoriesApi.createRepository({
-              apiRepositoryRequest: {
-                snapshot: true,
-                name: repo.name,
-                url: repo.url,
-              },
-            });
-            console.log(`Successfully created repository: ${repo.name}`);
-          } catch (error) {
-            console.log(`Repository ${repo.name} may already exist in organization: ${error}`);
-          }
-        }
-      }
     });
 
     await test.step('Check that repositories are introspected and have valid status', async () => {
       // Reuse the existing pulp repositories data
-      //   expect(existingPulpRepos.length).toBe(36);
+      expect(existingPulpRepos.length).toBe(36);
       console.log(`Validating introspection status for ${existingPulpRepos.length} repositories`);
 
       let allReposValid = true;
@@ -91,7 +72,14 @@ test.describe('Pulp Fixture Repository Introspection', () => {
           console.log(`Checking repository: ${repo.name}`);
 
           // Get detailed repository information
-          const repoDetails = await repositoriesApi.getRepository({ uuid: repo.uuid });
+          const repoDetails = await repositoriesApi.getRepository(
+            { uuid: repo.uuid },
+            {
+              headers: {
+                Authorization: process.env.STABLE_SAM_STAGE_TOKEN || '',
+              },
+            },
+          );
           const lastSuccessIntrospectionTime = repoDetails.lastSuccessIntrospectionTime;
 
           try {

--- a/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
+++ b/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, RepositoriesApi, FeaturesApi } from 'test-utils';
+
+/**
+ * Pulp Fixture Repository Introspection Test using stable_sam_stage user
+ * This test validates that existing Pulp project fixture repositories can be successfully
+ * introspected via the API. The stable_sam_stage user already has access to these repositories.
+ */
+
+test.describe('Pulp Fixture Repository Introspection', () => {
+  test.use({
+    storageState: '.auth/stable-sam-stage-user.json',
+    extraHTTPHeaders: process.env.STABLE_SAM_STAGE_TOKEN
+      ? { Authorization: process.env.STABLE_SAM_STAGE_TOKEN }
+      : {},
+  });
+
+  test('should check snapshot support for stable_sam_stage user', async ({ client }) => {
+    await test.step('Check if stable_sam_stage user has snapshot support', async () => {
+      const featuresApi = new FeaturesApi(client);
+      const features = await featuresApi.listFeatures();
+
+      console.log('Available features:', Object.keys(features));
+
+      // Check if snapshots feature exists
+      expect(features.snapshots).toBeDefined();
+
+      // Check if snapshots are accessible - if not, skip the test
+      if (!features.snapshots?.accessible) {
+        test.skip(true, 'This account does not support snapshots.');
+      }
+
+      // Assert that snapshots are enabled
+      expect(features.snapshots?.enabled).toBe(true);
+
+      console.log(
+        `Snapshots feature - accessible: ${features.snapshots?.accessible}, enabled: ${features.snapshots?.enabled}`,
+      );
+    });
+  });
+
+  test('should validate existing repositories with stable_sam_stage user', async ({ client }) => {
+    await test.step('Get existing repositories for stable_sam_stage user', async () => {
+      const repositoriesApi = new RepositoriesApi(client);
+      const response = await repositoriesApi.listRepositories({
+        search: 'pulpproject.org',
+      });
+
+      expect(response.data).toBeDefined();
+
+      const repositories = response.data || [];
+      console.log(`Found ${repositories.length} Pulp repositories`);
+      expect(repositories.length).toBe(36);
+    });
+  });
+
+  test('should verify introspection is completed and status is valid with stable_sam_stage user', async ({
+    client,
+  }) => {
+    await test.step('Check that repositories are introspected and have valid status', async () => {
+      const repositoriesApi = new RepositoriesApi(client);
+      const response = await repositoriesApi.listRepositories({});
+
+      expect(response.data).toBeDefined();
+      const repositories = response.data || [];
+      expect(repositories.length).toBeGreaterThan(0);
+
+      // Prefer Pulp fixture repositories if available
+      const testRepo =
+        repositories.find((repo) => repo.url?.includes('fixtures.pulpproject.org')) ||
+        repositories[0];
+
+      console.log(`Checking introspection status for: ${testRepo.name} with stable_sam_stage user`);
+
+      if (testRepo.uuid) {
+        // Get detailed repository information to check status
+        const repoDetails = await repositoriesApi.getRepository({ uuid: testRepo.uuid });
+
+        // Assert that introspection is completed and status is valid
+        expect(repoDetails).toBeDefined();
+        expect(repoDetails.status).toBe('valid');
+
+        console.log(`Repository ${testRepo.name} has valid status: ${repoDetails.status}`);
+      }
+    });
+  });
+});

--- a/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
+++ b/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
@@ -8,27 +8,32 @@ import { test, expect, RepositoriesApi, FeaturesApi } from 'test-utils';
 
 test.describe('Pulp Fixture Repository Introspection', () => {
   test.use({
-    storageState: '.auth/stable-sam-stage-user.json',
+    storageState: '.auth/stable_sam_stage.json',
     extraHTTPHeaders: process.env.STABLE_SAM_STAGE_TOKEN
       ? { Authorization: process.env.STABLE_SAM_STAGE_TOKEN }
       : {},
   });
 
-  test('should check snapshot support for stable_sam_stage user', async ({ client }) => {
+  test('should validate pulp fixture repository introspection for stable_sam_stage user', async ({
+    client,
+  }) => {
+    // Initialize APIs once for the entire test
+    const repositoriesApi = new RepositoriesApi(client);
+    const featuresApi = new FeaturesApi(client);
+
+    // Date constants for introspection validation
+    const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD format
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+
     await test.step('Check if stable_sam_stage user has snapshot support', async () => {
-      const featuresApi = new FeaturesApi(client);
       const features = await featuresApi.listFeatures();
 
       console.log('Available features:', Object.keys(features));
 
       // Check if snapshots feature exists
       expect(features.snapshots).toBeDefined();
-
-      // Check if snapshots are accessible - if not, skip the test
-      if (!features.snapshots?.accessible) {
-        test.skip(true, 'This account does not support snapshots.');
-      }
-
+      // Check if snapshots are accessible
+      expect(features.snapshots?.accessible).toBe(true);
       // Assert that snapshots are enabled
       expect(features.snapshots?.enabled).toBe(true);
 
@@ -36,51 +41,96 @@ test.describe('Pulp Fixture Repository Introspection', () => {
         `Snapshots feature - accessible: ${features.snapshots?.accessible}, enabled: ${features.snapshots?.enabled}`,
       );
     });
-  });
 
-  test('should validate existing repositories with stable_sam_stage user', async ({ client }) => {
-    await test.step('Get existing repositories for stable_sam_stage user', async () => {
-      const repositoriesApi = new RepositoriesApi(client);
-      const response = await repositoriesApi.listRepositories({
-        search: 'pulpproject.org',
-      });
-
-      expect(response.data).toBeDefined();
-
-      const repositories = response.data || [];
-      console.log(`Found ${repositories.length} Pulp repositories`);
-      expect(repositories.length).toBe(36);
+    // Get pulp repositories once and reuse across steps
+    const pulpReposResponse = await repositoriesApi.listRepositories({
+      search: 'fixtures.pulpproject.org',
     });
-  });
+    console.log('pulpReposResponse', pulpReposResponse.data?.length);
+    const existingPulpRepos = pulpReposResponse.data || [];
 
-  test('should verify introspection is completed and status is valid with stable_sam_stage user', async ({
-    client,
-  }) => {
-    await test.step('Check that repositories are introspected and have valid status', async () => {
-      const repositoriesApi = new RepositoriesApi(client);
-      const response = await repositoriesApi.listRepositories({});
+    await test.step('Validate existing pulp repositories count', async () => {
+      expect(pulpReposResponse.data).toBeDefined();
+      console.log('existingPulpRepos.length', existingPulpRepos.length);
+      //   expect(existingPulpRepos.length).toBe(36);
+      console.log(`Found ${existingPulpRepos.length} existing pulp fixture repositories`);
+    });
 
-      expect(response.data).toBeDefined();
-      const repositories = response.data || [];
-      expect(repositories.length).toBeGreaterThan(0);
+    await test.step('Ensure pulp fixture repositories are created', async () => {
+      for (const repo of existingPulpRepos) {
+        if (repo.url && repo.name) {
+          console.log(`Processing existing repository: ${repo.name} with URL: ${repo.url}`);
 
-      // Prefer Pulp fixture repositories if available
-      const testRepo =
-        repositories.find((repo) => repo.url?.includes('fixtures.pulpproject.org')) ||
-        repositories[0];
-
-      console.log(`Checking introspection status for: ${testRepo.name} with stable_sam_stage user`);
-
-      if (testRepo.uuid) {
-        // Get detailed repository information to check status
-        const repoDetails = await repositoriesApi.getRepository({ uuid: testRepo.uuid });
-
-        // Assert that introspection is completed and status is valid
-        expect(repoDetails).toBeDefined();
-        expect(repoDetails.status).toBe('valid');
-
-        console.log(`Repository ${testRepo.name} has valid status: ${repoDetails.status}`);
+          // Create repository with snapshot enabled if it doesn't already exist in our organization
+          try {
+            await repositoriesApi.createRepository({
+              apiRepositoryRequest: {
+                snapshot: true,
+                name: repo.name,
+                url: repo.url,
+              },
+            });
+            console.log(`Successfully created repository: ${repo.name}`);
+          } catch (error) {
+            console.log(`Repository ${repo.name} may already exist in organization: ${error}`);
+          }
+        }
       }
+    });
+
+    await test.step('Check that repositories are introspected and have valid status', async () => {
+      // Reuse the existing pulp repositories data
+      //   expect(existingPulpRepos.length).toBe(36);
+      console.log(`Validating introspection status for ${existingPulpRepos.length} repositories`);
+
+      let allReposValid = true;
+
+      // Look for valid introspection status of pulp repos
+      for (const repo of existingPulpRepos) {
+        if (repo.uuid) {
+          console.log(`Checking repository: ${repo.name}`);
+
+          // Get detailed repository information
+          const repoDetails = await repositoriesApi.getRepository({ uuid: repo.uuid });
+          const lastSuccessIntrospectionTime = repoDetails.lastSuccessIntrospectionTime;
+
+          try {
+            // Check that repo has the snapshot flag
+            expect(repo.snapshot).toBe(true);
+            console.log(`✓ ${repo.name} has snapshot enabled`);
+          } catch {
+            console.error(`✗ ${repo.name} has no snapshot`);
+            allReposValid = false;
+          }
+
+          try {
+            // Check the status of the repo
+            expect(['Pending', 'Valid']).toContain(repo.status);
+            console.log(`✓ ${repo.name} status is ${repo.status}`);
+          } catch {
+            console.error(`✗ ${repo.name} is invalid with status: ${repo.status}`);
+            allReposValid = false;
+          }
+
+          try {
+            // Assert last introspection was today or yesterday
+            if (lastSuccessIntrospectionTime) {
+              const introspectionDate = lastSuccessIntrospectionTime.split('T')[0];
+              expect([today, yesterday]).toContain(introspectionDate);
+              console.log(`✓ ${repo.name} was introspected recently: ${introspectionDate}`);
+            } else {
+              throw new Error('No introspection time found');
+            }
+          } catch {
+            console.error(`✗ ${repo.name} was not introspected in the last 24 hours`);
+            allReposValid = false;
+          }
+        }
+      }
+
+      // After all repos are checked in the loop, then assert they all passed the checks
+      expect(allReposValid).toBe(true);
+      console.log('All repositories passed introspection validation');
     });
   });
 });

--- a/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
+++ b/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
@@ -51,50 +51,36 @@ test.describe('Pulp Fixture Repository Introspection', () => {
     });
 
     await test.step('Check that repositories are introspected and have valid status', async () => {
-      // Reuse the existing pulp repositories data
-      expect(existingPulpRepos.length).toBe(36);
-
       let allReposValid = true;
 
       // Look for valid introspection status of pulp repos
       for (const repo of existingPulpRepos) {
-        if (repo.uuid) {
-          // Get detailed repository information
-          const repoDetails = await repositoriesApi.getRepository(
-            { uuid: repo.uuid },
-            {
-              headers: {
-                Authorization: process.env.STABLE_SAM_STAGE_TOKEN || '',
-              },
-            },
-          );
-          const lastSuccessIntrospectionTime = repoDetails.lastSuccessIntrospectionTime;
+        const lastSuccessIntrospectionTime = repo.lastSuccessIntrospectionTime;
 
-          try {
-            // Check that repo has the snapshot flag
-            expect(repo.snapshot).toBe(true);
-          } catch {
-            allReposValid = false;
-          }
+        try {
+          // Check that repo has the snapshot flag
+          expect(repo.snapshot).toBe(true);
+        } catch {
+          allReposValid = false;
+        }
 
-          try {
-            // Check the status of the repo
-            expect(['Pending', 'Valid']).toContain(repo.status);
-          } catch {
-            allReposValid = false;
-          }
+        try {
+          // Check the status of the repo
+          expect(['Pending', 'Valid']).toContain(repo.status);
+        } catch {
+          allReposValid = false;
+        }
 
-          try {
-            // Assert last introspection was today or yesterday
-            if (lastSuccessIntrospectionTime) {
-              const introspectionDate = lastSuccessIntrospectionTime.split('T')[0];
-              expect([today, yesterday]).toContain(introspectionDate);
-            } else {
-              throw new Error('No introspection time found');
-            }
-          } catch {
-            allReposValid = false;
+        try {
+          // Assert last introspection was today or yesterday
+          if (lastSuccessIntrospectionTime) {
+            const introspectionDate = lastSuccessIntrospectionTime.split('T')[0];
+            expect([today, yesterday]).toContain(introspectionDate);
+          } else {
+            throw new Error('No introspection time found');
           }
+        } catch {
+          allReposValid = false;
         }
       }
 

--- a/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
+++ b/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
@@ -26,18 +26,12 @@ test.describe('Pulp Fixture Repository Introspection', () => {
         },
       });
 
-      console.log('Available features:', Object.keys(features));
-
       // Check if snapshots feature exists
       expect(features.snapshots).toBeDefined();
       // Check if snapshots are accessible
       expect(features.snapshots?.accessible).toBe(true);
       // Assert that snapshots are enabled
       expect(features.snapshots?.enabled).toBe(true);
-
-      console.log(
-        `Snapshots feature - accessible: ${features.snapshots?.accessible}, enabled: ${features.snapshots?.enabled}`,
-      );
     });
 
     // Get pulp repositories once and reuse across steps
@@ -49,28 +43,22 @@ test.describe('Pulp Fixture Repository Introspection', () => {
         },
       },
     );
-    console.log('pulpReposResponse', pulpReposResponse.data?.length);
     const existingPulpRepos = pulpReposResponse.data || [];
 
     await test.step('Validate existing pulp repositories count', async () => {
       expect(pulpReposResponse.data).toBeDefined();
-      console.log('existingPulpRepos.length', existingPulpRepos.length);
       expect(existingPulpRepos.length).toBe(36);
-      console.log(`Found ${existingPulpRepos.length} existing pulp fixture repositories`);
     });
 
     await test.step('Check that repositories are introspected and have valid status', async () => {
       // Reuse the existing pulp repositories data
       expect(existingPulpRepos.length).toBe(36);
-      console.log(`Validating introspection status for ${existingPulpRepos.length} repositories`);
 
       let allReposValid = true;
 
       // Look for valid introspection status of pulp repos
       for (const repo of existingPulpRepos) {
         if (repo.uuid) {
-          console.log(`Checking repository: ${repo.name}`);
-
           // Get detailed repository information
           const repoDetails = await repositoriesApi.getRepository(
             { uuid: repo.uuid },
@@ -85,18 +73,14 @@ test.describe('Pulp Fixture Repository Introspection', () => {
           try {
             // Check that repo has the snapshot flag
             expect(repo.snapshot).toBe(true);
-            console.log(`✓ ${repo.name} has snapshot enabled`);
           } catch {
-            console.error(`✗ ${repo.name} has no snapshot`);
             allReposValid = false;
           }
 
           try {
             // Check the status of the repo
             expect(['Pending', 'Valid']).toContain(repo.status);
-            console.log(`✓ ${repo.name} status is ${repo.status}`);
           } catch {
-            console.error(`✗ ${repo.name} is invalid with status: ${repo.status}`);
             allReposValid = false;
           }
 
@@ -105,12 +89,10 @@ test.describe('Pulp Fixture Repository Introspection', () => {
             if (lastSuccessIntrospectionTime) {
               const introspectionDate = lastSuccessIntrospectionTime.split('T')[0];
               expect([today, yesterday]).toContain(introspectionDate);
-              console.log(`✓ ${repo.name} was introspected recently: ${introspectionDate}`);
             } else {
               throw new Error('No introspection time found');
             }
           } catch {
-            console.error(`✗ ${repo.name} was not introspected in the last 24 hours`);
             allReposValid = false;
           }
         }
@@ -118,7 +100,6 @@ test.describe('Pulp Fixture Repository Introspection', () => {
 
       // After all repos are checked in the loop, then assert they all passed the checks
       expect(allReposValid).toBe(true);
-      console.log('All repositories passed introspection validation');
     });
   });
 });

--- a/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
+++ b/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
@@ -51,41 +51,24 @@ test.describe('Pulp Fixture Repository Introspection', () => {
     });
 
     await test.step('Check that repositories are introspected and have valid status', async () => {
-      let allReposValid = true;
-
       // Look for valid introspection status of pulp repos
       for (const repo of existingPulpRepos) {
         const lastSuccessIntrospectionTime = repo.lastSuccessIntrospectionTime;
 
-        try {
-          // Check that repo has the snapshot flag
-          expect(repo.snapshot).toBe(true);
-        } catch {
-          allReposValid = false;
-        }
+        // Check that repo has the snapshot flag
+        expect(repo.snapshot).toBe(true);
 
-        try {
-          // Check the status of the repo
-          expect(['Pending', 'Valid']).toContain(repo.status);
-        } catch {
-          allReposValid = false;
-        }
+        // Check the status of the repo
+        expect(['Pending', 'Valid']).toContain(repo.status);
 
-        try {
-          // Assert last introspection was today or yesterday
-          if (lastSuccessIntrospectionTime) {
-            const introspectionDate = lastSuccessIntrospectionTime.split('T')[0];
-            expect([today, yesterday]).toContain(introspectionDate);
-          } else {
-            throw new Error('No introspection time found');
-          }
-        } catch {
-          allReposValid = false;
+        // Assert last introspection was today or yesterday
+        if (lastSuccessIntrospectionTime) {
+          const introspectionDate = lastSuccessIntrospectionTime.split('T')[0];
+          expect([today, yesterday]).toContain(introspectionDate);
+        } else {
+          throw new Error('No introspection time found');
         }
       }
-
-      // After all repos are checked in the loop, then assert they all passed the checks
-      expect(allReposValid).toBe(true);
     });
   });
 });

--- a/_playwright-tests/helpers/loginHelpers.ts
+++ b/_playwright-tests/helpers/loginHelpers.ts
@@ -102,6 +102,13 @@ export const logInWithNoSubsUser = async (page: Page) =>
     process.env.NO_SUBS_USER_PASSWORD,
   );
 
+export const logInWithStableSamStageUser = async (page: Page) =>
+  await logInWithUsernameAndPassword(
+    page,
+    process.env.STABLE_SAM_STAGE_USERNAME,
+    process.env.STABLE_SAM_STAGE_PASSWORD,
+  );
+
 export const getUserAuthToken = (name: string) => {
   const userPath = path.join(__dirname, `../../.auth/${name}.json`);
   const fileContent = readFileSync(userPath, { encoding: 'utf8' });
@@ -142,6 +149,9 @@ export const throwIfMissingEnvVariables = () => {
           'RHEL_ONLY_ACCESS_PASSWORD',
           'LAYERED_REPO_ACCESS_ORG_ID',
           'LAYERED_REPO_ACCESS_ACTIVATION_KEY',
+          ...(process.env.STABLE_SAM_STAGE_USERNAME && process.env.STABLE_SAM_STAGE_PASSWORD
+            ? ['STABLE_SAM_STAGE_USERNAME', 'STABLE_SAM_STAGE_PASSWORD']
+            : []),
         ]
       : []),
   ];

--- a/playwright_example.env
+++ b/playwright_example.env
@@ -35,6 +35,11 @@ LAYERED_REPO_ACCESS_ACTIVATION_KEY="<activation_key>" # activation key for layer
 NO_SUBS_USER_USERNAME=""
 NO_SUBS_USER_PASSWORD=""
 
+# stable_sam_stage user (AWS-defined user for specialized API testing)
+
+STABLE_SAM_STAGE_USERNAME="" # Required for integration tests with stable_sam_stage user
+STABLE_SAM_STAGE_PASSWORD="" # Required for integration tests with stable_sam_stage user
+
 # ----------- DESTINATION -----------
 BASE_URL="https://stage.foo.redhat.com:1337" # Required
 PROXY=""                                     # Set this if running directly against stage (not using "yarn local")


### PR DESCRIPTION
## Summary

- Configure stable_sam_stage user authentication
  - Add credentials to GitHub Actions workflow (.github/workflows/nightly-stage-test-action.yml)
  - Update playwright environment template (playwright_example.env)
  - Add authentication setup in auth.setup.ts

- Implement Pulp Fixture Repository Introspection test
  - New integration test
  - Validates existing Pulp project fixture repositories via API
  - Uses stable_sam_stage user which has pre-existing pulp fixture repos
  - Verifies repository introspection status
  
## Testing steps

peer review