### PR TITLE
Test: Introduce simpler nightly Slack reporter

### DIFF
--- a/.github/workflows/nightly-stage-test-action.yml
+++ b/.github/workflows/nightly-stage-test-action.yml
@@ -105,14 +105,50 @@ jobs:
           path: ./playwright-ctrf
           retention-days: 10
 
-      - name: Slack Notification
-        if: ${{ github.event_name != 'pull_request' && !cancelled() }}
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_COLOR: ${{ job.status }}
-          SLACK_ICON: https://jlsherrill.fedorapeople.org/nightly.png
-          SLACK_TITLE: Nightly Stage Test
-          SLACK_USERNAME: Content Sources
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOOK }}
-          SLACK_MESSAGE_ON_SUCCESS: 'Nightly stage tests successful!'
-          SLACK_MESSAGE_ON_FAILURE: 'Nightly stage tests FAILED :('
+      - name: Notify Slack on success
+        uses: slackapi/slack-github-action@v2.1.1
+        if: ${{ success() && github.event_name != 'pull_request' && !cancelled() }}
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#2EB67D",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly test run>: *SUCCESS* :partymeow:"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v2.1.1
+        if: ${{ failure() && github.event_name != 'pull_request' && !cancelled() }}
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#d72839",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly test run>: *FAILED* :big-sad:"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }


### PR DESCRIPTION
Simplify the report that is sent to Slack. This one is oneliner compared to ~10 lines.

Shamelessly stolen from https://github.com/osbuild/image-builder-frontend/blob/main/.github/workflows/boot-tests-nightly.yml#L100 , original author @tkoscieln!

Current output:
<img width="1564" height="243" alt="Screenshot From 2025-09-09 13-54-27" src="https://github.com/user-attachments/assets/076f895c-30da-4e77-9581-f958a8a0a1f1" />

New output: 
<img width="1037" height="79" alt="image" src="https://github.com/user-attachments/assets/5b256a09-db31-4f34-9ed2-3d8ec526adad" />

