### PR TITLE
HMS-8900: Add UserSnapshotPermissionsTest for snapshot API validation

### DIFF
--- a/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
+++ b/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
@@ -11,11 +11,9 @@ test.describe('Pulp Fixture Repository Introspection', () => {
   test('should validate pulp fixture repository introspection for stable_sam_stage user', async ({
     client,
   }) => {
-    // Initialize APIs once for the entire test
     const repositoriesApi = new RepositoriesApi(client);
     const featuresApi = new FeaturesApi(client);
 
-    // Date constants for introspection validation
     const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD format
     const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().split('T')[0];
 
@@ -26,15 +24,11 @@ test.describe('Pulp Fixture Repository Introspection', () => {
         },
       });
 
-      // Check if snapshots feature exists
       expect(features.snapshots).toBeDefined();
-      // Check if snapshots are accessible
       expect(features.snapshots?.accessible).toBe(true);
-      // Assert that snapshots are enabled
       expect(features.snapshots?.enabled).toBe(true);
     });
 
-    // Get pulp repositories once and reuse across steps
     const pulpReposResponse = await repositoriesApi.listRepositories(
       { search: 'fixtures.pulpproject.org' },
       {
@@ -55,10 +49,8 @@ test.describe('Pulp Fixture Repository Introspection', () => {
       for (const repo of existingPulpRepos) {
         const lastSuccessIntrospectionTime = repo.lastSuccessIntrospectionTime;
 
-        // Check that repo has the snapshot flag
         expect(repo.snapshot).toBe(true);
 
-        // Check the status of the repo
         expect(['Pending', 'Valid']).toContain(repo.status);
 
         // Assert last introspection was today or yesterday

--- a/_playwright-tests/Integration/UserSnapshotPermissionsTest.spec.ts
+++ b/_playwright-tests/Integration/UserSnapshotPermissionsTest.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect, RepositoriesApi, SnapshotsApi, ApiRepositoryResponse } from 'test-utils';
+
+/**
+ * User Snapshot Permissions Test using stable_sam_stage user
+ * Tests that a user with the snapshotting feature can list snapshots API.
+ * The stable_sam_stage user already has access to repositories with snapshots.
+ * Need to pass headers to the API calls to authenticate the request.
+ */
+
+test.describe('User Snapshot Permissions Test', () => {
+  test('Test user has permissions to use snapshot APIs', async ({ client }) => {
+    const repositoriesApi = new RepositoriesApi(client);
+    const snapshotsApi = new SnapshotsApi(client);
+
+    let testRhelRepo: ApiRepositoryResponse | null = null;
+    let testCustomRepo: ApiRepositoryResponse | null = null;
+
+    await test.step('Find one RHEL repo with snapshots for testing', async () => {
+      const redHatRepoList = await repositoriesApi.listRepositories(
+        {
+          origin: 'red_hat',
+          limit: 10,
+        },
+        {
+          headers: {
+            Authorization: process.env.STABLE_SAM_STAGE_TOKEN || '',
+          },
+        },
+      );
+
+      testRhelRepo = redHatRepoList.data?.find((repo) => repo.snapshot === true) || null;
+    });
+
+    await test.step('Find one custom repo with snapshots for testing', async () => {
+      const customRepoList = await repositoriesApi.listRepositories(
+        {
+          origin: 'external',
+          limit: 10,
+        },
+        {
+          headers: {
+            Authorization: process.env.STABLE_SAM_STAGE_TOKEN || '',
+          },
+        },
+      );
+
+      testCustomRepo = customRepoList.data?.find((repo) => repo.snapshot === true) || null;
+    });
+
+    await test.step('Test user can list snapshots for RHEL repo', async () => {
+      if (!testRhelRepo?.uuid) {
+        throw new Error('No RHEL repository with snapshots found for testing');
+      }
+
+      const snapshots = await snapshotsApi.listSnapshotsForRepo(
+        {
+          uuid: testRhelRepo.uuid,
+        },
+        {
+          headers: {
+            Authorization: process.env.STABLE_SAM_STAGE_TOKEN || '',
+          },
+        },
+      );
+
+      expect(snapshots).toBeDefined();
+      expect(snapshots.data).toBeDefined();
+    });
+
+    await test.step('Test user can list snapshots for custom repo', async () => {
+      if (!testCustomRepo?.uuid) {
+        throw new Error('No custom repository with snapshots found for testing');
+      }
+
+      const snapshots = await snapshotsApi.listSnapshotsForRepo(
+        {
+          uuid: testCustomRepo.uuid,
+        },
+        {
+          headers: {
+            Authorization: process.env.STABLE_SAM_STAGE_TOKEN || '',
+          },
+        },
+      );
+
+      expect(snapshots).toBeDefined();
+      expect(snapshots.data).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add integration test to verify user permissions for snapshot APIs across RHEL and custom repositories. Tests feature access validation and ensures users can successfully list snapshots for repositories with snapshotting enabled.

- Test snapshot listing for RHEL repositories
- Test snapshot listing for custom repositories
- Validate API responses and data structure