### PR TITLE
Test: Update UI tests to use unusedRepoUrl()

### DIFF
--- a/_playwright-tests/Integration/UseSnapshotConfig.spec.ts
+++ b/_playwright-tests/Integration/UseSnapshotConfig.spec.ts
@@ -9,7 +9,7 @@ import { runCmd } from './helpers/helpers';
 const repoNamePrefix = 'Snapshot_Config';
 
 test.describe('Use Snapshot Config', () => {
-  test('Use Snapshot Config', async ({ page, client, cleanup }) => {
+  test('Use Snapshot Config', async ({ page, client, cleanup, unusedRepoUrl }) => {
     let repoName = '';
     let fileContent = '';
 
@@ -24,7 +24,7 @@ test.describe('Use Snapshot Config', () => {
     await test.step('Verify "download config file" and "copy to clipboard config" content has same value', async () => {
       await navigateToRepositories(page);
       await closeGenericPopupsIfExist(page);
-      await createCustomRepo(page, repoName);
+      await createCustomRepo(page, repoName, unusedRepoUrl);
       const row = await waitForValidStatus(page, repoName, 60000);
 
       await navigateToSnapshotsOfRepository(page, row);

--- a/_playwright-tests/UI/CustomRepoCRUD.spec.ts
+++ b/_playwright-tests/UI/CustomRepoCRUD.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'test-utils';
-import { cleanupRepositories, randomName, randomUrl } from 'test-utils/helpers';
+import { cleanupRepositories, randomName } from 'test-utils/helpers';
 import { navigateToRepositories } from './helpers/navHelpers';
 import {
   closeGenericPopupsIfExist,
@@ -9,10 +9,10 @@ import {
 
 const repoNamePrefix = 'Repo-CRUD';
 const repoName = `${repoNamePrefix}-${randomName()}`;
-const url = randomUrl();
 
 test.describe('Custom Repositories CRUD', () => {
-  test('Add, Read, update, delete a repo', async ({ page, client, cleanup }) => {
+  test('Add, Read, update, delete a repo', async ({ page, client, cleanup, unusedRepoUrl }) => {
+    const url = await unusedRepoUrl();
     await cleanup.runAndAdd(() => cleanupRepositories(client, repoNamePrefix));
     await navigateToRepositories(page);
     await closeGenericPopupsIfExist(page);

--- a/_playwright-tests/UI/CustomRepoPagination.spec.ts
+++ b/_playwright-tests/UI/CustomRepoPagination.spec.ts
@@ -8,10 +8,15 @@ import { bulkCreateRepos } from './helpers/createRepositories';
 const repoNamePrefix = 'custom_repo-pagination';
 
 test.describe('Custom repositories pagination', () => {
-  test('Verify pagination on custom repo page', async ({ page, client, cleanup }) => {
+  test('Verify pagination on custom repo page', async ({
+    page,
+    client,
+    cleanup,
+    unusedRepoUrl,
+  }) => {
     await test.step('Populate the custom repo table', async () => {
       await cleanup.runAndAdd(() => cleanupRepositories(client, repoNamePrefix));
-      await bulkCreateRepos(page, 12, repoNamePrefix);
+      await bulkCreateRepos(page, 12, repoNamePrefix, unusedRepoUrl);
       await navigateToRepositories(page);
       await closeGenericPopupsIfExist(page);
       await page.getByPlaceholder(/^Filter by name.*$/).fill(repoNamePrefix);

--- a/_playwright-tests/UI/RBACUserTest.spec.ts
+++ b/_playwright-tests/UI/RBACUserTest.spec.ts
@@ -1,19 +1,19 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from 'test-utils';
 import { deleteAllRepos } from './helpers/deleteRepositories';
-import { randomName, randomUrl } from './helpers/repoHelpers';
+import { randomName } from './helpers/repoHelpers';
 import { navigateToRepositories } from './helpers/navHelpers';
 import { closeGenericPopupsIfExist, waitForValidStatus } from './helpers/helpers';
 
 const repoNamePrefix = 'Repo-RBAC';
 const repoName = `${repoNamePrefix}-${randomName()}`;
-const url = randomUrl();
 
 test.describe('Create, update, and read a repo as admin user', () => {
   test.skip(!process.env.RBAC, `Skipping as the RBAC environment variable isn't set to true.`);
   test.use({ storageState: '.auth/ADMIN_TOKEN.json' });
   test.describe.configure({ mode: 'serial' });
 
-  test('Login as admin and manage repo', async ({ page }) => {
+  test('Login as admin and manage repo', async ({ page, unusedRepoUrl }) => {
+    const url = await unusedRepoUrl();
     await test.step('Create a repository', async () => {
       await navigateToRepositories(page);
       await closeGenericPopupsIfExist(page);

--- a/_playwright-tests/UI/TemplateCRUD.spec.ts
+++ b/_playwright-tests/UI/TemplateCRUD.spec.ts
@@ -8,7 +8,6 @@ import {
   waitForValidStatus,
 } from './helpers/helpers';
 import { createCustomRepo } from './helpers/createRepositories';
-import { randomUrl } from './helpers/repoHelpers';
 
 const templateNamePrefix = 'template_CRUD';
 const repoNamePrefix = 'custom_repo-template';
@@ -21,7 +20,7 @@ const templateName = `${templateNamePrefix}-${randomName()}`;
 const smallRHRepo = 'Red Hat CodeReady Linux Builder for RHEL 9 ARM 64 (RPMs)';
 
 test.describe('Templates CRUD', () => {
-  test('Add, Read, update, delete a template', async ({ page, client, cleanup }) => {
+  test('Add, Read, update, delete a template', async ({ page, client, cleanup, unusedRepoUrl }) => {
     await test.step('Delete any templates and template test repos that exist', async () => {
       await cleanup.runAndAdd(() => cleanupRepositories(client, repoNamePrefix));
       await cleanup.runAndAdd(() => cleanupTemplates(client, templateNamePrefix));
@@ -31,7 +30,7 @@ test.describe('Templates CRUD', () => {
       await closeGenericPopupsIfExist(page);
 
       // Create first repo (aarch64, with snapshot)
-      await createCustomRepo(page, repoName);
+      await createCustomRepo(page, repoName, unusedRepoUrl);
       await waitForValidStatus(page, repoName);
 
       // Create second repo (x86_64, with snapshot)
@@ -41,7 +40,7 @@ test.describe('Templates CRUD', () => {
         name: repoNameX86,
         origin: 'external',
         snapshot: true,
-        url: randomUrl(),
+        url: await unusedRepoUrl(),
       };
       await page.request.post('/api/content-sources/v1/repositories/', {
         data: repoDataX86,
@@ -56,7 +55,7 @@ test.describe('Templates CRUD', () => {
         name: repoNameNoSnaps,
         origin: 'external',
         snapshot: false,
-        url: randomUrl(),
+        url: await unusedRepoUrl(),
       };
       await page.request.post('/api/content-sources/v1/repositories/', {
         data: repoDataNoSnaps,

--- a/_playwright-tests/UI/helpers/createRepositories.ts
+++ b/_playwright-tests/UI/helpers/createRepositories.ts
@@ -1,19 +1,17 @@
 import { expect, type Page } from '@playwright/test';
-import { randomUrl } from './repoHelpers';
 
 export const bulkCreateRepos = async (
   { request }: Page,
   repoCount: number,
   repoNamePrefix: string,
+  unusedRepoUrl: () => Promise<string>,
 ) => {
   const list: Record<string, string | boolean | number>[] = [];
   for (let count = 1; count <= repoCount; count++) {
     const repoNum = `${count.toString().padStart(2, '0')}`;
-    const randomURL = () =>
-      `https://content-services.github.io/fixtures/yum/centirepos/repo${repoNum}/`;
     list.push({
       name: `${repoNamePrefix}-${repoNum}`,
-      url: randomURL(),
+      url: await unusedRepoUrl(),
       snapshot: false,
     });
   }
@@ -26,14 +24,19 @@ export const bulkCreateRepos = async (
   expect(response.status()).toBe(201);
 };
 
-export const createCustomRepo = async ({ request }: Page, repoName: string) => {
+export const createCustomRepo = async (
+  { request }: Page,
+  repoName: string,
+  unusedRepoUrl: () => Promise<string>,
+) => {
+  const url = await unusedRepoUrl();
   const repoData = {
     distribution_arch: 'aarch64',
     distribution_versions: ['8', '9'],
     name: repoName,
     origin: 'external',
     snapshot: true,
-    url: randomUrl(), // Ensure randomUrl() returns a valid string
+    url,
   };
 
   try {


### PR DESCRIPTION
## Summary

Update UI tests to use unusedRepoUrl()

    The createRepositories helper now uses unusedRepoUrl()
    Tests must pass unusedRepoUrl when calling the helper.


## Testing steps

Tests pass

#testwith https://github.com/content-services/content-sources-backend/pull/1361