### PR TITLE
Test: Increase Template test timeout

### DIFF
--- a/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
+++ b/_playwright-tests/Integration/AssociatedTemplateCRUD.spec.ts
@@ -19,6 +19,9 @@ test.describe('Associated Template CRUD', () => {
     client,
     cleanup,
   }) => {
+    // Increase timeout for CI environment because template validation can take up to 11 minutes
+    test.setTimeout(900000); // 15 minutes
+
     let hostname: string;
     await test.step('Set up cleanup for templates and RHSM client', async () => {
       await cleanup.runAndAdd(() => cleanupTemplates(client, templateNamePrefix));

--- a/_playwright-tests/Integration/InstallUploadRepoContent.spec.ts
+++ b/_playwright-tests/Integration/InstallUploadRepoContent.spec.ts
@@ -8,6 +8,9 @@ import { closePopupsIfExist, getRowByNameOrUrl, retry } from '../UI/helpers/help
 const uploadRepoNamePrefix = 'Upload_Repo';
 test.describe('Install Upload Repo Content', () => {
   test('Install Upload Repo Content', async ({ page, client, cleanup }) => {
+    // Increase timeout for CI environment because template validation can take up to 11 minutes
+    test.setTimeout(900000); // 15 minutes
+
     const uploadRepoName = `${uploadRepoNamePrefix}_${randomName()}`;
     const templateNamePrefix = 'integration_test_upload_repo';
     const templateName = `${templateNamePrefix}_${randomName()}`;


### PR DESCRIPTION
## Summary

  Templates can take 11 minutes to reach valid status.
  Early test timeout calls cleanup and test fails shortly before it would have passed.
  This causes test to be run which wastes more time.

## Testing steps
AssociatedTemplateCRUD and Integration/InstallUploadRepoContent passes.