### PR TITLE
Test: check for rhcd to be ready before proceeding

### DIFF
--- a/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
+++ b/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
@@ -4,7 +4,7 @@ import {
   cleanupTemplates,
   randomName,
 } from '../test-utils/_playwright-tests/test-utils/src';
-import { RHSMClient, refreshSubscriptionManager } from './helpers/rhsmClient';
+import { RHSMClient, refreshSubscriptionManager, waitForRhcdActive } from './helpers/rhsmClient';
 import { navigateToTemplates } from '../UI/helpers/navHelpers';
 import { closePopupsIfExist, getRowByNameOrUrl } from '../UI/helpers/helpers';
 import { pollForSystemTemplateAttachment } from './helpers/systemHelpers';
@@ -80,6 +80,8 @@ test.describe('Associated Template CRUD', () => {
         console.log('Registration stderr:', reg?.stderr);
       }
       expect(reg?.exitCode, 'registration should be successful').toBe(0);
+
+      await waitForRhcdActive(regClient);
 
       await refreshSubscriptionManager(regClient);
     });

--- a/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
+++ b/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
@@ -6,7 +6,7 @@ import {
   TemplatesApi,
   ListTemplatesRequest,
 } from 'test-utils';
-import { RHSMClient, refreshSubscriptionManager } from './helpers/rhsmClient';
+import { RHSMClient, refreshSubscriptionManager, waitForRhcdActive } from './helpers/rhsmClient';
 import { runCmd } from './helpers/helpers';
 import { navigateToTemplates } from '../UI/helpers/navHelpers';
 import { closePopupsIfExist, getRowByNameOrUrl } from '../UI/helpers/helpers';
@@ -81,6 +81,8 @@ test.describe('Test System With Template', () => {
         console.log(reg?.stderr);
       }
       expect(reg?.exitCode, 'Expect registering to be successful').toBe(0);
+
+      await waitForRhcdActive(regClient);
 
       await refreshSubscriptionManager(regClient);
 


### PR DESCRIPTION
## Summary

 Wait for rhcd service to become active before proceeding with subscription-manager refresh.

## Testing steps
Template Integration tests pass