### PR TITLE
Test: Make text consistent for filter results

### DIFF
--- a/src/components/EmptyTableDataView/EmptyTableDataView.test.tsx
+++ b/src/components/EmptyTableDataView/EmptyTableDataView.test.tsx
@@ -48,7 +48,7 @@ it('should render filtered state correctly', async () => {
     </Table>,
   );
 
-  expect(screen.getByText(`No ${itemName} match your criteria`)).toBeInTheDocument();
+  expect(screen.getByText(`No ${itemName} match the filter criteria`)).toBeInTheDocument();
   expect(screen.getByText('Clear all filters to show more results.')).toBeInTheDocument();
 
   const button = screen.getByRole('button', { name: 'Clear all filters' });

--- a/src/components/EmptyTableDataView/EmptyTableDataView.tsx
+++ b/src/components/EmptyTableDataView/EmptyTableDataView.tsx
@@ -37,7 +37,7 @@ const EmptyTableDataView = ({
         <Td colSpan={colSpan}>
           <EmptyState
             icon={isFiltered ? CubesIcon : RepositoryIcon}
-            titleText={isFiltered ? `No ${itemName} match your criteria` : `No ${itemName}`}
+            titleText={isFiltered ? `No ${itemName} match the filter criteria` : `No ${itemName}`}
             variant={EmptyStateVariant.full}
             headingLevel='h4'
           >


### PR DESCRIPTION
## Summary

When filtering for repositories, the text displayed is inconsistent when no repos are found.


<img width="353" height="243" alt="image" src="https://github.com/user-attachments/assets/8a141346-4f30-44ce-b5df-cd44fe727eed" />

<img width="481" height="243" alt="image" src="https://github.com/user-attachments/assets/6989f22b-08af-40a4-89dc-f55dca915349" />

The older text, "match the filter criteria", is more precise.

## Testing steps
Layered repo Integration test passes
