### PR TITLE
Test: Add await expect for kebab button

### DIFF
--- a/_playwright-tests/UI/helpers/navHelpers.ts
+++ b/_playwright-tests/UI/helpers/navHelpers.ts
@@ -83,6 +83,7 @@ export const navigateToTemplates = async (page: Page) => {
 
 export const navigateToSnapshotsOfRepository = async (page: Page, row: Locator) => {
   await test.step(`Navigating to snapshots of repository`, async () => {
+    await expect(row.getByRole('button', { name: 'Kebab toggle' })).toBeEnabled();
     await row.getByRole('button', { name: 'Kebab toggle' }).click();
     await page.getByRole('menuitem', { name: 'View all snapshots' }).click();
   });


### PR DESCRIPTION
## Summary

Add await expect for kebab button to be enabled

## Testing steps

## Summary by Sourcery

Tests:
- Assert the kebab toggle button is enabled in the snapshots navigation Playwright helper before attempting to click it.