### PR TITLE
Test: Set dependabot ignore for major updates to eslint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,12 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "jest-environment-jsdom"
         update-types: ["version-update:semver-major"]
+      # eslint-plugin-react is not yet compatible with ESLint 10 (context API)
+      # TODO: Revert this change when possible (HMS-10187)
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@eslint/js"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "Build: "
     groups:


### PR DESCRIPTION
## Summary

 Set dependabot ignore for major updates to eslint

Hold Eslint version to 9.x because with ESLint 10, eslint-plugin-react breaks for every file
(e.g. src/App.tsx) because of the context.getFilename API change, not only for Playwright tests.

## Testing steps
tests pass 

