### PR TITLE
Test: Change "Custom" to "Other" in Template modal locator

### DIFF
--- a/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
+++ b/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
@@ -40,7 +40,7 @@ test.describe('Associated Template CRUD', async () => {
       await page.getByRole('button', { name: 'Next', exact: true }).click();
 
       await expect(
-        page.getByRole('heading', { name: 'Custom repositories', exact: true }),
+        page.getByRole('heading', { name: 'Other repositories', exact: true }),
       ).toBeVisible();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
 

--- a/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
+++ b/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
@@ -43,7 +43,7 @@ test.describe('Test System With Template', async () => {
       await rowHARepo.getByLabel('Select row').click();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
       await expect(
-        page.getByRole('heading', { name: 'Custom repositories', exact: true }),
+        page.getByRole('heading', { name: 'Other repositories', exact: true }),
       ).toBeVisible();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
       await page.getByText('Use up to a specific date', { exact: true }).click();
@@ -111,7 +111,7 @@ test.describe('Test System With Template', async () => {
       ).toBeVisible();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
       await expect(
-        page.getByRole('heading', { name: 'Custom repositories', exact: true }),
+        page.getByRole('heading', { name: 'Other repositories', exact: true }),
       ).toBeVisible();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
       await page.getByText('Use the latest content', { exact: true }).click();


### PR DESCRIPTION
## Summary

    The menu and title was changed for the Template model (HMS-5829)
    This updates the locator (from "Custom" to "Other" repositories)

## Testing steps

Integration tests pass (i.e. AssociatedTemplateCRUD and CanUpdateSystemWithTemplate)
All UI template tests pass