### PR TITLE
Test: Fix empty RHEL repo table message

### DIFF
--- a/_playwright-tests/Integration/LayeredRepoAccess.spec.ts
+++ b/_playwright-tests/Integration/LayeredRepoAccess.spec.ts
@@ -41,7 +41,7 @@ test.describe('Test layered repos access is restricted', async () => {
       let initialRowCount = await rows.count();
       await expect(initialRowCount).toBeGreaterThan(0);
       await page.getByPlaceholder(/^Filter by name.*$/).fill('openshift');
-      await expect(page.getByText('No repositories match your criteria')).toBeVisible({
+      await expect(page.getByText(/No.*repositories match your criteria/)).toBeVisible({
         timeout: 10000,
       });
       await clearFilters(page);
@@ -51,7 +51,7 @@ test.describe('Test layered repos access is restricted', async () => {
       initialRowCount = await rows.count();
       await expect(initialRowCount).toBeGreaterThan(0);
       await page.getByPlaceholder(/^Filter by name.*$/).fill('high availability');
-      await expect(page.getByText('No repositories match your criteria')).toBeVisible({
+      await expect(page.getByText(/No.*repositories match your criteria/)).toBeVisible({
         timeout: 10000,
       });
       await clearFilters(page);


### PR DESCRIPTION
## Summary

The new empty repo table message is context-aware based on the content origin filter. 
When the test filters to show only "Red Hat" repositories, the empty state message would be:
"No Red Hat repositories match your criteria"

## Testing steps
All tests pass, esp. Integration/LayeredRepoAccess.spec.ts