### PR TITLE
Test: Drop deprecated randomUrl function

### DIFF
--- a/_playwright-tests/UI/helpers/repoHelpers.ts
+++ b/_playwright-tests/UI/helpers/repoHelpers.ts
@@ -1,9 +1,1 @@
 export const randomName = () => (Math.random() + 1).toString(36).substring(2, 6);
-
-export const randomNum = () =>
-  Math.floor(Math.random() * 100 + 1)
-    .toString()
-    .padStart(2, '0');
-
-export const randomUrl = () =>
-  `https://content-services.github.io/fixtures/yum/centirepos/repo${randomNum()}/`;


### PR DESCRIPTION
## Summary

Drop deprecated randomUrl function
Tests now use unusedRepoUrl function

## Testing steps
test pass

## Summary by Sourcery

Enhancements:
- Clean up Playwright repo helper utilities by removing the deprecated randomUrl and supporting randomNum functions used in tests.