### PR TITLE
Test: Merge fork and PR names for codecov

### DIFF
--- a/.github/workflows/playwright-actions.yml
+++ b/.github/workflows/playwright-actions.yml
@@ -215,5 +215,7 @@ jobs:
         with:
           directory: ./coverage-e2e/
           flags: e2e
+          # This merges the "fork" name and "PR" name into one entry
+          override_branch: ${{ github.head_ref || github.ref_name }}
           name: playwright-tests
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary

Merge fork and PR names for codecov
To prevent one name for a push event and one name for a pull_request event.

## Testing steps
Check for this branch name in "Branch Context" drop down menu at https://app.codecov.io/gh/content-services/content-sources-frontend

EDIT: We can't check for *this* branch's name because it not a playwright test. Need to merge and check the next PR with tests.
