### PR TITLE
Test: Add try block to subs-man refresh

### DIFF
--- a/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
+++ b/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
@@ -4,7 +4,7 @@ import {
   cleanupTemplates,
   randomName,
 } from '../test-utils/_playwright-tests/test-utils/src';
-import { RHSMClient } from './helpers/rhsmClient';
+import { RHSMClient, refreshSubscriptionManager } from './helpers/rhsmClient';
 import { navigateToTemplates } from '../UI/helpers/navHelpers';
 import { closePopupsIfExist, getRowByNameOrUrl } from '../UI/helpers/helpers';
 
@@ -72,8 +72,7 @@ test.describe('Associated Template CRUD', async () => {
       }
       expect(reg?.exitCode).toBe(0);
 
-      const subManRefresh = await regClient.Exec(['subscription-manager', 'refresh', '--force']);
-      expect(subManRefresh?.exitCode).toBe(0);
+      await refreshSubscriptionManager(regClient);
     });
 
     await test.step('Attempt to delete template and verify warning appears', async () => {

--- a/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
+++ b/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, cleanupTemplates, randomName } from 'test-utils';
-import { RHSMClient } from './helpers/rhsmClient';
+import { RHSMClient, refreshSubscriptionManager } from './helpers/rhsmClient';
 import { navigateToTemplates } from '../UI/helpers/navHelpers';
 import { closePopupsIfExist, getRowByNameOrUrl } from '../UI/helpers/helpers';
 
@@ -75,9 +75,7 @@ test.describe('Test System With Template', async () => {
       }
       expect(reg?.exitCode).toBe(0);
 
-      // refresh subscription-manager
-      const subManRefresh = await regClient.Exec(['subscription-manager', 'refresh', '--force']);
-      expect(subManRefresh?.exitCode).toBe(0);
+      await refreshSubscriptionManager(regClient);
 
       // clean cached metadata
       const dnfCleanAll = await regClient.Exec(['dnf', 'clean', 'all']);
@@ -125,9 +123,7 @@ test.describe('Test System With Template', async () => {
     });
 
     await test.step('Refresh system', async () => {
-      // refresh subscription-manager
-      const subManRefresh = await regClient.Exec(['subscription-manager', 'refresh', '--force']);
-      expect(subManRefresh?.exitCode).toBe(0);
+      await refreshSubscriptionManager(regClient);
 
       // clean cached metadata
       const dnfCleanAll = await regClient.Exec(['dnf', 'clean', 'all']);


### PR DESCRIPTION
## Summary

   subscription-manager refresh sometimes fails with error code 70.
   This could be caused by poor connectivity within the cluster.
   This change will mitigate that and provide logs.

## Testing steps

These two pass:
_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts