### PR TITLE
HMS-8608: display delete template modal over template detail page

### DIFF
--- a/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.tsx
@@ -8,7 +8,7 @@ import {
   TooltipPosition,
 } from '@patternfly/react-core';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { DELETE_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
+import { DELETE_ROUTE, DETAILS_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
 import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip';
 import { useAppContext } from 'middleware/AppContext';
 import { createUseStyles } from 'react-jss';
@@ -41,7 +41,8 @@ export default function TemplateActionDropdown() {
         setIsOpen(false);
         break;
       case 'delete':
-        navigate(`${baseRoute}/${uuid}/${DELETE_ROUTE}`);
+        navigate(`${baseRoute}/${uuid}/${DETAILS_ROUTE}/${DELETE_ROUTE}`);
+        setIsOpen(false);
         break;
 
       default:

--- a/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.test.tsx
@@ -4,6 +4,7 @@ import { ReactQueryTestWrapper, defaultSystemsListItem, defaultTemplateItem } fr
 import DeleteTemplateModal from './DeleteTemplateModal';
 import { useListSystemsByTemplateId } from 'services/Systems/SystemsQueries';
 import { useFetchTemplate } from 'services/Templates/TemplateQueries';
+import { DETAILS_ROUTE } from 'Routes/constants';
 
 jest.mock('react-query', () => ({
   ...jest.requireActual('react-query'),
@@ -15,6 +16,9 @@ jest.mock('react-router-dom', () => ({
     templateUUID: `${defaultTemplateItem.uuid}`,
   }),
   useNavigate: () => jest.fn,
+  useLocation: () => ({
+    pathname: `/mocked/${DETAILS_ROUTE}`,
+  }),
 }));
 
 jest.mock('Hooks/useRootPath', () => () => 'someUrl');

--- a/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.tsx
@@ -24,6 +24,7 @@ import {
 import { DETAILS_ROUTE, SYSTEMS_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
 import { useListSystemsByTemplateId } from 'services/Systems/SystemsQueries';
 import { ActionButtons } from 'components/ActionButtons/ActionButtons';
+import { checkValidUUID } from 'helpers';
 
 const useStyles = createUseStyles({
   description: {
@@ -48,6 +49,9 @@ export default function DeleteTemplateModal() {
   const isOverTemplateDetail = useLocation().pathname.includes('details');
 
   const { templateUUID: uuid } = useParams();
+  const isValidUUID = checkValidUUID(uuid!);
+
+  if (!isValidUUID) throw new Error('UUID is invalid');
 
   const { data: templateData, isLoading: isTemplateLoading } = useFetchTemplate(uuid!);
 

--- a/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.tsx
@@ -14,7 +14,7 @@ import {
 import { createUseStyles } from 'react-jss';
 import Hide from 'components/Hide/Hide';
 import { useQueryClient } from 'react-query';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import useRootPath from 'Hooks/useRootPath';
 import {
   GET_TEMPLATES_KEY,
@@ -44,6 +44,9 @@ export default function DeleteTemplateModal() {
   const rootPath = useRootPath();
   const queryClient = useQueryClient();
 
+  // delete template modal can be placed over templates list page or the template details page
+  const isOverTemplateDetail = useLocation().pathname.includes('details');
+
   const { templateUUID: uuid } = useParams();
 
   const { data: templateData, isLoading: isTemplateLoading } = useFetchTemplate(uuid!);
@@ -53,10 +56,14 @@ export default function DeleteTemplateModal() {
 
   const onClose = () => navigate(`${rootPath}/${TEMPLATES_ROUTE}`);
 
+  const onCancel = isOverTemplateDetail
+    ? () => navigate(`${rootPath}/${TEMPLATES_ROUTE}/${uuid}/${DETAILS_ROUTE}`)
+    : onClose;
+
   const onSave = async () => {
     deleteTemplate(uuid as string).then(() => {
-      onClose();
       queryClient.invalidateQueries(GET_TEMPLATES_KEY);
+      onClose();
     });
   };
 
@@ -73,7 +80,7 @@ export default function DeleteTemplateModal() {
       variant={ModalVariant.medium}
       ouiaId='delete_template'
       isOpen
-      onClose={onClose}
+      onClose={onCancel}
       aria-labelledby='delete-template-modal-title'
     >
       <ModalHeader
@@ -113,7 +120,7 @@ export default function DeleteTemplateModal() {
         </Hide>
       </ModalBody>
       <ModalFooter>
-        <ActionButtons isAction={actionTakingPlace} onSave={onSave} onClose={onClose} />
+        <ActionButtons isAction={actionTakingPlace} onSave={onSave} onClose={onCancel} />
       </ModalFooter>
     </Modal>
   );

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -143,9 +143,7 @@ export default function RepositoriesRoutes() {
         </Route>
         {!rbac?.templateRead ? (
           <Route path={TEMPLATES_ROUTE} element={<NoPermissionsPage />} />
-        ) : (
-          ''
-        )}
+        ) : null}
         <Route
           path={`${TEMPLATES_ROUTE}/:templateUUID/${DETAILS_ROUTE}`}
           element={<TemplateDetails />}
@@ -161,10 +159,11 @@ export default function RepositoriesRoutes() {
           <Route path={SYSTEMS_ROUTE} element={<TemplateSystemsTab />}>
             {rbac?.templateWrite && subscriptions?.red_hat_enterprise_linux ? (
               <Route path={ADD_ROUTE} element={<AddSystemModal />} />
-            ) : (
-              ''
-            )}
+            ) : null}
           </Route>
+          {rbac?.templateWrite ? (
+            <Route path={`${DELETE_ROUTE}`} element={<DeleteTemplateModal />} />
+          ) : null}
         </Route>
         <Route path={TEMPLATES_ROUTE} element={<TemplatesTable />}>
           {rbac?.templateWrite && subscriptions?.red_hat_enterprise_linux ? (
@@ -177,17 +176,14 @@ export default function RepositoriesRoutes() {
                 element={<DeleteTemplateModal />}
               />
             </>
-          ) : rbac?.templateWrite ? (
-            <>
-              <Route
-                key='3'
-                path={`:templateUUID/${DELETE_ROUTE}`}
-                element={<DeleteTemplateModal />}
-              />
-            </>
-          ) : (
-            ''
-          )}
+          ) : null}
+          {rbac?.templateWrite ? (
+            <Route
+              key='3'
+              path={`:templateUUID/${DELETE_ROUTE}`}
+              element={<DeleteTemplateModal />}
+            />
+          ) : null}
           <Route path='*' element={<Navigate to='' replace />} />
         </Route>
         <Route path='*' element={<Navigate to={REPOSITORIES_ROUTE} replace />} />

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -67,3 +67,8 @@ export const reduceStringToCharsWithEllipsis = (str: string, maxLength: number =
 // Removes any cases of 3+ line breaks and replaces them with 2
 export const formatDescription = (description: string): string =>
   description.replace(/\n{3,}/g, '\n\n');
+
+// test a string to be a valid UUID
+const UUIDPATTERN =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
+export const checkValidUUID = (uuidToTest: string): boolean => UUIDPATTERN.test(uuidToTest);


### PR DESCRIPTION
## Summary
Previously when on a template details page, clicking the delete action:
- redirected to the templates list page where it was overlayed with the delete template modal. 

This might have confused users, especially when cancelling the action. 

Now the delete modal:
- is showed over the template details
- and only after the delete confirmation a user is navigated to the templates list page.

And as expected, when the delete action is triggered from the templates list page, the delete modal is overlayed over the templates list.

## Testing steps
- navigate to a template detail, trigger delete action there, test out cancel and delete
- you can also test out that the modal is layered over the templates list page when it happens to be triggered from there