### PR TITLE
Test: Pull from stagecdn rather than cdn.stage

### DIFF
--- a/_playwright-tests/Integration/helpers/rhsmClient.ts
+++ b/_playwright-tests/Integration/helpers/rhsmClient.ts
@@ -217,7 +217,7 @@ const stageConfigureCommand = (): string[] => {
     '--server.port=443',
     '--server.prefix=/subscription',
     '--server.insecure=0',
-    '--rhsm.baseurl=https://cdn.stage.redhat.com',
+    '--rhsm.baseurl=https://stagecdn.redhat.com',
   ];
   if (process.env.PROXY !== undefined) {
     const url = new URL(process.env.PROXY);


### PR DESCRIPTION
## Summary

Test clients should pull from `stagecdn` rather than `cdn.stage`.
  Because `cdn.stage` can have dependency errors.

## Testing steps
tests pass
