### PR TITLE
Test: update GitHub Actions to be Node 24 compatible

### DIFF
--- a/.github/workflows/content-sources-actions.yml
+++ b/.github/workflows/content-sources-actions.yml
@@ -1,7 +1,7 @@
 name: Build & Unit Tests
 on:
   pull_request:
-    branches: [main, prod-beta, prod-stable]
+    branches: [ main, prod-beta, prod-stable ]
     paths-ignore:
       - '**.md'
       - '.github/workflows/playwright-actions.yml'
@@ -30,7 +30,7 @@ jobs:
 
       - name: Cache - node_modules
         if: always()
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -65,7 +65,7 @@ jobs:
 
       - name: Cache - node_modules
         if: always()
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -100,7 +100,7 @@ jobs:
 
       - name: Cache - node_modules
         if: always()
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -159,7 +159,7 @@ jobs:
 
       - name: Cache - node_modules
         if: always()
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules

--- a/.github/workflows/nightly-prod-test-action.yml
+++ b/.github/workflows/nightly-prod-test-action.yml
@@ -32,7 +32,7 @@ jobs:
         run: git submodule update
 
       - name: Cache - node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -79,7 +79,7 @@ jobs:
         if: ${{ !cancelled() }}
 
       - name: Store report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/nightly-stage-test-action.yml
+++ b/.github/workflows/nightly-stage-test-action.yml
@@ -1,7 +1,7 @@
 name: 'E2E tests: Stage'
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    types: [ opened, reopened, synchronize, labeled, unlabeled ]
 
   schedule:
     - cron: '0 0 * * *' # This cron expression runs the action every 24 hours at midnight UTC
@@ -30,7 +30,7 @@ jobs:
         uses: ./.github/actions/sparse-checkout-utils
 
       - name: Cache - node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -137,7 +137,7 @@ jobs:
         if: ${{ !cancelled() }}
 
       - name: Store report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/playwright-actions.yml
+++ b/.github/workflows/playwright-actions.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Resolve PR head for comment trigger
         id: pr-ref
         if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { data: pr } = await github.rest.pulls.get({
@@ -133,7 +133,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Cache - node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -142,7 +142,7 @@ jobs:
           restore-keys: ${{ runner.os }}-frontend-node-modules-
 
       - name: Cache - Backend compose files
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: content-sources-backend/release
           key: ${{ runner.os }}-compose-${{ hashFiles('content-sources-backend/compose_files/pulp/docker-compose.yml') }}-${{ hashFiles('content_sources_backend/compose_files/candlepin/Dockerfile') }}
@@ -169,9 +169,10 @@ jobs:
           echo "go-version=$GO_VERSION" >> $GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '${{ steps.get-go-version.outputs.go-version }}'
+          cache: false
 
       - name: Update /etc/hosts
         run: sudo npm run patch:hosts
@@ -231,7 +232,7 @@ jobs:
           report-path: './playwright-ctrf/playwright-ctrf.json'
 
       - name: Store front-end Test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report
           path: playwright-report/


### PR DESCRIPTION
## Summary

Disables `setup-go` built-in caching to prevent cache misses. Its cache key relies on `ImageOS`, which fluctuates across our ephemeral CodeBuild EC2 instances. Our custom `actions/cache` steps (e.g., Node) are unaffected because they rely on stable keys

<img width="1360" height="281" alt="image" src="https://github.com/user-attachments/assets/99bf0e55-9f3a-41c4-9271-241a079a3310" />

---

Updates GitHub Actions to Node 24 compatible versions to resolve deprecation warnings in test logs. They require GitHub Actions runner ≥2.327.1. Confirmed our AWS CodeBuild `standard:7.0` image meets this requirement

- **actions/cache**: v4 → v5
- **actions/setup-go**: v5 → v6
- **actions/github-script**: v7 → v9
- **actions/upload-artifact**: v4 → v6

<img width="1339" height="375" alt="image" src="https://github.com/user-attachments/assets/588b5f74-5527-4f79-90d1-1cfa95a84482" />

## Note
**Why we're still seeing the Node 20 deprecation warning?** One of our third-party GitHub Actions _deepakputhraya/action-pr-title_ still uses Node 20. We're waiting for the official fix
