### PR TITLE
Test: Disable React rules for playwright tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -91,12 +91,18 @@ export default [
   },
 
   {
-    // Override for Playwright tests
+    // Override for Playwright tests: disable React rules (incompatible with ESLint 10
+    // context API). Test specs are not React components.
     files: ['_playwright-tests/**/*.ts'],
     plugins: {
       playwright: playwright,
     },
     rules: {
+      ...(react?.rules
+        ? Object.fromEntries(
+            Object.keys(react.rules).map((ruleName) => [`react/${ruleName}`, 'off']),
+          )
+        : {}),
       ...playwright.configs.recommended.rules,
       'playwright/no-conditional-in-test': 'off',
       'playwright/no-conditional-expect': 'off',


### PR DESCRIPTION
## Summary

Disable React rules for playwright tests.
They are incompatible with Eslint 10 and test specs are not React components.

## Testing steps
CI lint check passes