### PR TITLE
Test: Make token and auth file names match

### DIFF
--- a/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
+++ b/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
@@ -22,7 +22,7 @@ let firstCount;
 
 test.describe('Test System With Template', () => {
   test.use({
-    storageState: '.auth/layered-repo-user.json',
+    storageState: '.auth/LAYERED_REPO_TOKEN.json',
     extraHTTPHeaders: process.env.LAYERED_REPO_TOKEN
       ? { Authorization: process.env.LAYERED_REPO_TOKEN }
       : {},

--- a/_playwright-tests/Integration/CheckIntrospectionFeature.spec.ts
+++ b/_playwright-tests/Integration/CheckIntrospectionFeature.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, RepositoriesApi } from 'test-utils';
 
 test.describe('Verify Repository Introspection Feature with pulp repo', () => {
   test.use({
-    storageState: '.auth/stable_sam.json',
+    storageState: '.auth/STABLE_SAM_TOKEN.json',
     extraHTTPHeaders: process.env.STABLE_SAM_TOKEN
       ? { Authorization: process.env.STABLE_SAM_TOKEN }
       : {},

--- a/_playwright-tests/Integration/LayeredRepoAccess.spec.ts
+++ b/_playwright-tests/Integration/LayeredRepoAccess.spec.ts
@@ -13,7 +13,7 @@ const repos = [
 
 test.describe('Test layered repos access is restricted', () => {
   test.use({
-    storageState: '.auth/rhel-only-user.json',
+    storageState: '.auth/RHEL_ONLY_TOKEN.json',
     extraHTTPHeaders: process.env.RHEL_ONLY_TOKEN
       ? { Authorization: process.env.RHEL_ONLY_TOKEN }
       : {},
@@ -61,7 +61,7 @@ test.describe('Test layered repos access is restricted', () => {
 
 test.describe('Test layered repos access is granted', () => {
   test.use({
-    storageState: '.auth/layered-repo-user.json',
+    storageState: '.auth/LAYERED_REPO_TOKEN.json',
     extraHTTPHeaders: process.env.LAYERED_REPO_TOKEN
       ? { Authorization: process.env.LAYERED_REPO_TOKEN }
       : {},

--- a/_playwright-tests/Integration/NoSubsUserTest.spec.ts
+++ b/_playwright-tests/Integration/NoSubsUserTest.spec.ts
@@ -8,7 +8,7 @@ test.describe('Template use requires a RHEL subscription', () => {
     `Skipping as the INTEGRATION and RBAC environment variables aren't both set to true.`,
   );
   test.use({
-    storageState: '.auth/no_subs_user.json',
+    storageState: '.auth/NO_SUBS_TOKEN.json',
     extraHTTPHeaders: process.env.NO_SUBS_TOKEN ? { Authorization: process.env.NO_SUBS_TOKEN } : {},
   });
 

--- a/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
+++ b/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
@@ -15,7 +15,7 @@ import pulpFixtures from './data/pulp_fixtures.json';
 
 test.describe('Pulp Fixture Repository Introspection', () => {
   test.use({
-    storageState: '.auth/stable_sam.json',
+    storageState: '.auth/STABLE_SAM_TOKEN.json',
     extraHTTPHeaders: process.env.STABLE_SAM_TOKEN
       ? { Authorization: process.env.STABLE_SAM_TOKEN }
       : {},

--- a/_playwright-tests/Integration/SnapshotListingFilterByOrgId.spec.ts
+++ b/_playwright-tests/Integration/SnapshotListingFilterByOrgId.spec.ts
@@ -9,7 +9,7 @@ import { test, expect, RepositoriesApi, expectError } from 'test-utils';
 
 test.describe('Snapshot Listing Filter by Org ID', () => {
   test.use({
-    storageState: '.auth/stable_sam.json',
+    storageState: '.auth/STABLE_SAM_TOKEN.json',
     extraHTTPHeaders: process.env.STABLE_SAM_TOKEN
       ? { Authorization: process.env.STABLE_SAM_TOKEN }
       : {},

--- a/_playwright-tests/Integration/UserSnapshotPermissionsTest.spec.ts
+++ b/_playwright-tests/Integration/UserSnapshotPermissionsTest.spec.ts
@@ -9,7 +9,7 @@ import { test, expect, RepositoriesApi, SnapshotsApi, ApiRepositoryResponse } fr
 
 test.describe('User Snapshot Permissions Test', () => {
   test.use({
-    storageState: '.auth/stable_sam.json',
+    storageState: '.auth/STABLE_SAM_TOKEN.json',
     extraHTTPHeaders: process.env.STABLE_SAM_TOKEN
       ? { Authorization: process.env.STABLE_SAM_TOKEN }
       : {},

--- a/_playwright-tests/UI/RBACUserTest.spec.ts
+++ b/_playwright-tests/UI/RBACUserTest.spec.ts
@@ -10,7 +10,7 @@ const url = randomUrl();
 
 test.describe('Create, update, and read a repo as admin user', () => {
   test.skip(!process.env.RBAC, `Skipping as the RBAC environment variable isn't set to true.`);
-  test.use({ storageState: '.auth/admin_user.json' });
+  test.use({ storageState: '.auth/ADMIN_TOKEN.json' });
   test.describe.configure({ mode: 'serial' });
 
   test('Login as admin and manage repo', async ({ page }) => {
@@ -44,7 +44,7 @@ test.describe('Create, update, and read a repo as admin user', () => {
 
   test.describe('Check read-only user can view but not edit the repo', () => {
     test.use({
-      storageState: '.auth/read-only.json',
+      storageState: '.auth/READONLY_TOKEN.json',
       extraHTTPHeaders: process.env.READONLY_TOKEN
         ? { Authorization: process.env.READONLY_TOKEN }
         : {},
@@ -64,7 +64,7 @@ test.describe('Create, update, and read a repo as admin user', () => {
 
   test.describe('Check rhel-operator user can view but not edit the repo', () => {
     test.use({
-      storageState: '.auth/rhel_operator.json',
+      storageState: '.auth/RHEL_OPERATOR_TOKEN.json',
       extraHTTPHeaders: process.env.RHEL_OPERATOR_TOKEN
         ? { Authorization: process.env.RHEL_OPERATOR_TOKEN }
         : {},

--- a/_playwright-tests/auth.setup.ts
+++ b/_playwright-tests/auth.setup.ts
@@ -37,13 +37,13 @@ test.describe('Setup Authentication States', () => {
     // Save state for rhel-operator user
     const { cookies } = await page
       .context()
-      .storageState({ path: path.join(__dirname, '../../.auth', 'rhel_operator.json') });
+      .storageState({ path: path.join(__dirname, '../../.auth', 'RHEL_OPERATOR_TOKEN.json') });
     const rhelOperatorToken = cookies.find((cookie) => cookie.name === 'cs_jwt')?.value;
     expect(rhelOperatorToken).toBeDefined();
 
     process.env.RHEL_OPERATOR_TOKEN = `Bearer ${rhelOperatorToken}`;
 
-    await storeStorageStateAndToken(page, 'rhel_operator.json');
+    await storeStorageStateAndToken(page, 'RHEL_OPERATOR_TOKEN.json');
     await logout(page);
   });
 
@@ -57,13 +57,13 @@ test.describe('Setup Authentication States', () => {
     // Save state for read-only user
     const { cookies } = await page
       .context()
-      .storageState({ path: path.join(__dirname, '../../.auth', 'read-only.json') });
+      .storageState({ path: path.join(__dirname, '../../.auth', 'READONLY_TOKEN.json') });
     const readOnlyToken = cookies.find((cookie) => cookie.name === 'cs_jwt')?.value;
     expect(readOnlyToken).toBeDefined();
 
     process.env.READONLY_TOKEN = `Bearer ${readOnlyToken}`;
 
-    await storeStorageStateAndToken(page, 'read-only.json');
+    await storeStorageStateAndToken(page, 'READONLY_TOKEN.json');
     await logout(page);
   });
 
@@ -80,13 +80,13 @@ test.describe('Setup Authentication States', () => {
     // Save state for layered repo user
     const { cookies } = await page
       .context()
-      .storageState({ path: path.join(__dirname, '../../.auth', 'layered-repo-user.json') });
+      .storageState({ path: path.join(__dirname, '../../.auth', 'LAYERED_REPO_TOKEN.json') });
     const layeredRepoToken = cookies.find((cookie) => cookie.name === 'cs_jwt')?.value;
     expect(layeredRepoToken).toBeDefined();
 
     process.env.LAYERED_REPO_TOKEN = `Bearer ${layeredRepoToken}`;
 
-    await storeStorageStateAndToken(page, 'layered-repo-user.json');
+    await storeStorageStateAndToken(page, 'LAYERED_REPO_TOKEN.json');
     await logout(page);
   });
 
@@ -103,13 +103,13 @@ test.describe('Setup Authentication States', () => {
     // Save state for RHEL-only user
     const { cookies } = await page
       .context()
-      .storageState({ path: path.join(__dirname, '../../.auth', 'rhel-only-user.json') });
+      .storageState({ path: path.join(__dirname, '../../.auth', 'RHEL_ONLY_TOKEN.json') });
     const rhelOnlyToken = cookies.find((cookie) => cookie.name === 'cs_jwt')?.value;
     expect(rhelOnlyToken).toBeDefined();
 
     process.env.RHEL_ONLY_TOKEN = `Bearer ${rhelOnlyToken}`;
 
-    await storeStorageStateAndToken(page, 'rhel-only-user.json');
+    await storeStorageStateAndToken(page, 'RHEL_ONLY_TOKEN.json');
     await logout(page);
   });
 
@@ -126,13 +126,13 @@ test.describe('Setup Authentication States', () => {
     // Save state for no-subs user
     const { cookies } = await page
       .context()
-      .storageState({ path: path.join(__dirname, '../../.auth', 'no_subs_user.json') });
+      .storageState({ path: path.join(__dirname, '../../.auth', 'NO_SUBS_TOKEN.json') });
     const noSubsToken = cookies.find((cookie) => cookie.name === 'cs_jwt')?.value;
     expect(noSubsToken).toBeDefined();
 
     process.env.NO_SUBS_TOKEN = `Bearer ${noSubsToken}`;
 
-    await storeStorageStateAndToken(page, 'no_subs_user.json');
+    await storeStorageStateAndToken(page, 'NO_SUBS_TOKEN.json');
     await logout(page);
   });
 
@@ -151,17 +151,17 @@ test.describe('Setup Authentication States', () => {
     // Save state for stable_sam user
     const { cookies } = await page
       .context()
-      .storageState({ path: path.join(__dirname, '../../.auth', 'stable_sam.json') });
+      .storageState({ path: path.join(__dirname, '../../.auth', 'STABLE_SAM_TOKEN.json') });
     const stableSamToken = cookies.find((cookie) => cookie.name === 'cs_jwt')?.value;
     expect(stableSamToken).toBeDefined();
 
     process.env.STABLE_SAM_TOKEN = `Bearer ${stableSamToken}`;
 
-    await storeStorageStateAndToken(page, 'stable_sam.json');
+    await storeStorageStateAndToken(page, 'STABLE_SAM_TOKEN.json');
     await logout(page);
   });
 
-  test('Authenticate Default User and Save State', async ({ page }) => {
+  test('Authenticate Default Admin User and Save State', async ({ page }) => {
     test.setTimeout(60_000);
 
     // Login default admin user
@@ -170,12 +170,13 @@ test.describe('Setup Authentication States', () => {
 
     const { cookies } = await page
       .context()
-      .storageState({ path: path.join(__dirname, '../../.auth', 'admin_user.json') });
-    const defaultUserToken = cookies.find((cookie) => cookie.name === 'cs_jwt')?.value;
-    expect(defaultUserToken).toBeDefined();
+      .storageState({ path: path.join(__dirname, '../../.auth', 'ADMIN_TOKEN.json') });
+    const adminToken = cookies.find((cookie) => cookie.name === 'cs_jwt')?.value;
+    expect(adminToken).toBeDefined();
+
+    process.env.ADMIN_TOKEN = `Bearer ${adminToken}`;
 
     // Save state for default admin user
-    // This also sets process.env.TOKEN, which is picked up by main config.
-    await storeStorageStateAndToken(page, 'admin_user.json');
+    await storeStorageStateAndToken(page, 'ADMIN_TOKEN.json');
   });
 });

--- a/_playwright-tests/helpers/loginHelpers.ts
+++ b/_playwright-tests/helpers/loginHelpers.ts
@@ -59,7 +59,7 @@ export const storeStorageStateAndToken = async (page: Page, fileName: string) =>
   const { cookies } = await page
     .context()
     .storageState({ path: path.join(__dirname, '../../.auth', fileName) });
-  process.env.TOKEN = `Bearer ${cookies.find((cookie) => cookie.name === 'cs_jwt')?.value}`;
+  process.env.ADMIN_TOKEN = `Bearer ${cookies.find((cookie) => cookie.name === 'cs_jwt')?.value}`;
 };
 
 export const logInWithRHELOperatorUser = async (page: Page) =>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,10 +31,10 @@ export default defineConfig({
     launchOptions: {
       args: ['--use-fake-device-for-media-stream'],
     },
-    ...(process.env.TOKEN
+    ...(process.env.ADMIN_TOKEN
       ? {
           extraHTTPHeaders: {
-            Authorization: process.env.TOKEN,
+            Authorization: process.env.ADMIN_TOKEN,
           },
         }
       : {}),
@@ -62,7 +62,7 @@ export default defineConfig({
             : [/switch-to-preview/, /local-only/],
           use: {
             ...devices['Desktop Chrome'],
-            storageState: `.auth/admin_user.json`,
+            storageState: `.auth/ADMIN_TOKEN.json`,
           },
           testIgnore: ['**/UI/**'],
           testDir: './_playwright-tests/Integration/',
@@ -72,7 +72,7 @@ export default defineConfig({
           name: 'UI',
           use: {
             ...devices['Desktop Chrome'],
-            storageState: '.auth/admin_user.json',
+            storageState: '.auth/ADMIN_TOKEN.json',
           },
           testIgnore: ['**/Integration/**'],
           testDir: './_playwright-tests/UI/',
@@ -85,7 +85,7 @@ export default defineConfig({
             grep: [/switch-to-preview/],
             use: {
               ...devices['Desktop Chrome'],
-              storageState: `.auth/admin_user.json`,
+              storageState: `.auth/ADMIN_TOKEN.json`,
             },
             dependencies: ['setup', 'integration'],
           },
@@ -94,7 +94,7 @@ export default defineConfig({
             grep: [/preview-only/],
             use: {
               ...devices['Desktop Chrome'],
-              storageState: `.auth/admin_user.json`,
+              storageState: `.auth/ADMIN_TOKEN.json`,
             },
             testDir: './_playwright-tests/Integration',
             dependencies: ['Switch to preview'],


### PR DESCRIPTION
## Summary

To avoid using maps to translate between them.

## Testing steps
Tests pass
