### PR TITLE
Test: Fix timeout for dnf info commands

### DIFF
--- a/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
+++ b/_playwright-tests/Integration/CanUpdateSystemWithTemplate.spec.ts
@@ -235,6 +235,7 @@ test.describe('Test System With Template', () => {
         'Verify that booth was installed from the HA repo',
         ['sh', '-c', "dnf info booth | grep '^From repo' | cut -d ':' -f2-"],
         regClient,
+        YUM_INSTALL_QUICK_TIMEOUT_MS,
       );
       expect(dnfVerifyRepo?.stdout?.toString().trim()).toBe(
         'rhel-9-for-x86_64-highavailability-rpms',

--- a/_playwright-tests/Integration/InstallUploadRepoContent.spec.ts
+++ b/_playwright-tests/Integration/InstallUploadRepoContent.spec.ts
@@ -160,6 +160,7 @@ test.describe('Install Upload Repo Content', () => {
         'Verify that bear was installed from the upload repo',
         ['sh', '-c', "dnf info bear | grep '^From repo' | cut -d ':' -f2-"],
         regClient,
+        YUM_INSTALL_QUICK_TIMEOUT_MS,
       );
       expect(dnfVerifyRepo?.stdout?.toString().trim()).toBe(uploadRepoName);
     });


### PR DESCRIPTION
## Summary
Fix timeout for dnf info commands
This matches other dnf commands.

## Testing steps

Integration/CanUpdateSystemWithTemplate.spec.ts does not fail at `dnf info booth` step.