### PR TITLE
HMS-10325: add minor version and release stream to templates table

### DIFF
--- a/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
@@ -127,10 +127,12 @@ export default function DeleteContentModal() {
 
   const templateFilterData: TemplateFilterData = {
     arch: '',
-    version: '',
+    version: [],
     search: '',
+    extended_release_version: [],
     repository_uuids: uuids.join(','),
     snapshot_uuids: '',
+    extended_release: [],
   };
 
   const {

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -4,6 +4,7 @@ import {
   FlexItem,
   Grid,
   Icon,
+  Label,
   Pagination,
   PaginationVariant,
   Spinner,
@@ -45,6 +46,7 @@ import { ExclamationTriangleIcon, ExternalLinkSquareAltIcon } from '@patternfly/
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useFlag } from '@unleash/proxy-client-react';
 import { TEMPLATES_DOCS_URL } from './constants';
+import { abbreviateStreamName } from './helpers';
 
 const useStyles = createUseStyles({
   topContainer: {
@@ -91,10 +93,12 @@ const TemplatesTable = () => {
 
   const defaultValues: TemplateFilterData = {
     arch: '',
-    version: '',
+    version: [],
+    extended_release_version: [],
     search: '',
     repository_uuids: '',
     snapshot_uuids: '',
+    extended_release: [],
   };
 
   const [filterData, setFilterData] = useState<TemplateFilterData>(defaultValues);
@@ -102,9 +106,13 @@ const TemplatesTable = () => {
   const clearFilters = () => setFilterData(defaultValues);
 
   const notFiltered =
-    filterData.arch === '' && filterData.version === '' && filterData.search === '';
+    filterData.arch === '' &&
+    filterData.version.length === 0 &&
+    filterData.extended_release_version.length === 0 &&
+    filterData.search === '' &&
+    filterData.extended_release.length === 0;
 
-  const columnSortAttributes = ['name', '', 'arch', 'version', '', ''];
+  const columnSortAttributes = ['name', '', 'arch', 'version', '', '', ''];
 
   const sortString = useMemo(
     () =>
@@ -189,6 +197,8 @@ const TemplatesTable = () => {
     isError: repositoryParamsIsError,
     getArchName,
     getVersionName,
+    getStreamName,
+    getMinorVersionName,
   } = useDistributionDetails();
 
   const actionTakingPlace = isLoading || isFetching || repositoryParamsLoading;
@@ -313,6 +323,8 @@ const TemplatesTable = () => {
                       last_update_snapshot_error,
                       last_update_task,
                       to_be_deleted_snapshots,
+                      extended_release,
+                      extended_release_version,
                     }: TemplateItem,
                     index,
                   ) => (
@@ -327,6 +339,11 @@ const TemplatesTable = () => {
                               {name}
                             </Button>
                           </FlexItem>
+                          {extended_release ? (
+                            <Label isCompact color='blue'>
+                              {abbreviateStreamName(getStreamName(extended_release))}
+                            </Label>
+                          ) : null}
                           <Hide
                             hide={!(to_be_deleted_snapshots && to_be_deleted_snapshots.length > 0)}
                           >
@@ -348,7 +365,11 @@ const TemplatesTable = () => {
                       </Td>
                       <Td>{description}</Td>
                       <Td>{getArchName(arch)}</Td>
-                      <Td>{getVersionName(version)}</Td>
+                      <Td>
+                        {extended_release && extended_release_version
+                          ? getMinorVersionName(extended_release_version)
+                          : getVersionName(version)}
+                      </Td>
                       <Td>
                         <ConditionalTooltip
                           show={!use_latest}

--- a/src/Pages/Templates/TemplatesTable/components/TemplateFilters.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/TemplateFilters.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { testRepositoryParamsResponse } from 'testingHelpers';
+import { testEUSRepositoryParamsResponse } from 'testingHelpers';
 import TemplateFilters from './TemplateFilters';
 import { useQueryClient } from '@tanstack/react-query';
 import userEvent from '@testing-library/user-event';
@@ -16,7 +16,7 @@ jest.mock('@tanstack/react-query');
 
 beforeAll(() => {
   (useQueryClient as jest.Mock).mockImplementation(() => ({
-    getQueryData: () => testRepositoryParamsResponse,
+    getQueryData: () => testEUSRepositoryParamsResponse,
   }));
 });
 
@@ -27,10 +27,12 @@ it('Render loading state (disabled)', async () => {
       setFilterData={() => null}
       filterData={{
         search: '',
-        version: '',
+        version: [],
+        extended_release_version: [],
         arch: '',
         repository_uuids: '',
         snapshot_uuids: '',
+        extended_release: [],
       }}
     />,
   );
@@ -39,16 +41,18 @@ it('Render loading state (disabled)', async () => {
   expect(filterInput).toHaveAttribute('disabled');
 });
 
-it('Select a filter of each type and ensure chips are present ContentListFilters', async () => {
-  const { queryByText, getByRole, getByLabelText, queryAllByText, getByText } = render(
+it('Select a filter of each type and ensure chips are present', async () => {
+  const { queryByText, getByRole, getByLabelText, queryAllByText } = render(
     <TemplateFilters
       setFilterData={() => null}
       filterData={{
         search: '',
-        version: '',
+        version: [],
+        extended_release_version: [],
         arch: '',
         repository_uuids: '',
         snapshot_uuids: '',
+        extended_release: [],
       }}
     />,
   );
@@ -63,19 +67,35 @@ it('Select a filter of each type and ensure chips are present ContentListFilters
 
   await userEvent.click(optionMenu);
 
-  // Select a Version item
-  const versionOption = getByText('OS version')?.closest('button') as Element;
-
+  // Select major and minor version items
+  const versionOption = getByRole('menuitem', { name: 'OS version' });
   expect(versionOption).toBeInTheDocument();
   await userEvent.click(versionOption);
 
-  const versionSelector = getByLabelText('filter OS version') as Element;
-  expect(versionSelector).toBeInTheDocument();
+  const versionSelector = getByRole('button', { name: 'filter OS version' }) as Element;
   await userEvent.click(versionSelector);
 
-  const versionItem = getByRole('menuitem', { name: 'RHEL 7' }) as Element;
-  expect(versionItem).toBeInTheDocument();
-  await userEvent.click(versionItem);
+  const majorVersionItem = queryByText('RHEL 8') as Element;
+  expect(majorVersionItem).toBeInTheDocument();
+  await userEvent.click(majorVersionItem);
+
+  const minorVersionItem = queryByText('RHEL 9.4') as Element;
+  expect(minorVersionItem).toBeInTheDocument();
+  await userEvent.click(minorVersionItem);
+
+  await userEvent.click(optionMenu);
+
+  // Select a release stream item
+  const streamOption = getByRole('menuitem', { name: 'Release stream' });
+  expect(streamOption).toBeInTheDocument();
+  await userEvent.click(streamOption);
+
+  const streamSelector = getByRole('button', { name: 'filter stream' }) as Element;
+  await userEvent.click(streamSelector);
+
+  const streamItem = queryByText('Standard') as Element;
+  expect(streamItem).toBeInTheDocument();
+  await userEvent.click(streamItem);
 
   await userEvent.click(optionMenu);
 
@@ -93,7 +113,9 @@ it('Select a filter of each type and ensure chips are present ContentListFilters
   await userEvent.click(archItem);
 
   // Check all the chips are there
-  expect(queryByText('RHEL 7')).toBeInTheDocument();
-  expect(queryAllByText('aarch64')).toHaveLength(3);
   expect(queryByText('EPEL')).toBeInTheDocument();
+  expect(queryByText('RHEL 8')).toBeInTheDocument();
+  expect(queryByText('RHEL 9.4')).toBeInTheDocument();
+  expect(queryByText('Standard')).toBeInTheDocument();
+  expect(queryAllByText('aarch64')).toHaveLength(3); // aarch64 displayed in the filter dropdown, the filter label, and the filter chip
 });

--- a/src/Pages/Templates/TemplatesTable/components/TemplateFilters.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/TemplateFilters.tsx
@@ -12,11 +12,13 @@ import {
   MenuToggle,
   DropdownList,
   DropdownItem,
+  TreeView,
+  TreeViewDataItem,
 } from '@patternfly/react-core';
 
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import Hide from 'components/Hide/Hide';
-import { RepositoryParamsResponse } from 'services/Content/ContentApi';
+import { NameLabel, RepositoryParamsResponse } from 'services/Content/ContentApi';
 import { useQueryClient } from '@tanstack/react-query';
 import { REPOSITORY_PARAMS_KEY } from 'services/Content/ContentQueries';
 import useDebounce from 'Hooks/useDebounce';
@@ -26,6 +28,8 @@ import { useAppContext } from 'middleware/AppContext';
 import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip';
 import { useNavigate } from 'react-router-dom';
 import { TemplateFilterData } from 'services/Templates/TemplateApi';
+import { STANDARD_STREAM } from '../constants';
+
 interface Props {
   isLoading?: boolean;
   setFilterData: (filterData: TemplateFilterData) => void;
@@ -46,7 +50,7 @@ const useStyles = createUseStyles({
   },
 });
 
-export type Filters = 'Name' | 'OS version' | 'Architecture';
+export type Filters = 'Name' | 'OS version' | 'Architecture' | 'Release stream';
 
 const Filters = ({ isLoading, setFilterData, filterData }: Props) => {
   const classes = useStyles();
@@ -55,16 +59,22 @@ const Filters = ({ isLoading, setFilterData, filterData }: Props) => {
   const navigate = useNavigate();
   const [isActionOpen, setActionOpen] = useState(false);
   const [typeFilterOpen, setTypeFilterOpen] = useState(false);
-  const filters = ['Name', 'OS version', 'Architecture'];
+  const filters = ['Name', 'OS version', 'Architecture', 'Release stream'];
   const [filterType, setFilterType] = useState<Filters>('Name');
   const [versionNamesLabels, setVersionNamesLabels] = useState({});
   const [archNamesLabels, setArchNamesLabels] = useState({});
+  const [streamNamesLabels, setStreamNamesLabels] = useState({});
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedVersion, setSelectedVersion] = useState<string>('');
   const [selectedArch, setSelectedArch] = useState<string>('');
+  const [selectedStreams, setSelectedStreams] = useState<string[]>([]);
+  const [selectedVersions, setSelectedVersions] = useState<string[]>([]);
 
-  const { distribution_arches = [], distribution_versions = [] } =
-    queryClient.getQueryData<RepositoryParamsResponse>([REPOSITORY_PARAMS_KEY]) || {};
+  const {
+    distribution_arches = [],
+    distribution_versions = [],
+    distribution_minor_versions = [],
+    extended_release_streams = [],
+  } = queryClient.getQueryData<RepositoryParamsResponse>([REPOSITORY_PARAMS_KEY]) || {};
 
   const hasRHELSubscription = !!subscriptions?.red_hat_enterprise_linux;
   const isMissingRequirements = !rbac?.templateWrite || !hasRHELSubscription;
@@ -73,30 +83,63 @@ const Filters = ({ isLoading, setFilterData, filterData }: Props) => {
 
   const clearFilters = () => {
     setSearchQuery('');
-    setSelectedVersion('');
     setSelectedArch('');
-    setFilterData({ search: '', version: '', arch: '', repository_uuids: '', snapshot_uuids: '' });
+    setSelectedStreams([]);
+    setSelectedVersions([]);
+    setFilterData({
+      search: '',
+      version: [],
+      extended_release_version: [],
+      arch: '',
+      repository_uuids: '',
+      snapshot_uuids: '',
+      extended_release: [],
+    });
   };
 
   useEffect(() => {
     // If the filters get cleared at the top level, sense that and clear them here.
-    if (!filterData.arch && !filterData.version && !filterData.search) {
+    if (
+      !filterData.arch &&
+      filterData.version.length === 0 &&
+      !filterData.search &&
+      filterData.extended_release.length === 0
+    ) {
       clearFilters();
     }
-  }, [filterData.arch, filterData.version, filterData.search]);
+  }, [
+    filterData.arch,
+    filterData.version.length,
+    filterData.search,
+    filterData.extended_release.length,
+  ]);
 
   const {
     searchQuery: debouncedSearchQuery,
-    selectedVersion: debouncedSelectedVersion,
     selectedArch: debouncedSelectedArch,
+    selectedStreams: debouncedSelectedStreams,
+    selectedVersions: debouncedSelectedVersions,
   } = useDebounce({
     searchQuery,
-    selectedVersion,
     selectedArch,
+    selectedStreams,
+    selectedVersions,
   });
 
-  const getLabels = (type: 'arch' | 'version', name: string): string => {
-    const namesLabels = type === 'arch' ? distribution_arches : distribution_versions;
+  const getLabels = (type: 'arch' | 'version' | 'extended_release', name: string): string => {
+    if (type === 'extended_release' && name === STANDARD_STREAM.name) {
+      return 'none';
+    }
+
+    let namesLabels: NameLabel[];
+    if (type === 'arch') {
+      namesLabels = distribution_arches;
+    } else if (type === 'version') {
+      namesLabels = [...distribution_versions, ...distribution_minor_versions];
+    } else {
+      namesLabels = extended_release_streams;
+    }
+
     const found = namesLabels.find((v) => v.name === name);
     if (found) {
       return found.label;
@@ -107,28 +150,135 @@ const Filters = ({ isLoading, setFilterData, filterData }: Props) => {
   useEffect(() => {
     setFilterData({
       search: debouncedSearchQuery,
-      version: getLabels('version', debouncedSelectedVersion),
+      version: debouncedSelectedVersions.map((version) => getLabels('version', version)),
       arch: getLabels('arch', debouncedSelectedArch),
+      extended_release_version: [],
       repository_uuids: '',
       snapshot_uuids: '',
+      extended_release: debouncedSelectedStreams.map((stream) =>
+        getLabels('extended_release', stream),
+      ),
     });
-  }, [debouncedSearchQuery, debouncedSelectedVersion, debouncedSelectedArch]);
+  }, [
+    debouncedSearchQuery,
+    debouncedSelectedArch,
+    debouncedSelectedStreams,
+    debouncedSelectedVersions,
+  ]);
 
   useEffect(() => {
-    if (
-      isEmpty(versionNamesLabels) &&
-      isEmpty(archNamesLabels) &&
-      distribution_arches.length !== 0 &&
-      distribution_versions.length !== 0
-    ) {
+    if (isEmpty(archNamesLabels) && distribution_arches.length !== 0) {
       const arches = {};
-      const versions = {};
       distribution_arches.forEach((arch) => (arches[arch.name] = arch.label));
-      distribution_versions.forEach((version) => (versions[version.name] = version.label));
-      setVersionNamesLabels(versions);
       setArchNamesLabels(arches);
     }
-  }, [distribution_arches, distribution_versions]);
+
+    if (
+      isEmpty(versionNamesLabels) &&
+      (distribution_versions.length !== 0 || distribution_minor_versions.length !== 0)
+    ) {
+      const versions = {};
+      distribution_versions.forEach((major) => {
+        versions[major.name] = major.label;
+      });
+      distribution_minor_versions.forEach((minor) => {
+        versions[minor.name] = minor.label;
+      });
+      setVersionNamesLabels(versions);
+    }
+
+    if (isEmpty(streamNamesLabels) && extended_release_streams.length !== 0) {
+      const streams = {};
+      extended_release_streams.forEach((stream) => (streams[stream.name] = stream.label));
+      streams[STANDARD_STREAM.name] = STANDARD_STREAM.label;
+      setStreamNamesLabels(streams);
+    }
+  }, [
+    distribution_arches,
+    distribution_versions,
+    distribution_minor_versions,
+    extended_release_streams,
+    archNamesLabels,
+    streamNamesLabels,
+    versionNamesLabels,
+  ]);
+
+  const versionGroups = useMemo(
+    () =>
+      distribution_versions
+        .filter((major) => major.name !== 'Any' && major.name !== 'RHEL 7')
+        .reverse()
+        .map((major) => ({
+          majorName: major.name,
+          group: `${major.name}.x`,
+          minors: distribution_minor_versions
+            .filter((minor) => minor.major === major.label)
+            .map((minor) => ({
+              minorName: minor.name,
+            })),
+        })),
+    [distribution_versions, distribution_minor_versions],
+  );
+
+  const versionTree = useMemo<TreeViewDataItem[]>(
+    () =>
+      versionGroups.flatMap((group) => [
+        {
+          id: group.majorName,
+          name: group.majorName,
+          checkProps: {
+            checked: selectedVersions.includes(group.majorName),
+          },
+        },
+        {
+          id: group.group,
+          name: group.group,
+          checkProps: {
+            checked:
+              group.minors.length > 0 &&
+              group.minors.every((minor) => selectedVersions.includes(minor.minorName)),
+          },
+          children: group.minors.map((minor) => ({
+            id: minor.minorName,
+            name: minor.minorName,
+            checkProps: {
+              checked: selectedVersions.includes(minor.minorName),
+            },
+          })),
+          defaultExpanded: true,
+        },
+      ]),
+    [versionGroups, selectedVersions],
+  );
+
+  const onVersionCheck = (event: React.ChangeEvent, item: TreeViewDataItem) => {
+    const checked = (event?.target as HTMLInputElement).checked;
+    const itemID = item.id as string; // RHEL 8, RHEL 8.x, RHEL 8.8 etc
+
+    // if selected item is a parent (e.g. RHEL 8.x), either add or remove all minors in its group
+    const group = versionGroups.find((g) => g.group === itemID);
+    if (group) {
+      const minors = group.minors.map((minor) => minor.minorName);
+      setSelectedVersions((prev) => {
+        if (checked) {
+          return [...new Set([...prev, ...minors])];
+        }
+        return prev.filter((value) => !minors.includes(value));
+      });
+      return;
+    }
+
+    // otherwise just add or remove item
+    setSelectedVersions((prev) => {
+      if (checked) {
+        if (prev.includes(itemID)) {
+          return prev;
+        }
+        return [...new Set([...prev, itemID])];
+      }
+      return prev.filter((item) => item !== itemID);
+    });
+  };
 
   const Filter = useMemo(() => {
     switch (filterType) {
@@ -150,10 +300,6 @@ const Filters = ({ isLoading, setFilterData, filterData }: Props) => {
       case 'OS version':
         return (
           <Dropdown
-            onSelect={(_, val) => {
-              setSelectedVersion(val as string);
-              setActionOpen(false);
-            }}
             toggle={(toggleRef) => (
               <MenuToggle
                 ref={toggleRef}
@@ -164,27 +310,16 @@ const Filters = ({ isLoading, setFilterData, filterData }: Props) => {
                 isDisabled={isLoading}
                 isExpanded={isActionOpen}
               >
-                {selectedVersion || 'Filter by OS version'}
+                Filter by OS version
               </MenuToggle>
             )}
             onOpenChange={(isOpen) => setActionOpen(isOpen)}
             isOpen={isActionOpen}
           >
-            <DropdownList>
-              {Object.keys(versionNamesLabels).map((version) => (
-                <DropdownItem
-                  key={version}
-                  value={version}
-                  isSelected={selectedVersion === version}
-                  component='button'
-                  data-ouia-component-id={`filter_${version}`}
-                >
-                  {version}
-                </DropdownItem>
-              ))}
-            </DropdownList>
+            <TreeView data={versionTree} onCheck={onVersionCheck} hasCheckboxes />
           </Dropdown>
         );
+
       case 'Architecture':
         return (
           <Dropdown
@@ -223,6 +358,48 @@ const Filters = ({ isLoading, setFilterData, filterData }: Props) => {
             </DropdownList>
           </Dropdown>
         );
+      case 'Release stream':
+        return (
+          <Dropdown
+            onSelect={(_, val) => {
+              setSelectedStreams((prev) =>
+                prev.includes(val as string)
+                  ? prev.filter((item) => item !== (val as string))
+                  : [...new Set([...prev, val as string])],
+              );
+            }}
+            toggle={(toggleRef) => (
+              <MenuToggle
+                ref={toggleRef}
+                aria-label='filter stream'
+                id='streamSelect'
+                ouiaId='filter_by_stream'
+                onClick={() => setActionOpen((prev) => !prev)}
+                isDisabled={isLoading}
+                isExpanded={isActionOpen}
+              >
+                Filter by release stream
+              </MenuToggle>
+            )}
+            onOpenChange={(isOpen) => setActionOpen(isOpen)}
+            isOpen={isActionOpen}
+          >
+            <DropdownList>
+              {Object.keys(streamNamesLabels).map((stream) => (
+                <DropdownItem
+                  key={`stream_${stream}`}
+                  value={stream}
+                  isSelected={selectedStreams.includes(stream)}
+                  component='button'
+                  data-ouia-component-id={`filter_${stream}`}
+                  hasCheckbox
+                >
+                  {stream}
+                </DropdownItem>
+              ))}
+            </DropdownList>
+          </Dropdown>
+        );
       default:
         return <></>;
     }
@@ -230,11 +407,13 @@ const Filters = ({ isLoading, setFilterData, filterData }: Props) => {
     filterType,
     isLoading,
     searchQuery,
-    versionNamesLabels,
-    selectedVersion,
     archNamesLabels,
     selectedArch,
     isActionOpen,
+    selectedStreams,
+    streamNamesLabels,
+    selectedVersions,
+    versionGroups,
   ]);
 
   return (
@@ -322,38 +501,78 @@ const Filters = ({ isLoading, setFilterData, filterData }: Props) => {
         </ConditionalTooltip> */}
         </FlexItem>
       </Flex>
-      <Hide hide={!(selectedVersion || selectedArch || searchQuery)}>
+      <Hide
+        hide={
+          !(
+            selectedArch ||
+            searchQuery ||
+            selectedStreams?.length > 0 ||
+            selectedVersions?.length > 0
+          )
+        }
+      >
         <FlexItem className={classes.chipsContainer}>
-          {selectedVersion ? (
-            <LabelGroup categoryName='OS version'>
-              <Label variant='outline' key={selectedVersion} onClose={() => setSelectedVersion('')}>
-                {selectedVersion}
-              </Label>
-            </LabelGroup>
-          ) : (
-            <></>
-          )}
-          {selectedArch ? (
-            <LabelGroup categoryName='Architecture'>
-              <Label variant='outline' key={selectedArch} onClose={() => setSelectedArch('')}>
-                {selectedArch}
-              </Label>
-            </LabelGroup>
-          ) : (
-            <></>
-          )}
-          {searchQuery && (
-            <LabelGroup categoryName='Name'>
-              <Label variant='outline' key='name_chip' onClose={() => setSearchQuery('')}>
-                {searchQuery}
-              </Label>
-            </LabelGroup>
-          )}
-          {((debouncedSearchQuery && searchQuery) || !!selectedVersion || !!selectedArch) && (
-            <Button className={classes.clearFilters} onClick={clearFilters} variant='link' isInline>
-              Clear filters
-            </Button>
-          )}
+          <Flex gap={{ default: 'gapSm' }} flexWrap={{ default: 'wrap' }}>
+            {selectedVersions.length > 0 && (
+              <LabelGroup categoryName='OS version'>
+                {selectedVersions.map((version) => (
+                  <Label
+                    variant='filled'
+                    key={version}
+                    onClose={() => {
+                      setSelectedVersions((prev) => prev.filter((item) => item !== version));
+                    }}
+                  >
+                    {version}
+                  </Label>
+                ))}
+              </LabelGroup>
+            )}
+            {selectedArch ? (
+              <LabelGroup categoryName='Architecture'>
+                <Label variant='filled' key={selectedArch} onClose={() => setSelectedArch('')}>
+                  {selectedArch}
+                </Label>
+              </LabelGroup>
+            ) : (
+              <></>
+            )}
+            {searchQuery && (
+              <LabelGroup categoryName='Name'>
+                <Label variant='filled' key='name_chip' onClose={() => setSearchQuery('')}>
+                  {searchQuery}
+                </Label>
+              </LabelGroup>
+            )}
+            {selectedStreams.length > 0 && (
+              <LabelGroup categoryName='Release stream'>
+                {selectedStreams.map((stream) => (
+                  <Label
+                    variant='filled'
+                    key={stream}
+                    onClose={() => {
+                      setSelectedStreams((prev) => prev.filter((item) => item !== stream));
+                    }}
+                  >
+                    {stream}
+                  </Label>
+                ))}
+              </LabelGroup>
+            )}
+            {((debouncedSearchQuery && searchQuery) ||
+              selectedVersions?.length > 0 ||
+              !!selectedArch ||
+              selectedStreams?.length > 0) && (
+              <Button
+                className={classes.clearFilters}
+                onClick={clearFilters}
+                variant='link'
+                isInline
+              >
+                Clear filters
+              </Button>
+            )}
+          </Flex>
         </FlexItem>
       </Hide>
     </Flex>

--- a/src/services/Templates/TemplateApi.ts
+++ b/src/services/Templates/TemplateApi.ts
@@ -64,10 +64,12 @@ export interface SnapshotRpmCollectionResponse {
 
 export type TemplateFilterData = {
   arch: string;
-  version: string;
+  version: string[];
+  extended_release_version: string[];
   search: string;
   repository_uuids: string;
   snapshot_uuids: string;
+  extended_release: string[];
 };
 
 export const getTemplates: (
@@ -79,18 +81,31 @@ export const getTemplates: (
   page,
   limit,
   sortBy,
-  { search, arch, version, repository_uuids, snapshot_uuids },
+  {
+    search,
+    arch,
+    version,
+    extended_release_version,
+    repository_uuids,
+    snapshot_uuids,
+    extended_release,
+  },
 ) => {
+  const streamParam = extended_release?.join(',').toLowerCase();
+  const minorVersionParam = extended_release_version?.join(',');
+  const majorVersionParam = version?.join(',');
   const { data } = await axios.get(
     `/api/content-sources/v1/templates/?${objectToUrlParams({
       offset: ((page - 1) * limit).toString(),
       limit: limit?.toString(),
       search,
       arch,
-      version,
+      version: majorVersionParam,
+      extended_release_version: minorVersionParam,
       sort_by: sortBy,
       repository_uuids: repository_uuids,
       snapshot_uuids: snapshot_uuids,
+      extended_release: streamParam,
     })}`,
   );
   return data;


### PR DESCRIPTION
## Summary

- Adds minor OS version data to the templates table
- Release stream is added as a label next to the template name
- Adds support for filtering templates by multiple major and minor versions
- Adds support for filtering templates by release streams
  
<img width="1575" height="694" alt="Screenshot From 2026-04-21 11-46-03" src="https://github.com/user-attachments/assets/870f7b59-e184-4ca8-8569-b40f0da15648" />
<br>
<img width="1581" height="527" alt="Screenshot From 2026-04-21 11-46-41" src="https://github.com/user-attachments/assets/abedc925-e5c0-4fec-962b-2bf6e607b0dd" />


## Testing steps

1. Create templates of various OS versions and release streams. These values should be shown correctly in the OS version column and in a label next to the template name
2. Filtering by minor and major OS versions should work as expected
3. Filtering by release stream should work as expected
4. Tests pass