### PR TITLE
Test: fix flaky template tests

### DIFF
--- a/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
+++ b/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
@@ -46,7 +46,6 @@ test.describe('Test System With Template', () => {
         page.getByRole('heading', { name: 'Additional Red Hat repositories', exact: true }),
       ).toBeVisible();
       const modalPage = page.getByTestId('add_template_modal');
-      await page.getByRole('searchbox', { name: 'Filter by name' }).fill(HARepo);
       const rowHARepo = await getRowByNameOrUrl(modalPage, HARepo);
       await rowHARepo.getByLabel('Select row').click();
       await page.getByRole('button', { name: 'Next', exact: true }).click();

--- a/_playwright-tests/UI/TemplateCRUD.spec.ts
+++ b/_playwright-tests/UI/TemplateCRUD.spec.ts
@@ -60,6 +60,8 @@ test.describe('Templates CRUD', () => {
         data: repoDataIntrospect,
         headers: { 'Content-Type': 'application/json' },
       });
+      const rowIntrospect = await getRowByNameOrUrl(page, repoNameIntrospect);
+      await expect(rowIntrospect.getByText('Valid')).toBeVisible({ timeout: 60_000 });
     });
     await test.step('Create a template', async () => {
       await navigateToTemplates(page);
@@ -109,6 +111,8 @@ test.describe('Templates CRUD', () => {
       await page.getByRole('button', { name: 'Next', exact: true }).click();
       await page.getByRole('button', { name: 'Create other options' }).click();
       await page.getByText('Create template only', { exact: true }).click();
+      const rowTemplate = await getRowByNameOrUrl(page, templateName);
+      await expect(rowTemplate.getByText('Valid')).toBeVisible({ timeout: 60000 });
     });
     await test.step('Read and update values in the template', async () => {
       const rowTemplate = await getRowByNameOrUrl(page, templateName);

--- a/_playwright-tests/UI/TemplateCRUD.spec.ts
+++ b/_playwright-tests/UI/TemplateCRUD.spec.ts
@@ -76,13 +76,10 @@ test.describe('Templates CRUD', () => {
       await rowRHELRepo.getByLabel('Select row').click();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
       // Select first custom repo (aarch64)
-      await modalPage.getByRole('searchbox', { name: 'Filter by name/url' }).fill(repoName);
       const rowRepo = await getRowByNameOrUrl(modalPage, repoName);
       await rowRepo.getByLabel('Select row').click();
 
       // Verify repo without snapshots appears but checkbox is disabled
-      await modalPage.getByRole('searchbox', { name: 'Filter by name/url' }).clear();
-      await modalPage.getByRole('searchbox', { name: 'Filter by name/url' }).fill(repoNameNoSnaps);
       const rowNoSnaps = await getRowByNameOrUrl(modalPage, repoNameNoSnaps);
       await expect(rowNoSnaps).toBeVisible();
       const noSnapsCheckbox = rowNoSnaps.getByLabel('Select row');


### PR DESCRIPTION
## Summary

*  Wait for valid status before next step.
* Remove unnecessary navigation steps.
 * Wait for menu to open before clicking items.
 * Change introspect only repo name so its clear that absence of snapshots is essential for the test.


## Testing steps
Integration tests pass
UI/TemplateCRUD.spec.ts passes
