### PR TITLE
Test: add rhsmClient status helper for associated template tests

### DIFF
--- a/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
+++ b/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
@@ -133,6 +133,12 @@ test.describe('Associated Template CRUD', () => {
       expect(isAttached, 'system should be removed from inventory').toBe(true);
     });
 
+    // https://issues.redhat.com/browse/HMS-9731: backend cache issue with template deletion
+    await test.step('Reload page to ensure UI reflects system removal', async () => {
+      await page.reload();
+      await expect(page.getByRole('button', { name: 'Create template' })).toBeVisible();
+    });
+
     await test.step('Verify template can now be deleted without warning', async () => {
       const rowTemplate = await getRowByNameOrUrl(page, templateName);
       await rowTemplate.getByLabel('Kebab toggle').click();

--- a/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
+++ b/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
@@ -38,18 +38,23 @@ test.describe('Associated Template CRUD', () => {
 
       await expect(
         page.getByRole('heading', { name: 'Additional Red Hat repositories', exact: true }),
+        'should be on the RHEL repo tab',
       ).toBeVisible();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
 
       await expect(
         page.getByRole('heading', { name: 'Other repositories', exact: true }),
+        'should be on the Other repositories tab',
       ).toBeVisible();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
 
       await page.getByText('Use the latest content', { exact: true }).click();
       await page.getByRole('button', { name: 'Next', exact: true }).click();
 
-      await expect(page.getByText('Enter template details')).toBeVisible();
+      await expect(
+        page.getByText('Enter template details'),
+        'should be on the Enter template details tab',
+      ).toBeVisible();
       await page.getByPlaceholder('Enter name').fill(`${templateName}`);
       await page.getByPlaceholder('Description').fill('Template test for associated system CRUD');
       await page.getByRole('button', { name: 'Next', exact: true }).click();
@@ -57,7 +62,9 @@ test.describe('Associated Template CRUD', () => {
       await page.getByRole('button', { name: 'Create other options' }).click();
       await page.getByText('Create template only', { exact: true }).click();
       const rowTemplate = await getRowByNameOrUrl(page, `${templateName}`);
-      await expect(rowTemplate.getByText('Valid')).toBeVisible({ timeout: 660000 });
+      await expect(rowTemplate.getByText('Valid'), 'repo should show Valid status').toBeVisible({
+        timeout: 660000,
+      });
     });
 
     await test.step('Register system with template using RHSM client', async () => {
@@ -72,7 +79,7 @@ test.describe('Associated Template CRUD', () => {
         console.log('Registration stdout:', reg?.stdout);
         console.log('Registration stderr:', reg?.stderr);
       }
-      expect(reg?.exitCode).toBe(0);
+      expect(reg?.exitCode, 'registration should be successful').toBe(0);
 
       await refreshSubscriptionManager(regClient);
     });
@@ -81,7 +88,7 @@ test.describe('Associated Template CRUD', () => {
       hostname = await regClient.GetHostname();
       console.log('System hostname:', hostname);
       const isAttached = await pollForSystemTemplateAttachment(page, hostname, true, 10_000, 6);
-      expect(isAttached).toBe(true);
+      expect(isAttached, 'system should be attached to template').toBe(true);
     });
 
     await test.step('Attempt to delete template and verify warning appears', async () => {
@@ -90,16 +97,20 @@ test.describe('Associated Template CRUD', () => {
       await page.getByRole('menuitem', { name: 'Delete' }).click();
 
       await test.step('Verify deletion warning appears for template with associated systems', async () => {
-        await expect(page.getByText('Delete template?')).toBeVisible();
+        await expect(
+          page.getByText('Delete template?'),
+          'delete template warning should be visible',
+        ).toBeVisible();
 
         const modal = page.getByRole('dialog');
-        await expect(modal).toBeVisible();
+        await expect(modal, 'delete template modal should be visible').toBeVisible();
 
         const removeButton = modal.getByRole('button', { name: 'Delete' });
-        await expect(removeButton).toBeEnabled();
+        await expect(removeButton, 'delete button should be enabled').toBeEnabled();
 
         await expect(
           modal.getByRole('link', { name: /This template is assigned to \d+ system/i }),
+          'system assignment link should be visible',
         ).toBeVisible();
 
         await modal.getByRole('button', { name: 'Cancel' }).click();
@@ -112,14 +123,14 @@ test.describe('Associated Template CRUD', () => {
         console.log('Unregistration stdout:', unreg?.stdout);
         console.log('Unregistration stderr:', unreg?.stderr);
       }
-      expect(unreg?.exitCode).toBe(0);
+      expect(unreg?.exitCode, 'unregistration should be successful').toBe(0);
     });
 
     await test.step('Wait for system to be removed from inventory', async () => {
       // Poll until system is not found or not attached to template
       // This should ensure the backend has processed the unregistration before checking UI
       const isAttached = await pollForSystemTemplateAttachment(page, hostname, false, 10_000, 6);
-      expect(isAttached).toBe(true);
+      expect(isAttached, 'system should be removed from inventory').toBe(true);
     });
 
     await test.step('Verify template can now be deleted without warning', async () => {
@@ -128,7 +139,10 @@ test.describe('Associated Template CRUD', () => {
       await page.getByRole('menuitem', { name: 'Delete' }).click();
 
       await test.step('Verify no warning appears and deletion succeeds', async () => {
-        await expect(page.getByText('Delete template?')).toBeVisible();
+        await expect(
+          page.getByText('Delete template?'),
+          'delete template confirmation modal should be visible',
+        ).toBeVisible();
 
         const modal = page.getByRole('dialog');
 
@@ -136,6 +150,7 @@ test.describe('Associated Template CRUD', () => {
           modal.getByText(
             `Template ${templateName} and all its data will be deleted. This action cannot be undone.`,
           ),
+          'delete template modal body should be visible',
         ).toBeVisible();
 
         await expect(
@@ -144,7 +159,7 @@ test.describe('Associated Template CRUD', () => {
         ).toHaveCount(0);
 
         const removeButton = modal.getByRole('button', { name: 'Delete' });
-        await expect(removeButton).toBeEnabled();
+        await expect(removeButton, 'delete button should be enabled').toBeEnabled();
         await removeButton.click();
       });
 

--- a/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
+++ b/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
@@ -85,7 +85,6 @@ test.describe('Associated Template CRUD', () => {
     });
 
     await test.step('Attempt to delete template and verify warning appears', async () => {
-      await navigateToTemplates(page);
       const rowTemplate = await getRowByNameOrUrl(page, templateName);
       await rowTemplate.getByLabel('Kebab toggle').click();
       await page.getByRole('menuitem', { name: 'Delete' }).click();
@@ -124,8 +123,6 @@ test.describe('Associated Template CRUD', () => {
     });
 
     await test.step('Verify template can now be deleted without warning', async () => {
-      await navigateToTemplates(page);
-
       const rowTemplate = await getRowByNameOrUrl(page, templateName);
       await rowTemplate.getByLabel('Kebab toggle').click();
       await page.getByRole('menuitem', { name: 'Delete' }).click();

--- a/_playwright-tests/Integration/helpers/rhsmClient.ts
+++ b/_playwright-tests/Integration/helpers/rhsmClient.ts
@@ -169,6 +169,18 @@ export class RHSMClient {
   }
 
   /**
+   * Get the host name from inside the container
+   * @returns The host name of the container as a string
+   */
+  async GetHostname(): Promise<string> {
+    const result = await this.Exec(['hostname'], 5000);
+    if (result?.exitCode !== 0) {
+      throw new Error(`Failed to get hostname: ${result?.stderr}`);
+    }
+    return result?.stdout?.trim() || '';
+  }
+
+  /**
    * Unregister with subscription-manager
    * @returns
    */

--- a/_playwright-tests/Integration/helpers/systemHelpers.ts
+++ b/_playwright-tests/Integration/helpers/systemHelpers.ts
@@ -1,0 +1,104 @@
+import { Page } from '@playwright/test';
+
+// sleep in ms, must await e.g. await sleep(num)
+export const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
+/**
+ * Polls the API to check if a system with the given host name is attached to a template.
+ * @param page - Playwright Page object
+ * @param hostname - The display name of the system to check
+ * @param expectedAttachment - Whether to expect the system to be attached (true) or not attached (false) (default: true)
+ * @param delayMs - Delay between polling attempts in milliseconds (default: 10000ms / 10s)
+ * @param maxAttempts - Number of times to poll (default: 10)
+ * @returns Promise<boolean> - true if system is in the expected state, false otherwise
+ */
+export const pollForSystemTemplateAttachment = async (
+  page: Page,
+  hostname: string,
+  expectedAttachment: boolean = true,
+  delayMs: number = 10_000,
+  maxAttempts: number = 10,
+): Promise<boolean> => {
+  let attempts = 0;
+
+  while (attempts < maxAttempts) {
+    attempts++;
+    let shouldRetry = false;
+
+    try {
+      // Query the systems API with search filter for the host name
+      const response = await page.request.get(
+        `/api/patch/v3/systems?search=${encodeURIComponent(hostname)}&limit=100`,
+      );
+
+      if (response.status() !== 200) {
+        console.log(
+          `API request failed with status ${response.status()}, attempt ${attempts}/${maxAttempts}`,
+        );
+        shouldRetry = true;
+      } else {
+        const body = await response.json();
+
+        if (!body.data || !Array.isArray(body.data)) {
+          console.log(`Invalid response format, attempt ${attempts}/${maxAttempts}`);
+          shouldRetry = true;
+        } else {
+          // Find the system with matching host name
+          const system = body.data.find(
+            (sys: { attributes: { display_name: string } }) =>
+              sys.attributes.display_name === hostname,
+          );
+
+          if (!system) {
+            // System not found in inventory
+            if (expectedAttachment === false) {
+              // The system is expected to not be attached and so if it's not in inventory,
+              // that's a success (system was removed)
+              console.log(
+                `System '${hostname}' not found in inventory (as expected - system removed)`,
+              );
+              return true;
+            } else {
+              // If we expect the system to be attached but it's not found,
+              // continue polling as it might be slow to appear
+              console.log(
+                `System '${hostname}' not found in inventory, attempt ${attempts}/${maxAttempts}`,
+              );
+              shouldRetry = true;
+            }
+          } else {
+            // Check if system has a template_uuid assigned
+            const hasTemplate = !!system.attributes?.template_uuid;
+
+            // If the system is in the expected state, return early
+            if (hasTemplate === expectedAttachment) {
+              const message = hasTemplate
+                ? `System '${hostname}' is attached to template: ${system.attributes.template_name} (as expected)`
+                : `System '${hostname}' is not attached to any template (as expected)`;
+              console.log(message);
+              return true;
+            } else {
+              const message = hasTemplate
+                ? `System '${hostname}' is attached to template but expected not to be, attempt ${attempts}/${maxAttempts}`
+                : `System '${hostname}' is not attached to template but expected to be, attempt ${attempts}/${maxAttempts}`;
+              console.log(message);
+              shouldRetry = true;
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.log(
+        `Error checking system template attachment: ${error}, attempt ${attempts}/${maxAttempts}`,
+      );
+      shouldRetry = true;
+    }
+
+    // Check if we should retry with delay
+    if (shouldRetry && attempts < maxAttempts) {
+      await sleep(delayMs);
+    }
+  }
+
+  return false;
+};


### PR DESCRIPTION
## Summary

Add a helper that checks if an rhsmClient is present in inventory and attached to a template
Make use of that helper in Associated Template test

## Testing steps
Integration/AssociatedTemplateCRUD.spec.ts passes