### PR TITLE
Build: add malicious package check

### DIFF
--- a/.github/workflowScripts/malware-to-purl.py
+++ b/.github/workflowScripts/malware-to-purl.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+import json
+import urllib.request
+import urllib.error
+
+MALWARE_API_URL = 'https://malware-list.aikido.dev/malware_predictions.json'
+OUTPUT_FILE = 'dependency-review-config.yml'
+
+
+def to_purl(pkg):
+    """Convert a package entry to purl format.
+
+    Args:
+        pkg (dict): Package object with package_name, version, and reason
+
+    Returns:
+        str: Package URL in purl format
+    """
+    package_name = pkg['package_name']
+    version = pkg['version']
+
+    # Handle version - if it's "*" we'll omit the version part
+    version_part = '' if version == '*' else f'@{version}'
+
+    return f'pkg:npm/{package_name}{version_part}'
+
+
+def fetch_json(url):
+    """Fetch JSON data from URL.
+
+    Args:
+        url (str): URL to fetch
+
+    Returns:
+        list: Parsed JSON response
+
+    Raises:
+        Exception: If HTTP request or JSON parsing fails
+    """
+    try:
+        with urllib.request.urlopen(url) as response:
+            data = response.read().decode('utf-8')
+            return json.loads(data)
+    except urllib.error.URLError as e:
+        raise Exception(f'HTTP request failed: {e}')
+    except json.JSONDecodeError as e:
+        raise Exception(f'Failed to parse JSON: {e}')
+
+
+def generate_yaml(purls):
+    """Generate YAML content for dependency review config.
+
+    Args:
+        purls (list): Array of package URLs in purl format
+
+    Returns:
+        str: YAML formatted content
+    """
+    yaml_content = 'deny-packages:\n'
+    for purl in purls:
+        yaml_content += f'  - {purl}\n'
+    return yaml_content
+
+
+def main():
+    """Main function to fetch malware data and convert to purl format."""
+    try:
+        print('Fetching malware predictions...')
+        packages = fetch_json(MALWARE_API_URL)
+
+        print(f'Found {len(packages)} packages')
+        print('Converting to purl format...')
+
+        purls = [to_purl(pkg) for pkg in packages]
+        yaml_content = generate_yaml(purls)
+
+        print(f'Writing to {OUTPUT_FILE}...')
+        with open(OUTPUT_FILE, 'w') as f:
+            f.write(yaml_content)
+
+        print(f'Successfully created {OUTPUT_FILE} with {len(purls)} packages')
+
+    except Exception as e:
+        print(f'Error: {e}')
+        exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/content-sources-actions.yml
+++ b/.github/workflows/content-sources-actions.yml
@@ -116,6 +116,33 @@ jobs:
       - name: Build the application
         run: yarn build
 
+  malicious-package-check:
+    name: malicious-package-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          submodules: recursive
+
+      - name: Set up sparse checkout
+        uses: ./.github/actions/sparse-checkout-utils
+
+      - name: Generate list of additional malicious packages
+        working-directory: .github/
+        run: |
+          chmod +x workflowScripts/malware-to-purl.py
+          python3 workflowScripts/malware-to-purl.py
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          vulnerability-check: true
+          comment-summary-in-pr: on-failure
+          config-file: .github/dependency-review-config.yml
+
   unit-test:
     name: unit-test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
This adds the "dependency-review-action" to our PR CI workflow, which will check our dependencies for any malicious packages. Also adds a script that fetches the open-source "Aikido" malware list and adds those to the review action as packages which should be denied.
It would be good to have something like this with all the recent NPM supply-chain attacks.