### PR TITLE
HMS-9505: Add custom repos to template CRUD test with different archs 

### DIFF
--- a/_playwright-tests/UI/TemplateCRUD.spec.ts
+++ b/_playwright-tests/UI/TemplateCRUD.spec.ts
@@ -4,11 +4,14 @@ import { cleanupRepositories, cleanupTemplates, randomName } from 'test-utils/he
 import { navigateToRepositories, navigateToTemplates } from './helpers/navHelpers';
 import { closePopupsIfExist, getRowByNameOrUrl } from './helpers/helpers';
 import { createCustomRepo } from './helpers/createRepositories';
+import { randomUrl } from './helpers/repoHelpers';
 
 const templateNamePrefix = 'template_CRUD';
 const repoNamePrefix = 'custom_repo-template';
 
-const repoName = `${repoNamePrefix}-${randomName()}`;
+const repoName = `${repoNamePrefix}-aarch64-${randomName()}`;
+const repoNameX86 = `${repoNamePrefix}-x86_64-${randomName()}`;
+const repoNameIntrospect = `${repoNamePrefix}-introspect-only-${randomName()}`;
 const templateName = `${templateNamePrefix}-${randomName()}`;
 
 const smallRHRepo = 'Red Hat CodeReady Linux Builder for RHEL 9 ARM 64 (RPMs)';
@@ -19,12 +22,44 @@ test.describe('Templates CRUD', () => {
       await cleanup.runAndAdd(() => cleanupRepositories(client, repoNamePrefix));
       await cleanup.runAndAdd(() => cleanupTemplates(client, templateNamePrefix));
     });
-    await test.step('Create a repository', async () => {
+    await test.step('Create repositories', async () => {
       await navigateToRepositories(page);
       await closePopupsIfExist(page);
+
+      // Create first repo (aarch64, with snapshot)
       await createCustomRepo(page, repoName);
       const row = await getRowByNameOrUrl(page, repoName);
       await expect(row.getByText('Valid')).toBeVisible({ timeout: 60_000 });
+
+      // Create second repo (x86_64, with snapshot)
+      const repoDataX86 = {
+        distribution_arch: 'x86_64',
+        distribution_versions: ['8', '9'],
+        name: repoNameX86,
+        origin: 'external',
+        snapshot: true,
+        url: randomUrl(),
+      };
+      await page.request.post('/api/content-sources/v1/repositories/', {
+        data: repoDataX86,
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const rowX86 = await getRowByNameOrUrl(page, repoNameX86);
+      await expect(rowX86.getByText('Valid')).toBeVisible({ timeout: 60_000 });
+
+      // Create third repo ( Any arch, introspect only )
+      const repoDataIntrospect = {
+        distribution_arch: '',
+        distribution_versions: ['8', '9'],
+        name: repoNameIntrospect,
+        origin: 'external',
+        snapshot: false,
+        url: randomUrl(),
+      };
+      await page.request.post('/api/content-sources/v1/repositories/', {
+        data: repoDataIntrospect,
+        headers: { 'Content-Type': 'application/json' },
+      });
     });
     await test.step('Navigate to templates, ensure the Create template button can be clicked', async () => {
       await navigateToTemplates(page);
@@ -41,9 +76,33 @@ test.describe('Templates CRUD', () => {
       const rowRHELRepo = await getRowByNameOrUrl(modalPage, smallRHRepo);
       await rowRHELRepo.getByLabel('Select row').click();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
+      // Select first custom repo (aarch64)
       await modalPage.getByRole('searchbox', { name: 'Filter by name/url' }).fill(repoName);
       const rowRepo = await getRowByNameOrUrl(modalPage, repoName);
       await rowRepo.getByLabel('Select row').click();
+
+      // Verify introspect-only repo appears but checkbox is disabled
+      await modalPage.getByRole('searchbox', { name: 'Filter by name/url' }).clear();
+      await modalPage
+        .getByRole('searchbox', { name: 'Filter by name/url' })
+        .fill(repoNameIntrospect);
+      const rowIntrospect = await getRowByNameOrUrl(modalPage, repoNameIntrospect);
+      await expect(rowIntrospect).toBeVisible();
+      const introspectCheckbox = rowIntrospect.getByLabel('Select row');
+      await expect(introspectCheckbox).toBeDisabled();
+      // Verify warning message appears on hover
+      await introspectCheckbox.hover();
+      await expect(page.getByText('Snapshot not yet available for this repository')).toBeVisible();
+
+      // Verify x86 repo cannot be added due to architecture mismatch (should not appear)
+      await modalPage.getByRole('searchbox', { name: 'Filter by name/url' }).clear();
+      await modalPage.getByRole('searchbox', { name: 'Filter by name/url' }).fill(repoNameX86);
+      await expect(
+        modalPage.getByText('No custom repositories match the filter criteria', { exact: false }),
+      ).toBeVisible();
+      // Also verify the x86 repo row is not visible in the table
+      await expect(modalPage.getByText(repoNameX86)).not.toBeVisible();
+
       await page.getByRole('button', { name: 'Next', exact: true }).click();
       await page.getByText('Use the latest content', { exact: true }).click();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
@@ -73,6 +132,7 @@ test.describe('Templates CRUD', () => {
       await expect(
         page.getByRole('heading', { name: 'Other repositories', exact: true }),
       ).toBeVisible();
+      // Verify only the aarch64 custom repo is in the template
       await expect(page.getByText(`${repoName}`)).toBeVisible();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
       await expect(page.getByRole('heading', { name: 'Set up date', exact: true })).toBeVisible();


### PR DESCRIPTION
## Summary

Test template with more custom repos
  * Test with wrong arch and any arch repos
  * Verify popover message for no-snapshot repo
 
## Testing steps
tests pass