### PR TITLE
Test: Reduce worker count to 2

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   fullyParallel: false,
   forbidOnly: false,
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 3 : undefined,
+  workers: process.env.CI ? 2 : undefined,
   reporter: process.env.CI
     ? [
         ['html', { outputFolder: 'playwright-report' }],


### PR DESCRIPTION
## Summary

  To save RAM for containers using systemd.

Ours CI tests only take 10 minutes to run (with 3 workers). 
The rhsmClient container needs around 12G to run systemd, rhc and systemctl.
Lets try trade speed for reliability.

## Testing steps
tests pass