### PR TITLE
Test: Export ENABLE_SENTRY variable

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -17,7 +17,7 @@ else
     mv ${DIST_FOLDER} stable
     export BETA=true
     # export sentry specific variables
-    export SENTRY_AUTH_TOKEN SENTRY_DSN SENTRY_ORG SENTRY_PROJECT
+    export ENABLE_SENTRY SENTRY_AUTH_TOKEN SENTRY_DSN SENTRY_ORG SENTRY_PROJECT
     build
     source build_app_info.sh
     mv ${DIST_FOLDER} preview


### PR DESCRIPTION
## Summary

  Now required in build-tools/Dockerfile

   The build-tools/Dockerfile requires the ENABLE_SENTRY environment variable to be set

## Testing steps
 konflux pipelines pass