### PR TITLE
Build: add PR write permission to content actions

### DIFF
--- a/.github/workflows/content-sources-actions.yml
+++ b/.github/workflows/content-sources-actions.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
This adds missing PR write permissions to the `content-sources-actions` workflow. Should fix [this](https://github.com/content-services/content-sources-frontend/actions/runs/18284471624/job/52056523073?pr=672).