### PR TITLE
HMS-10144: Improve code coverage for Repositories/ContentListTable

### DIFF
--- a/_playwright-tests/Integration/UseSnapshotConfig.spec.ts
+++ b/_playwright-tests/Integration/UseSnapshotConfig.spec.ts
@@ -47,10 +47,9 @@ test.describe('Use Snapshot Config', () => {
       const snapshotsTable = snapshotsModal.getByRole('grid', { name: 'snapshot list table' });
       const firstSnapshotRow = snapshotsTable.locator('tbody tr').first();
 
-      // Find the copy button within the first row's config column
-      const copy_to_clipboard_button = firstSnapshotRow
-        .getByRole('button')
-        .and(firstSnapshotRow.locator('[label="repo_config_file_copy_button"]'));
+      const copy_to_clipboard_button = firstSnapshotRow.getByRole('button', {
+        name: 'Copy repository config',
+      });
       await copy_to_clipboard_button.click();
 
       let clipboardText = '';
@@ -61,10 +60,9 @@ test.describe('Use Snapshot Config', () => {
         })
         .not.toBe('');
 
-      // Find the download button within the first row's config column
-      const download_button = firstSnapshotRow
-        .getByRole('button')
-        .and(firstSnapshotRow.locator('[label="repo_config_file_download_button"]'));
+      const download_button = firstSnapshotRow.getByRole('button', {
+        name: 'Download repository config',
+      });
       const [download] = await Promise.all([
         page.waitForEvent('download'), // Wait for the download event
         download_button.click(),

--- a/_playwright-tests/UI/SnapshotErrataCountAndFilter.spec.ts
+++ b/_playwright-tests/UI/SnapshotErrataCountAndFilter.spec.ts
@@ -216,7 +216,7 @@ test.describe('Snapshot Errata Count and Filter', () => {
       const snapshotDetailModal = page.getByRole('dialog', { name: 'Snapshot detail' });
       await snapshotDetailModal
         .getByRole('contentinfo')
-        .getByRole('button', { name: 'Close' })
+        .getByRole('button', { name: 'Close snapshot detail' })
         .click();
       await expect(snapshotDetailModal).toBeHidden();
     });

--- a/src/Pages/Repositories/ContentListTable/components/AddContent/components/ContentValidity.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/components/ContentValidity.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import ContentValidity from './ContentValidity';
+
+describe('ContentValidity', () => {
+  it('shows a spinner while loading', () => {
+    const { container } = render(<ContentValidity loading />);
+
+    expect(container.querySelector('.pf-v6-c-spinner')).toBeInTheDocument();
+  });
+
+  it('shows Valid when required fields are touched and there are no errors', () => {
+    render(
+      <ContentValidity
+        touched={{ name: true, url: true }}
+        errors={{ name: undefined, url: undefined }}
+      />,
+    );
+
+    expect(screen.getByText('Valid')).toBeInTheDocument();
+  });
+
+  it('shows Invalid when a touched field has an error', () => {
+    render(
+      <ContentValidity
+        touched={{ name: true, url: true }}
+        errors={{ name: 'Required', url: undefined }}
+      />,
+    );
+
+    expect(screen.getByText('Invalid')).toBeInTheDocument();
+  });
+
+  it('renders nothing by default', () => {
+    const { container } = render(<ContentValidity />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/Pages/Repositories/ContentListTable/components/ContentOriginFilter.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/ContentOriginFilter.test.tsx
@@ -43,7 +43,7 @@ describe('ContentOriginFilter', () => {
       />,
     );
 
-    await user.click(screen.getByText('Custom'));
+    await user.click(screen.getByRole('button', { name: 'Custom' }));
 
     expect(setContentOrigin).toHaveBeenCalled();
     const updater = setContentOrigin.mock.calls[0][0] as (prev: ContentOrigin[]) => ContentOrigin[];
@@ -63,7 +63,7 @@ describe('ContentOriginFilter', () => {
       />,
     );
 
-    await user.click(screen.getByText('Custom'));
+    await user.click(screen.getByRole('button', { name: 'Custom' }));
 
     const updater = setContentOrigin.mock.calls[0][0] as (prev: ContentOrigin[]) => ContentOrigin[];
     expect(updater([ContentOrigin.EXTERNAL, ContentOrigin.UPLOAD, ContentOrigin.REDHAT])).toEqual([
@@ -79,7 +79,7 @@ describe('ContentOriginFilter', () => {
       <ContentOriginFilter contentOrigin={[]} setContentOrigin={setContentOrigin} />,
     );
 
-    await user.click(screen.getByText('Red Hat'));
+    await user.click(screen.getByRole('button', { name: 'Red Hat' }));
 
     let updater = setContentOrigin.mock.calls[0][0] as (prev: ContentOrigin[]) => ContentOrigin[];
     expect(updater([])).toEqual([ContentOrigin.REDHAT]);
@@ -93,7 +93,7 @@ describe('ContentOriginFilter', () => {
       />,
     );
 
-    await user.click(screen.getByText('Red Hat'));
+    await user.click(screen.getByRole('button', { name: 'Red Hat' }));
 
     updater = setContentOrigin.mock.calls[0][0] as (prev: ContentOrigin[]) => ContentOrigin[];
     expect(updater([ContentOrigin.REDHAT])).toEqual([]);
@@ -109,7 +109,7 @@ describe('ContentOriginFilter', () => {
 
     render(<ContentOriginFilter contentOrigin={[]} setContentOrigin={setContentOrigin} />);
 
-    await user.click(screen.getByText('EPEL'));
+    await user.click(screen.getByRole('button', { name: 'EPEL' }));
 
     const addCommunity = setContentOrigin.mock.calls[0][0] as (
       prev: ContentOrigin[],

--- a/src/Pages/Repositories/ContentListTable/components/ContentOriginFilter.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/ContentOriginFilter.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ContentOriginFilter from './ContentOriginFilter';
+import { ContentOrigin } from 'services/Content/ContentApi';
+import { useAppContext } from 'middleware/AppContext';
+
+jest.mock('middleware/AppContext', () => ({
+  useAppContext: jest.fn(),
+}));
+
+const defaultFeatures = {
+  snapshots: { accessible: true },
+  communityrepos: { enabled: false },
+};
+
+describe('ContentOriginFilter', () => {
+  beforeEach(() => {
+    (useAppContext as jest.Mock).mockReturnValue({
+      features: defaultFeatures,
+    });
+  });
+
+  it('renders nothing when snapshots are not accessible', () => {
+    (useAppContext as jest.Mock).mockReturnValue({
+      features: { snapshots: { accessible: false } },
+    });
+
+    const { container } = render(
+      <ContentOriginFilter contentOrigin={[]} setContentOrigin={jest.fn()} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('adds external and upload origins when Custom is turned on', async () => {
+    const user = userEvent.setup();
+    const setContentOrigin = jest.fn();
+
+    render(
+      <ContentOriginFilter
+        contentOrigin={[ContentOrigin.REDHAT]}
+        setContentOrigin={setContentOrigin}
+      />,
+    );
+
+    await user.click(screen.getByText('Custom'));
+
+    expect(setContentOrigin).toHaveBeenCalled();
+    const updater = setContentOrigin.mock.calls[0][0] as (prev: ContentOrigin[]) => ContentOrigin[];
+    expect(updater([ContentOrigin.REDHAT])).toEqual(
+      expect.arrayContaining([ContentOrigin.EXTERNAL, ContentOrigin.UPLOAD, ContentOrigin.REDHAT]),
+    );
+  });
+
+  it('removes external and upload origins when Custom is turned off', async () => {
+    const user = userEvent.setup();
+    const setContentOrigin = jest.fn();
+
+    render(
+      <ContentOriginFilter
+        contentOrigin={[ContentOrigin.EXTERNAL, ContentOrigin.UPLOAD, ContentOrigin.REDHAT]}
+        setContentOrigin={setContentOrigin}
+      />,
+    );
+
+    await user.click(screen.getByText('Custom'));
+
+    const updater = setContentOrigin.mock.calls[0][0] as (prev: ContentOrigin[]) => ContentOrigin[];
+    expect(updater([ContentOrigin.EXTERNAL, ContentOrigin.UPLOAD, ContentOrigin.REDHAT])).toEqual([
+      ContentOrigin.REDHAT,
+    ]);
+  });
+
+  it('toggles Red Hat origin', async () => {
+    const user = userEvent.setup();
+    const setContentOrigin = jest.fn();
+
+    const { rerender } = render(
+      <ContentOriginFilter contentOrigin={[]} setContentOrigin={setContentOrigin} />,
+    );
+
+    await user.click(screen.getByText('Red Hat'));
+
+    let updater = setContentOrigin.mock.calls[0][0] as (prev: ContentOrigin[]) => ContentOrigin[];
+    expect(updater([])).toEqual([ContentOrigin.REDHAT]);
+
+    setContentOrigin.mockClear();
+
+    rerender(
+      <ContentOriginFilter
+        contentOrigin={[ContentOrigin.REDHAT]}
+        setContentOrigin={setContentOrigin}
+      />,
+    );
+
+    await user.click(screen.getByText('Red Hat'));
+
+    updater = setContentOrigin.mock.calls[0][0] as (prev: ContentOrigin[]) => ContentOrigin[];
+    expect(updater([ContentOrigin.REDHAT])).toEqual([]);
+  });
+
+  it('toggles EPEL when community repositories are enabled', async () => {
+    const user = userEvent.setup();
+    const setContentOrigin = jest.fn();
+
+    (useAppContext as jest.Mock).mockReturnValue({
+      features: { ...defaultFeatures, communityrepos: { enabled: true } },
+    });
+
+    render(<ContentOriginFilter contentOrigin={[]} setContentOrigin={setContentOrigin} />);
+
+    await user.click(screen.getByText('EPEL'));
+
+    const addCommunity = setContentOrigin.mock.calls[0][0] as (
+      prev: ContentOrigin[],
+    ) => ContentOrigin[];
+    expect(addCommunity([])).toEqual([ContentOrigin.COMMUNITY]);
+  });
+});

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SnapshotDetailsModal, { SnapshotDetailTab } from './SnapshotDetailsModal';
+import { useAppContext } from 'middleware/AppContext';
+import { ContentOrigin } from 'services/Content/ContentApi';
+
+const mockNavigate = jest.fn();
+const mockSetSearchParams = jest.fn();
+
+jest.mock('./Tabs/SnapshotPackagesTab', () => ({
+  SnapshotPackagesTab: () => <div>Packages tab body</div>,
+}));
+
+jest.mock('./Tabs/SnapshotErrataTab', () => ({
+  SnapshotErrataTab: () => <div>Errata tab body</div>,
+}));
+
+jest.mock('./SnapshotSelector', () => ({
+  SnapshotSelector: () => <div>Snapshot selector</div>,
+}));
+
+jest.mock('middleware/AppContext', () => ({
+  useAppContext: jest.fn(),
+}));
+
+jest.mock('Hooks/useRootPath', () => () => '/app');
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ repoUUID: 'repo-uuid', snapshotUUID: 'snap-uuid' }),
+  useSearchParams: () => {
+    const params = new URLSearchParams(window.location.search);
+    return [params, mockSetSearchParams];
+  },
+}));
+
+describe('SnapshotDetailsModal', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockSetSearchParams.mockClear();
+    window.history.replaceState({}, '', '/');
+    (useAppContext as jest.Mock).mockReturnValue({
+      contentOrigin: [],
+    });
+  });
+
+  const clickModalClose = async (user: ReturnType<typeof userEvent.setup>) => {
+    const dialog = screen.getByRole('dialog');
+    const [headerClose] = within(dialog).getAllByRole('button', { name: 'Close' });
+    await user.click(headerClose);
+  };
+
+  it('navigates back to repositories on close without origin query by default', async () => {
+    const user = userEvent.setup();
+
+    render(<SnapshotDetailsModal />);
+
+    await clickModalClose(user);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/app/repositories');
+  });
+
+  it('appends origin query when only Red Hat is selected', async () => {
+    const user = userEvent.setup();
+    (useAppContext as jest.Mock).mockReturnValue({
+      contentOrigin: [ContentOrigin.REDHAT],
+    });
+
+    render(<SnapshotDetailsModal />);
+
+    await clickModalClose(user);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/app/repositories?origin=red_hat');
+  });
+
+  it('navigates to snapshots list when View all snapshots is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(<SnapshotDetailsModal />);
+
+    await user.click(screen.getByRole('button', { name: 'View all snapshots' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/app/repositories/repo-uuid/snapshots');
+  });
+
+  it('syncs errata tab from search params on mount', async () => {
+    window.history.replaceState({}, '', `/?tab=${SnapshotDetailTab.ERRATA}`);
+
+    render(<SnapshotDetailsModal />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Errata tab body')).toBeInTheDocument();
+    });
+  });
+
+  it('updates search params when switching tabs', async () => {
+    const user = userEvent.setup();
+
+    render(<SnapshotDetailsModal />);
+
+    await user.click(screen.getByRole('tab', { name: 'Snapshot errata detail tab' }));
+
+    expect(mockSetSearchParams).toHaveBeenCalledWith({ tab: SnapshotDetailTab.ERRATA });
+  });
+});

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.test.tsx
@@ -44,10 +44,10 @@ describe('SnapshotDetailsModal', () => {
     });
   });
 
-  const clickModalClose = async (user: ReturnType<typeof userEvent.setup>) => {
+  const clickModalHeaderClose = async (user: ReturnType<typeof userEvent.setup>) => {
     const dialog = screen.getByRole('dialog');
-    const [headerClose] = within(dialog).getAllByRole('button', { name: 'Close' });
-    await user.click(headerClose);
+    // Footer uses aria-label "Close snapshot detail"; PatternFly header close stays "Close".
+    await user.click(within(dialog).getByRole('button', { name: 'Close' }));
   };
 
   it('navigates back to repositories on close without origin query by default', async () => {
@@ -55,7 +55,7 @@ describe('SnapshotDetailsModal', () => {
 
     render(<SnapshotDetailsModal />);
 
-    await clickModalClose(user);
+    await clickModalHeaderClose(user);
 
     expect(mockNavigate).toHaveBeenCalledWith('/app/repositories');
   });
@@ -68,7 +68,7 @@ describe('SnapshotDetailsModal', () => {
 
     render(<SnapshotDetailsModal />);
 
-    await clickModalClose(user);
+    await clickModalHeaderClose(user);
 
     expect(mockNavigate).toHaveBeenCalledWith('/app/repositories?origin=red_hat');
   });
@@ -89,7 +89,9 @@ describe('SnapshotDetailsModal', () => {
     render(<SnapshotDetailsModal />);
 
     await waitFor(() => {
-      expect(screen.getByText('Errata tab body')).toBeInTheDocument();
+      expect(
+        screen.getByRole('tabpanel', { name: 'Snapshot errata detail tab' }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.tsx
@@ -118,7 +118,12 @@ export default function SnapshotDetailsModal() {
         </Stack>
       </InnerScrollContainer>
       <ModalFooter>
-        <Button key='close' variant='secondary' onClick={onClose}>
+        <Button
+          key='close'
+          variant='secondary'
+          onClick={onClose}
+          aria-label='Close snapshot detail'
+        >
           Close
         </Button>
       </ModalFooter>

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/components/RepoConfig.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/components/RepoConfig.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RepoConfig from './RepoConfig';
+import { ReactQueryTestWrapper } from 'testingHelpers';
+import {
+  useGetLatestRepoConfigFileQuery,
+  useGetRepoConfigFileQuery,
+} from 'services/Content/ContentQueries';
+
+jest.mock('services/Content/ContentQueries', () => ({
+  useGetRepoConfigFileQuery: jest.fn(),
+  useGetLatestRepoConfigFileQuery: jest.fn(),
+}));
+
+describe('RepoConfig', () => {
+  beforeEach(() => {
+    (useGetRepoConfigFileQuery as jest.Mock).mockReturnValue({
+      mutateAsync: jest.fn().mockResolvedValue('snapshot-repo-config'),
+    });
+    (useGetLatestRepoConfigFileQuery as jest.Mock).mockReturnValue({
+      mutateAsync: jest.fn().mockResolvedValue('latest-repo-config'),
+    });
+  });
+
+  it('uses latest snapshot query when latest is true', async () => {
+    const user = userEvent.setup();
+    const latestMutate = jest.fn().mockResolvedValue('cfg');
+    (useGetLatestRepoConfigFileQuery as jest.Mock).mockReturnValue({ mutateAsync: latestMutate });
+
+    render(
+      <ReactQueryTestWrapper>
+        <RepoConfig repoUUID='repo-1' snapUUID='snap-1' latest />
+      </ReactQueryTestWrapper>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Copy repository config' }));
+
+    await waitFor(() => {
+      expect(latestMutate).toHaveBeenCalled();
+    });
+
+    expect(useGetLatestRepoConfigFileQuery).toHaveBeenCalledWith('repo-1');
+  });
+
+  it('uses snapshot-specific query when latest is false', async () => {
+    const user = userEvent.setup();
+    const snapMutate = jest.fn().mockResolvedValue('cfg');
+    (useGetRepoConfigFileQuery as jest.Mock).mockReturnValue({ mutateAsync: snapMutate });
+
+    const createObjectURL = jest.fn(() => 'blob:mock');
+    const originalCreate = global.URL.createObjectURL;
+    global.URL.createObjectURL = createObjectURL;
+
+    const anchorClick = jest
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+
+    render(
+      <ReactQueryTestWrapper>
+        <RepoConfig repoUUID='repo-1' snapUUID='snap-1' latest={false} />
+      </ReactQueryTestWrapper>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Download repository config' }));
+
+    await waitFor(() => {
+      expect(snapMutate).toHaveBeenCalled();
+    });
+
+    expect(useGetRepoConfigFileQuery).toHaveBeenCalledWith('repo-1', 'snap-1');
+    expect(createObjectURL).toHaveBeenCalled();
+
+    anchorClick.mockRestore();
+
+    if (originalCreate) {
+      global.URL.createObjectURL = originalCreate;
+    } else {
+      delete (global.URL as Partial<URL> & { createObjectURL?: unknown }).createObjectURL;
+    }
+  });
+});

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/components/RepoConfig.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/components/RepoConfig.tsx
@@ -57,7 +57,7 @@ const RepoConfig = ({ repoUUID, snapUUID, latest }: Props) => {
             </Icon>
           }
           ouiaId='repo_config_file_copy_button'
-          label='repo_config_file_copy_button'
+          aria-label='Copy repository config'
           variant='link'
           className={classes.link}
           onClick={() => copyConfigFile()}
@@ -72,7 +72,7 @@ const RepoConfig = ({ repoUUID, snapUUID, latest }: Props) => {
             </Icon>
           }
           ouiaId='repo_config_file_download_button'
-          label='repo_config_file_download_button'
+          aria-label='Download repository config'
           variant='link'
           className={classes.link}
           onClick={() => downloadConfigFile()}

--- a/src/Pages/Repositories/ContentListTable/components/UploadContent/components/UploadStatusItem.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/UploadContent/components/UploadStatusItem.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UploadStatusItem from './UploadStatusItem';
+
+describe('UploadStatusItem', () => {
+  it('formats small byte sizes and larger units', () => {
+    const { rerender } = render(
+      <UploadStatusItem fileName='a.txt' progressValue={0} fileSize={500} />,
+    );
+
+    expect(screen.getByText('500B')).toBeInTheDocument();
+
+    rerender(<UploadStatusItem fileName='a.txt' progressValue={0} fileSize={2000} />);
+
+    expect(screen.getByText('2KB')).toBeInTheDocument();
+  });
+
+  it('shows a fallback when the file size exceeds supported units', () => {
+    render(<UploadStatusItem fileName='huge.bin' progressValue={0} fileSize={1e15} />);
+
+    expect(screen.getByText('File size too large')).toBeInTheDocument();
+  });
+
+  it('invokes retry when progress is in danger state', async () => {
+    const user = userEvent.setup();
+    const retry = jest.fn();
+
+    render(
+      <UploadStatusItem
+        fileName='bad.rpm'
+        progressValue={100}
+        progressVariant='danger'
+        retry={retry}
+      />,
+    );
+
+    await user.click(screen.getByText('Retry'));
+
+    expect(retry).toHaveBeenCalled();
+  });
+
+  it('does not show retry when variant is not danger', () => {
+    render(
+      <UploadStatusItem
+        fileName='ok.rpm'
+        progressValue={100}
+        progressVariant='success'
+        retry={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByText('Retry')).not.toBeInTheDocument();
+  });
+});

--- a/src/Pages/Repositories/ContentListTable/components/UploadContent/components/helpers.test.ts
+++ b/src/Pages/Repositories/ContentListTable/components/UploadContent/components/helpers.test.ts
@@ -1,0 +1,33 @@
+import { createHash } from 'crypto';
+import { getFileChecksumSHA256, MAX_CHUNK_SIZE } from './helpers';
+
+describe('UploadContent helpers', () => {
+  it('computes SHA-256 for an empty file', async () => {
+    const file = new File([], 'empty.dat');
+
+    const checksum = await getFileChecksumSHA256(file);
+
+    expect(checksum).toBe(createHash('sha256').update(Buffer.from([])).digest('hex'));
+  });
+
+  it('computes SHA-256 for a small file in one slice', async () => {
+    const content = Buffer.from('hello checksum');
+    const file = new File([content], 'small.txt');
+
+    const checksum = await getFileChecksumSHA256(file);
+
+    expect(checksum).toBe(createHash('sha256').update(Buffer.from(content)).digest('hex'));
+  });
+
+  it('computes SHA-256 for a file larger than MAX_CHUNK_SIZE', async () => {
+    const size = MAX_CHUNK_SIZE + 1024;
+    const buffer = new Uint8Array(size);
+    buffer[0] = 7;
+    buffer[size - 1] = 9;
+    const file = new File([buffer], 'large.bin');
+
+    const checksum = await getFileChecksumSHA256(file);
+
+    expect(checksum).toBe(createHash('sha256').update(Buffer.from(buffer)).digest('hex'));
+  });
+});


### PR DESCRIPTION
## Summary

Update Repositories ContentListTable unit test coverage

Update locators in UseSnapshotConfig

HMS-10144: [QE] Improve code coverage for Repositories/ContentListTable

## Testing steps

1] All tests must pass

2] Run this command on main and then this branch and compare the results:

```
yarn jest --coverage \
  --collectCoverageFrom='src/Pages/Repositories/ContentListTable/components/**/*.{ts,tsx}' \
  --collectCoverageFrom='!src/Pages/Repositories/ContentListTable/components/**/*.test.{ts,tsx}' \
  --testPathPattern='ContentListTable/components' \
  --no-cache
```
|                     On Main	                    |               On PR branch               |
|-----------------------------------------------|--------------------------------------------|
| Statements: 62.48% (758/1213) | Statements: 70.4% (854/1213)|
| Branches: 48.19% (293/608)       | Branches: 55.92% (340/608)    |
| Functions: 38.18% (118/309)      | Functions: 47.57% (147/309)   |
| Lines: 64.98% (735/1131)            | Lines: 73.12% (827/1131)         |







