### PR TITLE
HMS-8994: fix incorrect Calendar display in AddTemplate wizard

### DIFF
--- a/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddTemplate/steps/SetUpDateStep.tsx
@@ -1,16 +1,17 @@
 import {
   Alert,
+  Content,
+  ContentVariants,
   DatePicker,
   ExpandableSection,
+  Flex,
+  FlexItem,
   Form,
   FormAlert,
   FormGroup,
   Grid,
   Radio,
-  Content,
-  ContentVariants,
   Title,
-  Flex,
 } from '@patternfly/react-core';
 import { useAddTemplateContext } from '../AddTemplateContext';
 import { useContentListQuery, useGetSnapshotsByDates } from 'services/Content/ContentQueries';
@@ -19,6 +20,7 @@ import Hide from 'components/Hide/Hide';
 import { ContentOrigin } from 'services/Content/ContentApi';
 import { formatDateForPicker, formatTemplateDate, isDateValid } from 'helpers';
 import { createUseStyles } from 'react-jss';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 const useStyles = createUseStyles({
   snapshotInfoText: {
@@ -102,20 +104,22 @@ export default function SetUpDateStep() {
       <Form>
         <FormGroup>
           <Flex direction={{ default: 'column' }} gap={{ default: 'gapLg' }}>
-            <Radio
-              id='use latest snapshot radio'
-              ouiaId='use-latest-snapshot-radio'
-              name='use-latest-snapshot'
-              label='Use the latest content'
-              description='Always use the latest content from repositories. Snapshots might be updated daily.'
-              isChecked={templateRequest.use_latest}
-              onChange={() => {
-                if (!templateRequest.use_latest) {
-                  setTemplateRequest((prev) => ({ ...prev, use_latest: true, date: '' }));
-                }
-              }}
-            />
-            <Flex direction={{ default: 'column' }} gap={{ default: 'gapSm' }}>
+            <FlexItem>
+              <Radio
+                id='use latest snapshot radio'
+                ouiaId='use-latest-snapshot-radio'
+                name='use-latest-snapshot'
+                label='Use the latest content'
+                description='Always use the latest content from repositories. Snapshots might be updated daily.'
+                isChecked={templateRequest.use_latest}
+                onChange={() => {
+                  if (!templateRequest.use_latest) {
+                    setTemplateRequest((prev) => ({ ...prev, use_latest: true, date: '' }));
+                  }
+                }}
+              />
+            </FlexItem>
+            <FlexItem>
               <Radio
                 id='use snapshot date radio'
                 ouiaId='use-snapshot-date-radio'
@@ -128,6 +132,7 @@ export default function SetUpDateStep() {
                     setTemplateRequest((prev) => ({ ...prev, use_latest: false, date: '' }));
                   }
                 }}
+                className={spacing.mbSm}
               />
               <Hide hide={templateRequest.use_latest ?? false}>
                 <DatePicker
@@ -147,7 +152,7 @@ export default function SetUpDateStep() {
                   }}
                 />
               </Hide>
-            </Flex>
+            </FlexItem>
           </Flex>
         </FormGroup>
       </Form>


### PR DESCRIPTION
## Summary
This PR fixes a layout bug in the `AddTemplate` wizard. The Calendar popover was incorrectly pushing other components to the left side, causing the wizard body to overflow.

To fix this, the `DatePicker` component has been wrapped in `Flex` and `FlexItem`. This change ensures the `DatePicker` is treated as a single layout unit, allowing its popover to display correctly without disrupting the surrounding elements.

## Screenshots
<img width="1282" height="824" alt="Screenshot From 2025-08-25 12-25-02" src="https://github.com/user-attachments/assets/f5981f73-df10-4d5e-927f-8deec1ad9214" />

## Testing steps
- Verify that the app builds without any errors.
- Ensure that all automated tests pass.
- Navigate to Step 2 - Set up date in the Create content template wizard, then click the calendar icon to open the date picker popover. Verify that the calendar popover appears correctly next to the icon, without causing other components to shift or overflow the wizard body. An attached screenshot provides visual clarity for the expected result.