### PR TITLE
Test: Fix can update system with template

### DIFF
--- a/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
+++ b/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
@@ -135,7 +135,18 @@ test.describe('Test System With Template', () => {
               name: templateName,
             });
             const template = templates.data?.[0];
-            return template?.lastUpdateTask?.status;
+            const taskStatus = template?.lastUpdateTask?.status;
+            const taskError = template?.lastUpdateTask?.error;
+
+            // Log task status for debugging
+            if (taskStatus) {
+              console.log(`Template update task status: ${taskStatus}`);
+              if (taskError) {
+                console.log(`Template update task error: ${taskError}`);
+              }
+            }
+
+            return taskStatus;
           },
           {
             message: 'Wait for template update task to complete',

--- a/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
+++ b/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
@@ -24,6 +24,9 @@ test.describe('Test System With Template', () => {
       : {},
   });
   test('Verify system updates with template', async ({ page, client, cleanup }) => {
+    // Increase timeout for CI environment because template update tasks can take longer
+    test.setTimeout(900000); // 15 minutes
+
     const HARepo = 'Red Hat Enterprise Linux 9 for x86_64 - High Availability';
 
     await test.step('Add cleanup, delete any templates and template test repos that exist', async () => {


### PR DESCRIPTION
## Summary

Increase test timeout for template updating test
    
     Template update task completion alone can exceed 6 minutes.

## Testing steps

CanUpdateSystemWithTemplate  test passes