### PR TITLE
Test: fix template docs URL

### DIFF
--- a/_playwright-tests/UI/Templates.spec.ts
+++ b/_playwright-tests/UI/Templates.spec.ts
@@ -42,7 +42,7 @@ test.describe('Templates', () => {
       await page.getByRole('link', { name: 'Learn more about content templates' }).click();
       const docsPage = await pagePromise;
       await expect(docsPage).toHaveURL(
-        /^https:\/\/docs\.redhat\.com\/en\/documentation\/red_hat_lightspeed\/.*patching-using-content-templates.*$/,
+        /^https:\/\/docs\.redhat\.com\/en\/documentation\/red_hat_lightspeed\/.*using-content-templates-to-apply-system-patches.*$/,
       );
       await expect(docsPage.getByText(/^.*Using content templates.*$/).first()).toBeVisible();
       await expect(

--- a/src/Pages/Templates/TemplatesTable/constants.ts
+++ b/src/Pages/Templates/TemplatesTable/constants.ts
@@ -9,7 +9,7 @@ export const STANDARD_STREAM_PATH = 'dist';
 export const TEMPLATE_SYSTEMS_UPDATE_LIMIT = 1000;
 
 export const TEMPLATES_DOCS_URL =
-  'https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html/managing_system_content_and_patch_updates_on_rhel_systems/patching-using-content-templates';
+  'https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html/managing_system_content_and_patch_updates_on_rhel_systems/using-content-templates-to-apply-system-patches';
 
 export const LAST_FULL_SUPPORT_MINOR_VERSION = 9;
 export const EUS = 'eus';


### PR DESCRIPTION
## Summary
This test started failing. It looks like the old link 404s.

## Testing steps
