### PR TITLE
Test: Fix error msg searching systems for template ID

### DIFF
--- a/src/services/Systems/SystemsQueries.ts
+++ b/src/services/Systems/SystemsQueries.ts
@@ -73,7 +73,7 @@ export const useListSystemsByTemplateId = (
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       onError: (err: any) => {
         errorNotifier(
-          `Unable to find systems with the given id: ${id}`,
+          `Unable to find systems with the given template id: ${id}`,
           'An error occurred',
           err,
           'systems-list-error',


### PR DESCRIPTION
## Summary

  Make clear its the template ID used in the search.

## Testing steps
Integration/AssociatedTemplateCRUD test passes