### PR TITLE
Test: Integration tests after merging the fix for HMS-9325

### DIFF
--- a/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
+++ b/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
@@ -8,6 +8,13 @@ import { test, expect, RepositoriesApi, FeaturesApi } from 'test-utils';
  */
 
 test.describe('Pulp Fixture Repository Introspection', () => {
+  test.use({
+    storageState: '.auth/stable_sam_stage.json',
+    extraHTTPHeaders: process.env.STABLE_SAM_STAGE_TOKEN
+      ? { Authorization: process.env.STABLE_SAM_STAGE_TOKEN }
+      : {},
+  });
+
   test('should validate pulp fixture repository introspection for stable_sam_stage user', async ({
     client,
   }) => {
@@ -18,25 +25,16 @@ test.describe('Pulp Fixture Repository Introspection', () => {
     const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().split('T')[0];
 
     await test.step('Check if stable_sam_stage user has snapshot support', async () => {
-      const features = await featuresApi.listFeatures({
-        headers: {
-          Authorization: process.env.STABLE_SAM_STAGE_TOKEN || '',
-        },
-      });
+      const features = await featuresApi.listFeatures();
 
       expect(features.snapshots).toBeDefined();
       expect(features.snapshots?.accessible).toBe(true);
       expect(features.snapshots?.enabled).toBe(true);
     });
 
-    const pulpReposResponse = await repositoriesApi.listRepositories(
-      { search: 'fixtures.pulpproject.org' },
-      {
-        headers: {
-          Authorization: process.env.STABLE_SAM_STAGE_TOKEN || '',
-        },
-      },
-    );
+    const pulpReposResponse = await repositoriesApi.listRepositories({
+      search: 'fixtures.pulpproject.org',
+    });
     const existingPulpRepos = pulpReposResponse.data || [];
 
     await test.step('Validate existing pulp repositories count', async () => {

--- a/_playwright-tests/Integration/SnapshotListingFilterByOrgId.spec.ts
+++ b/_playwright-tests/Integration/SnapshotListingFilterByOrgId.spec.ts
@@ -8,20 +8,20 @@ import { test, expect, RepositoriesApi, expectError } from 'test-utils';
  */
 
 test.describe('Snapshot Listing Filter by Org ID', () => {
+  test.use({
+    storageState: '.auth/stable_sam_stage.json',
+    extraHTTPHeaders: process.env.STABLE_SAM_STAGE_TOKEN
+      ? { Authorization: process.env.STABLE_SAM_STAGE_TOKEN }
+      : {},
+  });
+
   test('should filter snapshot listing based on cross organization user', async ({ client }) => {
     const repositoriesApi = new RepositoriesApi(client);
     const testRepoUrl = 'https://yum.theforeman.org/pulpcore/3.4/el7/x86_64/';
     let samRepoUuid: string;
 
     await test.step('List repository using stable_sam_stage user', async () => {
-      const reposResponse = await repositoriesApi.listRepositories(
-        { search: testRepoUrl },
-        {
-          headers: {
-            Authorization: process.env.STABLE_SAM_STAGE_TOKEN || '',
-          },
-        },
-      );
+      const reposResponse = await repositoriesApi.listRepositories({ search: testRepoUrl });
 
       expect(reposResponse.data).toBeDefined();
       expect(reposResponse.data?.length).toBe(1);
@@ -33,14 +33,7 @@ test.describe('Snapshot Listing Filter by Org ID', () => {
     });
 
     await test.step('Get repository data with snapshot UUID', async () => {
-      const samDataResponse = await repositoriesApi.getRepository(
-        { uuid: samRepoUuid },
-        {
-          headers: {
-            Authorization: process.env.STABLE_SAM_STAGE_TOKEN || '',
-          },
-        },
-      );
+      const samDataResponse = await repositoriesApi.getRepository({ uuid: samRepoUuid });
       expect(samDataResponse.lastSnapshotUuid).toBeDefined();
 
       await test.step('Verify other org user cannot access repository configuration file', async () => {

--- a/_playwright-tests/Integration/UserSnapshotPermissionsTest.spec.ts
+++ b/_playwright-tests/Integration/UserSnapshotPermissionsTest.spec.ts
@@ -8,6 +8,13 @@ import { test, expect, RepositoriesApi, SnapshotsApi, ApiRepositoryResponse } fr
  */
 
 test.describe('User Snapshot Permissions Test', () => {
+  test.use({
+    storageState: '.auth/stable_sam_stage.json',
+    extraHTTPHeaders: process.env.STABLE_SAM_STAGE_TOKEN
+      ? { Authorization: process.env.STABLE_SAM_STAGE_TOKEN }
+      : {},
+  });
+
   test('Test user has permissions to use snapshot APIs', async ({ client }) => {
     const repositoriesApi = new RepositoriesApi(client);
     const snapshotsApi = new SnapshotsApi(client);
@@ -16,33 +23,19 @@ test.describe('User Snapshot Permissions Test', () => {
     let testCustomRepo: ApiRepositoryResponse | null = null;
 
     await test.step('Find one RHEL repo with snapshots for testing', async () => {
-      const redHatRepoList = await repositoriesApi.listRepositories(
-        {
-          origin: 'red_hat',
-          limit: 10,
-        },
-        {
-          headers: {
-            Authorization: process.env.STABLE_SAM_STAGE_TOKEN || '',
-          },
-        },
-      );
+      const redHatRepoList = await repositoriesApi.listRepositories({
+        origin: 'red_hat',
+        limit: 10,
+      });
 
       testRhelRepo = redHatRepoList.data?.find((repo) => repo.snapshot === true) || null;
     });
 
     await test.step('Find one custom repo with snapshots for testing', async () => {
-      const customRepoList = await repositoriesApi.listRepositories(
-        {
-          origin: 'external',
-          limit: 10,
-        },
-        {
-          headers: {
-            Authorization: process.env.STABLE_SAM_STAGE_TOKEN || '',
-          },
-        },
-      );
+      const customRepoList = await repositoriesApi.listRepositories({
+        origin: 'external',
+        limit: 10,
+      });
 
       testCustomRepo = customRepoList.data?.find((repo) => repo.snapshot === true) || null;
     });
@@ -52,16 +45,9 @@ test.describe('User Snapshot Permissions Test', () => {
         throw new Error('No RHEL repository with snapshots found for testing');
       }
 
-      const snapshots = await snapshotsApi.listSnapshotsForRepo(
-        {
-          uuid: testRhelRepo.uuid,
-        },
-        {
-          headers: {
-            Authorization: process.env.STABLE_SAM_STAGE_TOKEN || '',
-          },
-        },
-      );
+      const snapshots = await snapshotsApi.listSnapshotsForRepo({
+        uuid: testRhelRepo.uuid,
+      });
 
       expect(snapshots).toBeDefined();
       expect(snapshots.data).toBeDefined();
@@ -72,16 +58,9 @@ test.describe('User Snapshot Permissions Test', () => {
         throw new Error('No custom repository with snapshots found for testing');
       }
 
-      const snapshots = await snapshotsApi.listSnapshotsForRepo(
-        {
-          uuid: testCustomRepo.uuid,
-        },
-        {
-          headers: {
-            Authorization: process.env.STABLE_SAM_STAGE_TOKEN || '',
-          },
-        },
-      );
+      const snapshots = await snapshotsApi.listSnapshotsForRepo({
+        uuid: testCustomRepo.uuid,
+      });
 
       expect(snapshots).toBeDefined();
       expect(snapshots.data).toBeDefined();


### PR DESCRIPTION

- Add test.use() configuration to automatically authenticate as stable_sam_stage user
- Remove explicit auth headers token in each API request
