### PR TITLE
Test: Update docs URL for using content templates

### DIFF
--- a/_playwright-tests/UI/Templates.spec.ts
+++ b/_playwright-tests/UI/Templates.spec.ts
@@ -42,7 +42,7 @@ test.describe('Templates', () => {
       await page.getByRole('link', { name: 'Learn more about content templates' }).click();
       const docsPage = await pagePromise;
       await expect(docsPage).toHaveURL(
-        /^https:\/\/docs\.redhat\.com\/en\/documentation\/red_hat_lightspeed\/.*content-template.*$/,
+        /^https:\/\/docs\.redhat\.com\/en\/documentation\/red_hat_lightspeed\/.*patching-using-content-templates.*$/,
       );
       await expect(docsPage.getByText(/^.*Using content templates.*$/).first()).toBeVisible();
       await expect(

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -222,8 +222,7 @@ const TemplatesTable = () => {
           bodyContent:
             'Templates provide consistent content across environments and time. They enable you to control the scope of package and advisory updates that will be installed on selected systems.',
           linkText: 'Content templates documentation',
-          linkUrl:
-            'https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/managing_system_content_and_patch_updates_on_rhel_systems/patching-using-content-templates_patch-service-overview',
+          linkUrl: TEMPLATES_DOCS_URL,
         }}
       />
       {serviceUnavailable && <ServiceUnavailableAlert />}

--- a/src/Pages/Templates/TemplatesTable/constants.ts
+++ b/src/Pages/Templates/TemplatesTable/constants.ts
@@ -10,4 +10,4 @@ export const STANDARD_STREAM_PATH = 'dist';
 export const TEMPLATE_SYSTEMS_UPDATE_LIMIT = 1000;
 
 export const TEMPLATES_DOCS_URL =
-  'https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html/managing_system_content_and_patch_updates_on_rhel_systems/patching-using-content-templates_patch-service-overview';
+  'https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html/managing_system_content_and_patch_updates_on_rhel_systems/patching-using-content-templates';


### PR DESCRIPTION
## Summary
Update docs URL for using content templates
Fix to use constant not link in code
## Testing steps
 _playwright-tests/UI/Templates.spec.ts  passes