### PR TITLE
Test: Fix template cleanup in Integration tests

### DIFF
--- a/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
+++ b/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
@@ -1,9 +1,4 @@
-import {
-  test,
-  expect,
-  cleanupTemplates,
-  randomName,
-} from '../test-utils/_playwright-tests/test-utils/src';
+import { test, expect, cleanupTemplates, randomName, sleep } from 'test-utils';
 import { RHSMClient, refreshSubscriptionManager } from './helpers/rhsmClient';
 import { navigateToTemplates } from '../UI/helpers/navHelpers';
 import { closePopupsIfExist, getRowByNameOrUrl } from '../UI/helpers/helpers';
@@ -19,8 +14,13 @@ test.describe('Associated Template CRUD', async () => {
     cleanup,
   }) => {
     await test.step('Set up cleanup for templates and RHSM client', async () => {
-      await cleanup.runAndAdd(() => cleanupTemplates(client, templateNamePrefix));
-      cleanup.add(() => regClient.Destroy('rhc'));
+      // Clean up this test's template by exact name
+      cleanup.add(() => cleanupTemplates(client, templateName));
+      cleanup.add(async () => {
+        await regClient.Destroy('rhc');
+        // Wait for backend to process the unregistration before template cleanup
+        await sleep(5000);
+      });
     });
 
     await test.step('Navigate to templates and create a new template', async () => {

--- a/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
+++ b/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, cleanupTemplates, randomName } from 'test-utils';
+import { test, expect, cleanupTemplates, randomName, sleep } from 'test-utils';
 import { RHSMClient, refreshSubscriptionManager } from './helpers/rhsmClient';
 import { navigateToTemplates } from '../UI/helpers/navHelpers';
 import { closePopupsIfExist, getRowByNameOrUrl } from '../UI/helpers/helpers';
@@ -19,8 +19,13 @@ test.describe('Test System With Template', async () => {
     const HARepo = 'Red Hat Enterprise Linux 9 for x86_64 - High Availability';
 
     await test.step('Add cleanup, delete any templates and template test repos that exist', async () => {
-      await cleanup.runAndAdd(() => cleanupTemplates(client, templateNamePrefix));
-      cleanup.add(() => regClient.Destroy('rhc'));
+      // Clean up this test's template by exact name
+      cleanup.add(() => cleanupTemplates(client, templateName));
+      cleanup.add(async () => {
+        await regClient.Destroy('rhc');
+        // Wait for backend to process the unregistration before template cleanup
+        await sleep(5000);
+      });
     });
     await test.step('Navigate to templates, ensure the Create template button can be clicked', async () => {
       await navigateToTemplates(page);


### PR DESCRIPTION
## Summary

The template  cleanup helper does not support the use of prefix

## Testing steps
tests pass and templates are not left behind