### PR TITLE
HMS-10608: refine ContentListTable as AI migration model

### DIFF
--- a/_playwright-tests/Integration/LayeredRepoAccess.spec.ts
+++ b/_playwright-tests/Integration/LayeredRepoAccess.spec.ts
@@ -33,11 +33,11 @@ test.describe('Test layered repos access is restricted', () => {
         'aria-pressed',
         'true',
       );
-      await expect(page.getByTestId('custom_repositories_table')).toBeVisible();
+      await expect(page.getByTestId('repositories-table')).toBeVisible();
     });
 
     await test.step('Verify layered repos do not appear in the UI', async () => {
-      let rows = page.getByLabel('Custom repositories table').locator('tbody tr');
+      let rows = page.getByLabel('Repositories table').locator('tbody tr');
       let initialRowCount = await rows.count();
       expect(initialRowCount).toBeGreaterThan(0);
       await page.getByPlaceholder(/^Filter by name.*$/).fill('openshift');
@@ -46,7 +46,7 @@ test.describe('Test layered repos access is restricted', () => {
       });
       await clearFilters(page);
 
-      rows = page.getByLabel('Custom repositories table').locator('tbody tr');
+      rows = page.getByLabel('Repositories table').locator('tbody tr');
       await expect(rows.first()).toBeVisible({ timeout: 10000 });
       initialRowCount = await rows.count();
       expect(initialRowCount).toBeGreaterThan(0);
@@ -81,11 +81,11 @@ test.describe('Test layered repos access is granted', () => {
         'aria-pressed',
         'true',
       );
-      await expect(page.getByTestId('custom_repositories_table')).toBeVisible();
+      await expect(page.getByTestId('repositories-table')).toBeVisible();
     });
 
     await test.step('Verify layered repos appear and are valid', async () => {
-      let rows = page.getByLabel('Custom repositories table').locator('tbody tr');
+      let rows = page.getByLabel('Repositories table').locator('tbody tr');
       await expect(rows.nth(repos.length)).toBeVisible({ timeout: 10000 });
       let initialRowCount = await rows.count();
       expect(initialRowCount).toBeGreaterThan(repos.length);
@@ -93,7 +93,7 @@ test.describe('Test layered repos access is granted', () => {
       await expect(rows).toHaveCount(3, { timeout: 10000 });
       await clearFilters(page);
 
-      rows = page.getByLabel('Custom repositories table').locator('tbody tr');
+      rows = page.getByLabel('Repositories table').locator('tbody tr');
       await expect(rows.nth(repos.length)).toBeVisible({ timeout: 10000 });
       initialRowCount = await rows.count();
       expect(initialRowCount).toBeGreaterThan(repos.length);

--- a/_playwright-tests/UI/TemplateCRUD.spec.ts
+++ b/_playwright-tests/UI/TemplateCRUD.spec.ts
@@ -91,8 +91,8 @@ test.describe('Templates CRUD', () => {
       await expect(page.getByText('Snapshot not yet available for this repository')).toBeVisible();
 
       // Verify x86 repo cannot be added due to architecture mismatch (should not appear)
-      await modalPage.getByRole('searchbox', { name: 'Filter by name/url' }).clear();
-      await modalPage.getByRole('searchbox', { name: 'Filter by name/url' }).fill(repoNameX86);
+      await modalPage.getByRole('searchbox', { name: 'Filter by name or URL' }).clear();
+      await modalPage.getByRole('searchbox', { name: 'Filter by name or URL' }).fill(repoNameX86);
       await expect(
         modalPage.getByText('No custom repositories match the filter criteria', { exact: false }),
       ).toBeVisible();

--- a/src/Pages/Repositories/ContentListTable/ContentListTable.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.test.tsx
@@ -72,18 +72,18 @@ it('shows empty state when there are no repositories', () => {
   expect(queryByText('To get started, create a custom repository.')).toBeInTheDocument();
 });
 
-it('Render a loading state', () => {
+it('renders a loading state', () => {
   (useContentListQuery as jest.Mock).mockImplementation(() => ({
     isLoading: true,
   }));
 
   const { queryByTestId } = renderContentListTable();
 
-  expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument();
+  expect(queryByTestId('content-list-toolbar')).toBeInTheDocument();
   expect(queryByTestId('SkeletonTableBody-tbody')).toBeInTheDocument();
 });
 
-it('Render with a single row', async () => {
+it('renders with a single row', async () => {
   (useContentListQuery as jest.Mock).mockImplementation(() => ({
     isLoading: false,
     data: {
@@ -297,11 +297,10 @@ it('filters the table by major and minor OS versions', async () => {
 
   const user = userEvent.setup();
 
-  const toolbar = document.querySelector('[data-ouia-component-id="DataViewToolbar"]')!;
-
+  const toolbar = screen.getByTestId('content-list-toolbar');
   await user.click(within(toolbar).getByRole('button', { name: 'Name' }));
   await user.click(within(screen.getByRole('menu')).getByRole('menuitem', { name: osMenuItem }));
-  await user.click(within(screen.getByTestId('filter_version')).getByRole('button'));
+  await user.click(within(screen.getByTestId('filter-version')).getByRole('button'));
   await user.click(screen.getByLabelText('RHEL 9.6'));
 
   // After filtering by a minor version, there should be one row (for the filtered repository)
@@ -314,8 +313,8 @@ it('filters the table by major and minor OS versions', async () => {
   await user.click(within(toolbar).getByRole('button', { name: 'Name' }));
   await user.click(within(screen.getByRole('menu')).getByRole('menuitem', { name: osMenuItem }));
 
-  // PatternFly leaves stale filter_version elements in the DOM on re-render, so grab the last (active) one
-  const versionFilters = screen.getAllByTestId('filter_version');
+  // PatternFly leaves stale filter-version elements in the DOM on re-render, so grab the last (active) one
+  const versionFilters = screen.getAllByTestId('filter-version');
   const activeFilter = versionFilters[versionFilters.length - 1];
   await user.click(within(activeFilter).getAllByRole('button')[0]);
   await user.click(screen.getByLabelText('RHEL 10'));

--- a/src/Pages/Repositories/ContentListTable/ContentListTable.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.test.tsx
@@ -77,9 +77,9 @@ it('Render a loading state', () => {
     isLoading: true,
   }));
 
-  const { queryByText, queryByTestId } = renderContentListTable();
+  const { queryByTestId } = renderContentListTable();
 
-  expect(queryByText('Name/URL')).toBeInTheDocument();
+  expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument();
   expect(queryByTestId('SkeletonTableBody-tbody')).toBeInTheDocument();
 });
 
@@ -297,7 +297,9 @@ it('filters the table by major and minor OS versions', async () => {
 
   const user = userEvent.setup();
 
-  await user.click(screen.getByRole('button', { name: 'Name/URL' }));
+  const toolbar = document.querySelector('[data-ouia-component-id="DataViewToolbar"]')!;
+
+  await user.click(within(toolbar).getByRole('button', { name: 'Name' }));
   await user.click(within(screen.getByRole('menu')).getByRole('menuitem', { name: osMenuItem }));
   await user.click(within(screen.getByTestId('filter_version')).getByRole('button'));
   await user.click(screen.getByLabelText('RHEL 9.6'));
@@ -309,7 +311,7 @@ it('filters the table by major and minor OS versions', async () => {
   });
   expect(await screen.findByText(defaultEUSRepository.name!)).toBeInTheDocument();
   // Re-select the OS filter type and add a major version filter
-  await user.click(screen.getByRole('button', { name: 'Name/URL' }));
+  await user.click(within(toolbar).getByRole('button', { name: 'Name' }));
   await user.click(within(screen.getByRole('menu')).getByRole('menuitem', { name: osMenuItem }));
 
   // PatternFly leaves stale filter_version elements in the DOM on re-render, so grab the last (active) one

--- a/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
@@ -13,14 +13,14 @@ import {
   useDataViewSort,
   useDataViewSelection,
 } from '@patternfly/react-data-view/dist/dynamic/Hooks';
-import { ThProps, ActionsColumn, IAction } from '@patternfly/react-table';
+import { ThProps } from '@patternfly/react-table';
 import {
   useContentListQuery,
   useIntrospectRepositoryMutate,
   useTriggerSnapshot,
   useBulkDeleteContentItemMutate,
 } from '../../../services/Content/ContentQueries';
-import { memo, useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import {
   ContentItem,
   ContentOrigin,
@@ -28,20 +28,12 @@ import {
   IntrospectRepositoryRequestItem,
 } from '../../../services/Content/ContentApi';
 import { useAppContext } from '../../../middleware/AppContext';
-import {
-  Pagination,
-  Button,
-  EmptyStateActions,
-  Flex,
-  FlexItem,
-  Tooltip,
-  TooltipPosition,
-} from '@patternfly/react-core';
+import { Pagination, Button, EmptyStateActions, Flex, FlexItem } from '@patternfly/react-core';
 import useDistributionDetails from '../../../Hooks/useDistributionDetails';
 import dayjs from 'dayjs';
 import { useSearchParams, useNavigate, Outlet, useOutletContext } from 'react-router-dom';
 import Hide from 'components/Hide/Hide';
-import { ADD_ROUTE, EDIT_ROUTE, UPLOAD_ROUTE, DELETE_ROUTE } from 'Routes/constants';
+import { ADD_ROUTE } from 'Routes/constants';
 import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip';
 import {
   BulkSelect,
@@ -50,128 +42,20 @@ import {
 import flex from '@patternfly/react-styles/css/utilities/Flex/flex';
 import { useQueryClient } from '@tanstack/react-query';
 import StatusIcon from './components/StatusIcon';
+import RepositoryCell from './components/RepositoryCell';
+import RepositoryActionCell, { type ActionRowData } from './components/RepositoryActionCell';
+import useRowActions, { showPendingTooltip } from './hooks/useRowActions';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { SkeletonTableBody } from '@patternfly/react-component-groups';
-import UploadRepositoryLabel from 'components/RepositoryLabels/UploadRepositoryLabel';
-import UrlWithExternalIcon from '../../../components/UrlWithLinkIcon/UrlWithLinkIcon';
-import ChangedArrows from './components/SnapshotListModal/components/ChangedArrows';
-import { createUseStyles } from 'react-jss';
 import PackageCount from './components/PackageCount';
 import DeleteKebab from '../../../components/DeleteKebab/DeleteKebab';
 import { DataViewFilters } from '@patternfly/react-data-view/dist/dynamic/DataViewFilters';
 import { useContentListFilters, FilterLabelsMap } from './hooks/useContentListFilters';
 import ContentOriginFilter from './components/ContentOriginFilter';
-import CommunityRepositoryLabel from '../../../components/RepositoryLabels/CommunityRepositoryLabel';
 import EmptyTableDataView from 'components/EmptyTableDataView/EmptyTableDataView';
-import CustomEpelWarning from 'components/RepositoryLabels/CustomEpelWarning';
-import { isEPELUrl } from 'helpers';
 import { hasOrigin, versionNameToApiValue } from '../helpers';
 
-type ActionRowData = Pick<
-  ContentItem,
-  'uuid' | 'origin' | 'status' | 'snapshot' | 'last_snapshot_uuid' | 'last_snapshot_task'
->;
-
-const useStyles = createUseStyles({
-  snapshotInfoText: {
-    marginRight: '16px',
-  },
-  inline: {
-    display: 'flex',
-  },
-  disabledButton: {
-    pointerEvents: 'auto',
-    cursor: 'default',
-  },
-});
-
 export const perPageKey = 'contentListPerPage';
-
-interface ContentInformationCellProps {
-  rowData: Pick<ContentItem, 'name' | 'url' | 'last_snapshot' | 'origin'>;
-  snapshotsAccessible: boolean;
-  communityReposEnabled: boolean;
-}
-
-const ContentInformationCell = memo(
-  ({ rowData, snapshotsAccessible, communityReposEnabled }: ContentInformationCellProps) => {
-    const classes = useStyles();
-    const { name, url, last_snapshot, origin } = rowData;
-
-    return (
-      <>
-        {name}
-        <Hide hide={origin !== ContentOrigin.UPLOAD}>
-          <UploadRepositoryLabel />
-        </Hide>
-        <Hide hide={origin !== ContentOrigin.COMMUNITY}>
-          <CommunityRepositoryLabel />
-        </Hide>
-        <Hide
-          hide={!(origin === ContentOrigin.EXTERNAL && isEPELUrl(url)) || !communityReposEnabled}
-        >
-          <CustomEpelWarning />
-        </Hide>
-        <Hide hide={origin === ContentOrigin.UPLOAD}>
-          <UrlWithExternalIcon href={url} />
-        </Hide>
-        <Hide hide={!snapshotsAccessible}>
-          <Flex>
-            <FlexItem className={classes.snapshotInfoText}>
-              {last_snapshot
-                ? `Last snapshot ${dayjs(last_snapshot?.created_at).fromNow()}`
-                : 'No snapshot yet'}
-            </FlexItem>
-            <Hide hide={!last_snapshot}>
-              <FlexItem className={classes.inline}>
-                <FlexItem className={classes.snapshotInfoText}>Changes:</FlexItem>
-                <ChangedArrows
-                  addedCount={last_snapshot?.added_counts?.['rpm.package'] || 0}
-                  removedCount={last_snapshot?.removed_counts?.['rpm.package'] || 0}
-                />
-              </FlexItem>
-            </Hide>
-          </Flex>
-        </Hide>
-      </>
-    );
-  },
-);
-
-ContentInformationCell.displayName = 'ContentInformationCell';
-
-interface ContentListActionRowProps {
-  rowData: ActionRowData;
-  actions: IAction[];
-  showPendingTooltipContent: string | undefined;
-  isRedHatRepository: boolean;
-}
-
-const ContentListActionRow = memo(
-  ({
-    rowData,
-    actions,
-    showPendingTooltipContent,
-    isRedHatRepository,
-  }: ContentListActionRowProps) => {
-    const triggerRef = useRef<HTMLDivElement>(null);
-    const shouldShowTooltip =
-      !isRedHatRepository && rowData?.status === 'Pending' && !!showPendingTooltipContent;
-
-    return (
-      <Hide hide={!actions?.length}>
-        <div ref={triggerRef}>
-          <ActionsColumn items={actions} />
-        </div>
-        {shouldShowTooltip && (
-          <Tooltip content={showPendingTooltipContent} triggerRef={triggerRef} />
-        )}
-      </Hide>
-    );
-  },
-);
-
-ContentListActionRow.displayName = 'ContentListActionRow';
 
 const readOnlyReposTooltipCopy =
   'Red Hat and EPEL repositories are read-only and cannot be manipulated.';
@@ -183,7 +67,6 @@ const ContentListTable = () => {
   const [urlSearchParams, setUrlSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const classes = useStyles();
 
   const {
     getArchName,
@@ -460,19 +343,6 @@ const ContentListTable = () => {
     sortString,
   );
 
-  const showPendingTooltip = (
-    snapshotStatus: string | undefined,
-    introspectStatus: string | undefined,
-  ) => {
-    if (!snapshotStatus && !introspectStatus) {
-      return 'Introspection or snapshotting is in progress';
-    } else if (snapshotStatus === 'running' || snapshotStatus === 'pending') {
-      return 'Snapshotting is in progress';
-    } else if (introspectStatus === 'Pending') {
-      return 'Introspection is in progress';
-    }
-  };
-
   // Feature flags for memoized components
   const snapshotsAccessible = features?.snapshots?.accessible ?? false;
   const communityReposEnabled = features?.communityrepos?.enabled ?? false;
@@ -489,123 +359,12 @@ const ContentListTable = () => {
     await triggerSnapshot(repoUuid);
   };
 
-  const rowActions = useCallback(
-    (rowData: ActionRowData): IAction[] =>
-      isRedHatRepository ||
-      rowData.origin === ContentOrigin.REDHAT ||
-      rowData.origin === ContentOrigin.COMMUNITY
-        ? features?.snapshots?.accessible
-          ? [
-              {
-                isDisabled: !rowData.snapshot || !(rowData.snapshot && rowData.last_snapshot_uuid),
-
-                ouiaId: 'kebab_view_snapshots',
-                title:
-                  rowData.snapshot && rowData.last_snapshot_uuid
-                    ? 'View all snapshots'
-                    : 'No snapshots yet',
-                onClick: () => {
-                  navigate(`${rowData.uuid}/snapshots`);
-                },
-              },
-            ]
-          : []
-        : [
-            ...(rbac?.repoWrite
-              ? [
-                  {
-                    isDisabled: rowData?.status === 'Pending',
-                    title: 'Edit',
-                    ouiaId: 'kebab_edit',
-                    onClick: () => {
-                      navigate(`${rowData.uuid}/${EDIT_ROUTE}`);
-                    },
-                  },
-                  ...(rowData.origin === ContentOrigin.UPLOAD
-                    ? [
-                        {
-                          isDisabled: rowData?.status === 'Pending',
-                          title: 'Upload content',
-                          ouiaId: 'kebab_upload_content',
-                          onClick: () => {
-                            navigate(`${rowData.uuid}/${UPLOAD_ROUTE}`);
-                          },
-                        },
-                      ]
-                    : []),
-                ]
-              : []),
-            ...(features?.snapshots?.accessible
-              ? [
-                  {
-                    isDisabled: !rowData.last_snapshot_uuid,
-                    title: rowData.last_snapshot_uuid ? 'View all snapshots' : 'No snapshots yet',
-                    ouiaId: 'kebab_view_snapshots',
-                    onClick: () => {
-                      navigate(`${rowData.uuid}/snapshots`);
-                    },
-                  },
-                  ...(rbac?.repoWrite && rowData.origin !== ContentOrigin.UPLOAD
-                    ? [
-                        {
-                          id: 'actions-column-snapshot',
-                          className:
-                            rowData?.status === 'Pending' || !rowData.snapshot
-                              ? classes.disabledButton
-                              : '',
-                          isDisabled: rowData?.status === 'Pending' || !rowData.snapshot,
-                          title: 'Trigger snapshot',
-                          ouiaId: 'kebab_trigger_snapshots',
-                          onClick: () => {
-                            triggerIntrospectionAndSnapshot(rowData?.uuid);
-                          },
-                          tooltipProps: !rowData.snapshot
-                            ? {
-                                content: 'Snapshots disabled for this repository.',
-                                position: TooltipPosition.left,
-                                triggerRef: () =>
-                                  document.getElementById('actions-column-snapshot') ||
-                                  document.body,
-                              }
-                            : undefined,
-                        },
-                      ]
-                    : []),
-                ]
-              : []),
-            ...(rbac?.repoWrite && !rowData?.snapshot
-              ? [
-                  {
-                    isDisabled: rowData?.status == 'Pending',
-                    title: 'Introspect now',
-                    ouiaId: 'kebab_introspect_now',
-                    onClick: () =>
-                      introspectRepoForUuid(rowData?.uuid).then(clearSelectedRepositories),
-                  },
-                ]
-              : []),
-            ...(rbac?.repoWrite
-              ? [
-                  { isSeparator: true },
-                  {
-                    title: 'Delete',
-                    ouiaId: 'kebab_delete',
-                    onClick: () => navigate(`${DELETE_ROUTE}?repoUUID=${rowData.uuid}`),
-                  },
-                ]
-              : []),
-          ],
-    [
-      isRedHatRepository,
-      features?.snapshots?.accessible,
-      rbac?.repoWrite,
-      navigate,
-      triggerIntrospectionAndSnapshot,
-      introspectRepoForUuid,
-      clearSelectedRepositories,
-      classes.disabledButton,
-    ],
-  );
+  const { rowActions } = useRowActions({
+    isRedHatRepository,
+    introspectRepoForUuid,
+    triggerIntrospectionAndSnapshot,
+    clearSelectedRepositories,
+  });
 
   // Format rows for DataView using DataViewTr objects
   // Selection is handled by DataView selection system using id and isSelected
@@ -646,7 +405,7 @@ const ContentListTable = () => {
         row: [
           {
             cell: (
-              <ContentInformationCell
+              <RepositoryCell
                 rowData={{ name, url, last_snapshot, origin }}
                 snapshotsAccessible={snapshotsAccessible}
                 communityReposEnabled={communityReposEnabled}
@@ -684,7 +443,7 @@ const ContentListTable = () => {
           },
           {
             cell: (
-              <ContentListActionRow
+              <RepositoryActionCell
                 rowData={actionRowData}
                 actions={actions}
                 showPendingTooltipContent={pendingTooltipContent}
@@ -784,7 +543,7 @@ const ContentListTable = () => {
                   filterId='search'
                   ouiaId='filter_search'
                   title={FilterLabelsMap.Search}
-                  placeholder='Filter by name/url'
+                  placeholder='Filter by name or URL'
                   isDisabled={isLoading}
                 />
                 <DataViewTreeFilter

--- a/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
@@ -30,7 +30,6 @@ import {
 import { useAppContext } from '../../../middleware/AppContext';
 import { Pagination, Button, EmptyStateActions, Flex, FlexItem } from '@patternfly/react-core';
 import useDistributionDetails from '../../../Hooks/useDistributionDetails';
-import dayjs from 'dayjs';
 import { useSearchParams, useNavigate, Outlet, useOutletContext } from 'react-router-dom';
 import Hide from 'components/Hide/Hide';
 import { ADD_ROUTE } from 'Routes/constants';
@@ -53,7 +52,7 @@ import { DataViewFilters } from '@patternfly/react-data-view/dist/dynamic/DataVi
 import { useContentListFilters, FilterLabelsMap } from './hooks/useContentListFilters';
 import ContentOriginFilter from './components/ContentOriginFilter';
 import EmptyTableDataView from 'components/EmptyTableDataView/EmptyTableDataView';
-import { hasOrigin, versionNameToApiValue } from '../helpers';
+import { hasOrigin, versionNameToApiValue, lastIntrospectionDisplay } from '../helpers';
 
 export const perPageKey = 'contentListPerPage';
 
@@ -268,9 +267,6 @@ const ContentListTable = () => {
     onPerPageSelect,
   };
 
-  const lastIntrospectionDisplay = (time?: string): string =>
-    time === '' || time === undefined ? 'Never' : dayjs(time).fromNow();
-
   // Repository introspection status
   const { mutateAsync: introspectRepository } = useIntrospectRepositoryMutate(
     queryClient,
@@ -282,8 +278,11 @@ const ContentListTable = () => {
   );
 
   // Ensure that repository statuses are properly displayed
-  const introspectRepoForUuid = (uuid: string): Promise<void> =>
-    introspectRepository({ uuid: uuid, reset_count: true } as IntrospectRepositoryRequestItem);
+  const introspectRepoForUuid = useCallback(
+    (uuid: string): Promise<void> =>
+      introspectRepository({ uuid: uuid, reset_count: true } as IntrospectRepositoryRequestItem),
+    [introspectRepository],
+  );
 
   const selection = useDataViewSelection({ matchOption: (a, b) => a.id === b.id });
   const { selected, onSelect, isSelected } = selection;
@@ -349,15 +348,21 @@ const ContentListTable = () => {
 
   const { mutateAsync: triggerSnapshotMutation } = useTriggerSnapshot(queryClient);
 
-  const triggerSnapshot = async (uuid: string): Promise<void> => {
-    await triggerSnapshotMutation(uuid);
-  };
+  const triggerSnapshot = useCallback(
+    async (uuid: string): Promise<void> => {
+      await triggerSnapshotMutation(uuid);
+    },
+    [triggerSnapshotMutation],
+  );
 
-  const triggerIntrospectionAndSnapshot = async (repoUuid: string): Promise<void> => {
-    clearSelectedRepositories();
-    await introspectRepoForUuid(repoUuid);
-    await triggerSnapshot(repoUuid);
-  };
+  const triggerIntrospectionAndSnapshot = useCallback(
+    async (repoUuid: string): Promise<void> => {
+      clearSelectedRepositories();
+      await introspectRepoForUuid(repoUuid);
+      await triggerSnapshot(repoUuid);
+    },
+    [clearSelectedRepositories, introspectRepoForUuid, triggerSnapshot],
+  );
 
   const { rowActions } = useRowActions({
     isRedHatRepository,
@@ -368,93 +373,107 @@ const ContentListTable = () => {
 
   // Format rows for DataView using DataViewTr objects
   // Selection is handled by DataView selection system using id and isSelected
-  const rows: SelectableRow[] = contentList.map(
-    ({
-      uuid,
-      name,
-      url,
-      origin,
-      last_snapshot,
-      snapshot,
-      last_snapshot_uuid,
-      distribution_arch,
-      distribution_versions,
-      extended_release_version,
-      last_introspection_time,
-      failed_introspections_count,
-      last_introspection_error,
-      last_snapshot_task,
-      package_count,
-      status,
-    }: ContentItem) => {
-      // Pre-compute values for memoized components
-      const actionRowData: ActionRowData = {
-        uuid,
-        origin,
-        status,
-        snapshot,
-        last_snapshot_uuid,
-        last_snapshot_task,
-      };
-      const actions = rowActions(actionRowData);
-      const pendingTooltipContent = showPendingTooltip(last_snapshot_task?.status, status);
+  const rows: SelectableRow[] = useMemo(
+    () =>
+      contentList.map(
+        ({
+          uuid,
+          name,
+          url,
+          origin,
+          last_snapshot,
+          snapshot,
+          last_snapshot_uuid,
+          distribution_arch,
+          distribution_versions,
+          extended_release_version,
+          last_introspection_time,
+          failed_introspections_count,
+          last_introspection_error,
+          last_snapshot_task,
+          package_count,
+          status,
+        }: ContentItem) => {
+          // Pre-compute values for memoized components
+          const actionRowData: ActionRowData = {
+            uuid,
+            origin,
+            status,
+            snapshot,
+            last_snapshot_uuid,
+            last_snapshot_task,
+          };
+          const actions = rowActions(actionRowData);
+          const pendingTooltipContent = showPendingTooltip(last_snapshot_task?.status, status);
 
-      return {
-        id: uuid, // Used by useDataViewSelection for matching
-        origin: origin, // Used to determine if a repo is deletable
-        row: [
-          {
-            cell: (
-              <RepositoryCell
-                rowData={{ name, url, last_snapshot, origin }}
-                snapshotsAccessible={snapshotsAccessible}
-                communityReposEnabled={communityReposEnabled}
-              />
-            ),
-          },
-          { cell: getArchName(distribution_arch) },
-          {
-            cell: extended_release_version
-              ? getMinorVersionName(extended_release_version)
-              : getVersionName(distribution_versions),
-          },
-          { cell: <PackageCount rowData={{ uuid, status, package_count }} /> },
-          {
-            cell:
-              origin !== ContentOrigin.UPLOAD
-                ? lastIntrospectionDisplay(last_introspection_time)
-                : 'N/A',
-          },
-          {
-            cell: (
-              <StatusIcon
-                rowData={{
-                  uuid,
-                  status,
-                  failed_introspections_count,
-                  last_introspection_time,
-                  last_introspection_error,
-                  last_snapshot_task,
-                  origin,
-                }}
-                retryHandler={introspectRepoForUuid}
-              />
-            ),
-          },
-          {
-            cell: (
-              <RepositoryActionCell
-                rowData={actionRowData}
-                actions={actions}
-                showPendingTooltipContent={pendingTooltipContent}
-                isRedHatRepository={isRedHatRepository}
-              />
-            ),
-            props: { isActionCell: true },
-          },
-        ],
-      };
-    },
+          return {
+            id: uuid, // Used by useDataViewSelection for matching
+            origin: origin, // Used to determine if a repo is deletable
+            row: [
+              {
+                cell: (
+                  <RepositoryCell
+                    rowData={{ name, url, last_snapshot, origin }}
+                    snapshotsAccessible={snapshotsAccessible}
+                    communityReposEnabled={communityReposEnabled}
+                  />
+                ),
+              },
+              { cell: getArchName(distribution_arch) },
+              {
+                cell: extended_release_version
+                  ? getMinorVersionName(extended_release_version)
+                  : getVersionName(distribution_versions),
+              },
+              { cell: <PackageCount rowData={{ uuid, status, package_count }} /> },
+              {
+                cell:
+                  origin !== ContentOrigin.UPLOAD
+                    ? lastIntrospectionDisplay(last_introspection_time)
+                    : 'N/A',
+              },
+              {
+                cell: (
+                  <StatusIcon
+                    rowData={{
+                      uuid,
+                      status,
+                      failed_introspections_count,
+                      last_introspection_time,
+                      last_introspection_error,
+                      last_snapshot_task,
+                      origin,
+                    }}
+                    retryHandler={introspectRepoForUuid}
+                  />
+                ),
+              },
+              {
+                cell: (
+                  <RepositoryActionCell
+                    rowData={actionRowData}
+                    actions={actions}
+                    showPendingTooltipContent={pendingTooltipContent}
+                    isRedHatRepository={isRedHatRepository}
+                  />
+                ),
+                props: { isActionCell: true },
+              },
+            ],
+          };
+        },
+      ),
+    [
+      contentList,
+      rowActions,
+      snapshotsAccessible,
+      communityReposEnabled,
+      getArchName,
+      getVersionName,
+      getMinorVersionName,
+      introspectRepoForUuid,
+      isRedHatRepository,
+    ],
   );
 
   const handleBulkSelect = (value: BulkSelectValue) => {

--- a/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
@@ -125,7 +125,7 @@ const ContentListTable = () => {
   const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
   const [perPage, setPerPage] = useState(storedPerPage);
 
-  // Used to force-reset the active attribute of DataViewFilters back to the first item (Name/URL)
+  // Used to force-reset the active attribute of DataViewFilters back to the first item (Name)
   const [filtersActiveAttributeResetKey, setFiltersActiveAttributeResetKey] = useState(0);
 
   const {

--- a/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
@@ -43,7 +43,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import StatusIcon from './components/StatusIcon';
 import RepositoryCell from './components/RepositoryCell';
 import RepositoryActionCell, { type ActionRowData } from './components/RepositoryActionCell';
-import useRowActions, { showPendingTooltip } from './hooks/useRowActions';
+import useRowActions from './hooks/useRowActions';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { SkeletonTableBody } from '@patternfly/react-component-groups';
 import PackageCount from './components/PackageCount';
@@ -52,7 +52,12 @@ import { DataViewFilters } from '@patternfly/react-data-view/dist/dynamic/DataVi
 import { useContentListFilters, FilterLabelsMap } from './hooks/useContentListFilters';
 import ContentOriginFilter from './components/ContentOriginFilter';
 import EmptyTableDataView from 'components/EmptyTableDataView/EmptyTableDataView';
-import { hasOrigin, versionNameToApiValue, lastIntrospectionDisplay } from '../helpers';
+import {
+  hasOrigin,
+  versionNameToApiValue,
+  lastIntrospectionDisplay,
+  showPendingTooltip,
+} from '../helpers';
 
 export const perPageKey = 'contentListPerPage';
 

--- a/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
@@ -487,7 +487,7 @@ const ContentListTable = () => {
 
   const isPagePartiallySelected = pageSelectionCount > 0 && !isPageSelected;
 
-  const ouiaId = 'custom_repositories_table';
+  const ouiaId = 'repositories-table';
 
   const [activeState, setActiveState] = useState<DataViewState | undefined>(DataViewState.loading);
 
@@ -521,12 +521,13 @@ const ContentListTable = () => {
   return (
     <>
       <DataView
-        data-ouia-component-id='content_list_page'
+        ouiaId='content-list-page'
         activeState={activeState}
         {...(shouldEnableSelection && { selection: selectionWithDisabledRows })}
         className={`${spacing.pxLg} ${spacing.ptMd} ${flex.flexDirectionColumn}`}
       >
         <DataViewToolbar
+          ouiaId='content-list-toolbar'
           clearAllFilters={resetFiltersAndPagination}
           filters={
             <>
@@ -541,17 +542,18 @@ const ContentListTable = () => {
                 <DataViewTextFilter
                   key={`search-${filtersActiveAttributeResetKey}`}
                   filterId='search'
-                  ouiaId='filter_search'
+                  ouiaId='filter-search'
+                  aria-label='filter search'
                   title={FilterLabelsMap.Search}
                   placeholder='Filter by name or URL'
                   isDisabled={isLoading}
                 />
                 <DataViewTreeFilter
                   filterId='versions'
-                  ouiaId='filter_version'
+                  ouiaId='filter-version'
                   title={FilterLabelsMap.Versions}
                   // TODO: Create an issue in the data-view repository to support a custom aria-label and a placeholder
-                  // aria-label='filter by operating system'
+                  // aria-label='filter operating system'
                   // placeholder='Filter by operating system'
                   defaultExpanded={true}
                   items={osFilterOptions}
@@ -569,7 +571,7 @@ const ContentListTable = () => {
                 />
                 <DataViewCheckboxFilter
                   filterId='arches'
-                  ouiaId='filter_arch'
+                  ouiaId='filter-arch'
                   aria-label='filter architecture'
                   title={FilterLabelsMap.Arches}
                   placeholder='Filter by architecture'
@@ -577,7 +579,7 @@ const ContentListTable = () => {
                 />
                 <DataViewCheckboxFilter
                   filterId='statuses'
-                  ouiaId='filter_status'
+                  ouiaId='filter-status'
                   aria-label='filter status'
                   title={FilterLabelsMap.Statuses}
                   placeholder='Filter by status'
@@ -635,7 +637,7 @@ const ContentListTable = () => {
                 >
                   <Button
                     id='createContentSourceButton'
-                    ouiaId='create_content_source'
+                    ouiaId='create-content'
                     variant='primary'
                     isDisabled={
                       isLoading ||
@@ -676,7 +678,7 @@ const ContentListTable = () => {
                     }
                     atLeastOneRepoChecked={pageSelectionCount > 0}
                     numberOfReposChecked={pageSelectionCount}
-                    toggleOuiaId='custom_repositories_kebab_toggle'
+                    toggleOuiaId='repositories-kebab-toggle'
                   />
                 </ConditionalTooltip>
               </FlexItem>
@@ -692,7 +694,7 @@ const ContentListTable = () => {
           }
         />
         <DataViewTable
-          aria-label='Custom repositories table'
+          aria-label='Repositories table'
           ouiaId={ouiaId}
           variant='compact'
           columns={dataViewColumns}

--- a/src/Pages/Repositories/ContentListTable/components/RepositoryActionCell.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/RepositoryActionCell.tsx
@@ -1,0 +1,40 @@
+import { memo, useRef } from 'react';
+import { Tooltip } from '@patternfly/react-core';
+import { ActionsColumn, IAction } from '@patternfly/react-table';
+import { ContentItem } from 'services/Content/ContentApi';
+import Hide from 'components/Hide/Hide';
+
+export type ActionRowData = Pick<
+  ContentItem,
+  'uuid' | 'origin' | 'status' | 'snapshot' | 'last_snapshot_uuid' | 'last_snapshot_task'
+>;
+
+interface Props {
+  rowData: ActionRowData;
+  actions: IAction[];
+  showPendingTooltipContent: string | undefined;
+  isRedHatRepository: boolean;
+}
+
+const RepositoryActionCell = memo(
+  ({ rowData, actions, showPendingTooltipContent, isRedHatRepository }: Props) => {
+    const triggerRef = useRef<HTMLDivElement>(null);
+    const shouldShowTooltip =
+      !isRedHatRepository && rowData?.status === 'Pending' && !!showPendingTooltipContent;
+
+    return (
+      <Hide hide={!actions?.length}>
+        <div ref={triggerRef}>
+          <ActionsColumn items={actions} />
+        </div>
+        {shouldShowTooltip && (
+          <Tooltip content={showPendingTooltipContent} triggerRef={triggerRef} />
+        )}
+      </Hide>
+    );
+  },
+);
+
+RepositoryActionCell.displayName = 'RepositoryActionCell';
+
+export default RepositoryActionCell;

--- a/src/Pages/Repositories/ContentListTable/components/RepositoryCell.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/RepositoryCell.tsx
@@ -1,0 +1,69 @@
+import { memo } from 'react';
+import { Flex, FlexItem } from '@patternfly/react-core';
+import dayjs from 'dayjs';
+import { ContentItem, ContentOrigin } from 'services/Content/ContentApi';
+import Hide from 'components/Hide/Hide';
+import UploadRepositoryLabel from 'components/RepositoryLabels/UploadRepositoryLabel';
+import CommunityRepositoryLabel from 'components/RepositoryLabels/CommunityRepositoryLabel';
+import CustomEpelWarning from 'components/RepositoryLabels/CustomEpelWarning';
+import UrlWithExternalIcon from 'components/UrlWithLinkIcon/UrlWithLinkIcon';
+import ChangedArrows from './SnapshotListModal/components/ChangedArrows';
+import { isEPELUrl } from 'helpers';
+
+interface Props {
+  rowData: Pick<ContentItem, 'name' | 'url' | 'last_snapshot' | 'origin'>;
+  snapshotsAccessible: boolean;
+  communityReposEnabled: boolean;
+}
+
+const RepositoryCell = memo(({ rowData, snapshotsAccessible, communityReposEnabled }: Props) => {
+  const { name, url, last_snapshot, origin } = rowData;
+
+  return (
+    <Flex direction={{ default: 'column' }}>
+      <Flex gap={{ default: 'gapXs' }} alignItems={{ default: 'alignItemsCenter' }}>
+        <FlexItem>{name}</FlexItem>
+        <Hide hide={origin !== ContentOrigin.UPLOAD}>
+          <UploadRepositoryLabel />
+        </Hide>
+        <Hide hide={origin !== ContentOrigin.COMMUNITY}>
+          <CommunityRepositoryLabel />
+        </Hide>
+        <Hide
+          hide={!(origin === ContentOrigin.EXTERNAL && isEPELUrl(url)) || !communityReposEnabled}
+        >
+          <CustomEpelWarning />
+        </Hide>
+      </Flex>
+
+      <Hide hide={origin === ContentOrigin.UPLOAD}>
+        <UrlWithExternalIcon href={url} />
+      </Hide>
+
+      <Hide hide={!snapshotsAccessible}>
+        <Flex gap={{ default: 'gapMd' }}>
+          <FlexItem>
+            {last_snapshot
+              ? `Last snapshot ${dayjs(last_snapshot?.created_at).fromNow()}`
+              : 'No snapshot yet'}
+          </FlexItem>
+          <Hide hide={!last_snapshot}>
+            <Flex gap={{ default: 'gapXs' }}>
+              <FlexItem>Changes:</FlexItem>
+              <FlexItem>
+                <ChangedArrows
+                  addedCount={last_snapshot?.added_counts?.['rpm.package'] || 0}
+                  removedCount={last_snapshot?.removed_counts?.['rpm.package'] || 0}
+                />
+              </FlexItem>
+            </Flex>
+          </Hide>
+        </Flex>
+      </Hide>
+    </Flex>
+  );
+});
+
+RepositoryCell.displayName = 'RepositoryCell';
+
+export default RepositoryCell;

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/components/ChangedArrows.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/components/ChangedArrows.tsx
@@ -1,46 +1,39 @@
 import { LongArrowAltDownIcon, LongArrowAltUpIcon } from '@patternfly/react-icons';
 import { Flex, FlexItem } from '@patternfly/react-core';
 import {
-  t_global_color_status_danger_100 as global_danger_color_100,
-  t_global_color_status_success_100 as global_success_color_100,
+  t_global_color_status_danger_100,
+  t_global_color_status_success_100,
 } from '@patternfly/react-tokens';
-import { createUseStyles } from 'react-jss';
-
-const red = global_danger_color_100.value;
-const green = global_success_color_100.value;
-
-const useStyles = createUseStyles({
-  base: {
-    fontWeight: 'bold',
-    alignItems: 'center',
-    display: 'flex',
-    '& svg': {
-      marginRight: '5px',
-    },
-  },
-  red: { extend: 'base', color: red },
-  green: { extend: 'base', color: green },
-});
+import text from '@patternfly/react-styles/css/utilities/Text/text';
 
 interface Props {
   addedCount: number;
   removedCount: number;
 }
 
-const ChangedArrows = ({ addedCount, removedCount }: Props) => {
-  const classes = useStyles();
-  return (
-    <Flex>
-      <FlexItem className={classes.green}>
+const ChangedArrows = ({ addedCount, removedCount }: Props) => (
+  <Flex gap={{ default: 'gapSm' }} className={text.fontWeightBold}>
+    <Flex
+      gap={{ default: 'gapXs' }}
+      alignItems={{ default: 'alignItemsCenter' }}
+      style={{ color: t_global_color_status_success_100.value }}
+    >
+      <FlexItem>
         <LongArrowAltUpIcon />
-        {addedCount}
       </FlexItem>
-      <FlexItem className={classes.red}>
-        <LongArrowAltDownIcon />
-        {removedCount}
-      </FlexItem>
+      <FlexItem>{addedCount}</FlexItem>
     </Flex>
-  );
-};
+    <Flex
+      gap={{ default: 'gapXs' }}
+      alignItems={{ default: 'alignItemsCenter' }}
+      style={{ color: t_global_color_status_danger_100.value }}
+    >
+      <FlexItem>
+        <LongArrowAltDownIcon />
+      </FlexItem>
+      <FlexItem>{removedCount}</FlexItem>
+    </Flex>
+  </Flex>
+);
 
 export default ChangedArrows;

--- a/src/Pages/Repositories/ContentListTable/hooks/useContentListFilters.ts
+++ b/src/Pages/Repositories/ContentListTable/hooks/useContentListFilters.ts
@@ -16,7 +16,7 @@ const StatusDisplayMap = {
 } as const;
 
 export const FilterLabelsMap = {
-  Search: 'Name/URL',
+  Search: 'Name',
   Versions: 'Operating system',
   Arches: 'Architecture',
   Statuses: 'Status',
@@ -32,12 +32,10 @@ export const initialFilters: RepositoryFilters = {
 };
 
 const statusFilterOptions: DataViewFilterOption[] = Object.keys(StatusDisplayMap).map(
-  (statusDisplay) =>
-    ({
-      label: statusDisplay,
-      value: StatusDisplayMap[statusDisplay],
-      ['data-ouia-component-id']: `filter_${statusDisplay}`,
-    }) as unknown as DataViewFilterOption,
+  (statusDisplay) => ({
+    label: statusDisplay,
+    value: StatusDisplayMap[statusDisplay],
+  }),
 );
 
 export const useContentListFilters = () => {
@@ -96,14 +94,10 @@ export const useContentListFilters = () => {
 
   const archFilterOptions: DataViewFilterOption[] = useMemo(
     () =>
-      distribution_arches.map(
-        (nameLabel: NameLabel) =>
-          ({
-            label: nameLabel.name,
-            value: nameLabel.label,
-            ['data-ouia-component-id']: `filter_${nameLabel.name}`,
-          }) as unknown as DataViewFilterOption,
-      ),
+      distribution_arches.map((nameLabel: NameLabel) => ({
+        label: nameLabel.name,
+        value: nameLabel.label,
+      })),
     [distribution_arches],
   );
 

--- a/src/Pages/Repositories/ContentListTable/hooks/useRowActions.ts
+++ b/src/Pages/Repositories/ContentListTable/hooks/useRowActions.ts
@@ -1,0 +1,167 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { IAction } from '@patternfly/react-table';
+import { TooltipPosition } from '@patternfly/react-core';
+import { createUseStyles } from 'react-jss';
+import { ContentOrigin } from 'services/Content/ContentApi';
+import { useAppContext } from 'middleware/AppContext';
+import { EDIT_ROUTE, UPLOAD_ROUTE, DELETE_ROUTE } from 'Routes/constants';
+import type { ActionRowData } from '../components/RepositoryActionCell';
+
+const useStyles = createUseStyles({
+  disabledButton: {
+    pointerEvents: 'auto',
+    cursor: 'default',
+  },
+});
+
+export const showPendingTooltip = (
+  snapshotStatus: string | undefined,
+  introspectStatus: string | undefined,
+) => {
+  if (!snapshotStatus && !introspectStatus) {
+    return 'Introspection or snapshotting is in progress';
+  } else if (snapshotStatus === 'running' || snapshotStatus === 'pending') {
+    return 'Snapshotting is in progress';
+  } else if (introspectStatus === 'Pending') {
+    return 'Introspection is in progress';
+  }
+};
+
+interface UseRowActionsProps {
+  isRedHatRepository: boolean;
+  introspectRepoForUuid: (uuid: string) => Promise<void>;
+  triggerIntrospectionAndSnapshot: (uuid: string) => Promise<void>;
+  clearSelectedRepositories: () => void;
+}
+
+export default function useRowActions({
+  isRedHatRepository,
+  introspectRepoForUuid,
+  triggerIntrospectionAndSnapshot,
+  clearSelectedRepositories,
+}: UseRowActionsProps) {
+  const navigate = useNavigate();
+  const { rbac, features } = useAppContext();
+  const classes = useStyles();
+
+  const rowActions = useCallback(
+    (rowData: ActionRowData): IAction[] =>
+      isRedHatRepository ||
+      rowData.origin === ContentOrigin.REDHAT ||
+      rowData.origin === ContentOrigin.COMMUNITY
+        ? features?.snapshots?.accessible
+          ? [
+              {
+                isDisabled: !rowData.snapshot || !(rowData.snapshot && rowData.last_snapshot_uuid),
+
+                ouiaId: 'kebab_view_snapshots',
+                title:
+                  rowData.snapshot && rowData.last_snapshot_uuid
+                    ? 'View all snapshots'
+                    : 'No snapshots yet',
+                onClick: () => {
+                  navigate(`${rowData.uuid}/snapshots`);
+                },
+              },
+            ]
+          : []
+        : [
+            ...(rbac?.repoWrite
+              ? [
+                  {
+                    isDisabled: rowData?.status === 'Pending',
+                    title: 'Edit',
+                    ouiaId: 'kebab_edit',
+                    onClick: () => {
+                      navigate(`${rowData.uuid}/${EDIT_ROUTE}`);
+                    },
+                  },
+                  ...(rowData.origin === ContentOrigin.UPLOAD
+                    ? [
+                        {
+                          isDisabled: rowData?.status === 'Pending',
+                          title: 'Upload content',
+                          ouiaId: 'kebab_upload_content',
+                          onClick: () => {
+                            navigate(`${rowData.uuid}/${UPLOAD_ROUTE}`);
+                          },
+                        },
+                      ]
+                    : []),
+                ]
+              : []),
+            ...(features?.snapshots?.accessible
+              ? [
+                  {
+                    isDisabled: !rowData.last_snapshot_uuid,
+                    title: rowData.last_snapshot_uuid ? 'View all snapshots' : 'No snapshots yet',
+                    ouiaId: 'kebab_view_snapshots',
+                    onClick: () => {
+                      navigate(`${rowData.uuid}/snapshots`);
+                    },
+                  },
+                  ...(rbac?.repoWrite && rowData.origin !== ContentOrigin.UPLOAD
+                    ? [
+                        {
+                          id: 'actions-column-snapshot',
+                          className:
+                            rowData?.status === 'Pending' || !rowData.snapshot
+                              ? classes.disabledButton
+                              : '',
+                          isDisabled: rowData?.status === 'Pending' || !rowData.snapshot,
+                          title: 'Trigger snapshot',
+                          ouiaId: 'kebab_trigger_snapshots',
+                          onClick: () => {
+                            triggerIntrospectionAndSnapshot(rowData?.uuid);
+                          },
+                          tooltipProps: !rowData.snapshot
+                            ? {
+                                content: 'Snapshots disabled for this repository.',
+                                position: TooltipPosition.left,
+                                triggerRef: () =>
+                                  document.getElementById('actions-column-snapshot') ||
+                                  document.body,
+                              }
+                            : undefined,
+                        },
+                      ]
+                    : []),
+                ]
+              : []),
+            ...(rbac?.repoWrite && !rowData?.snapshot
+              ? [
+                  {
+                    isDisabled: rowData?.status == 'Pending',
+                    title: 'Introspect now',
+                    ouiaId: 'kebab_introspect_now',
+                    onClick: () =>
+                      introspectRepoForUuid(rowData?.uuid).then(clearSelectedRepositories),
+                  },
+                ]
+              : []),
+            ...(rbac?.repoWrite
+              ? [
+                  { isSeparator: true },
+                  {
+                    title: 'Delete',
+                    ouiaId: 'kebab_delete',
+                    onClick: () => navigate(`${DELETE_ROUTE}?repoUUID=${rowData.uuid}`),
+                  },
+                ]
+              : []),
+          ],
+    [
+      isRedHatRepository,
+      features?.snapshots?.accessible,
+      rbac?.repoWrite,
+      navigate,
+      triggerIntrospectionAndSnapshot,
+      introspectRepoForUuid,
+      clearSelectedRepositories,
+      classes.disabledButton,
+    ],
+  );
+
+  return { rowActions, showPendingTooltip };
+}

--- a/src/Pages/Repositories/ContentListTable/hooks/useRowActions.ts
+++ b/src/Pages/Repositories/ContentListTable/hooks/useRowActions.ts
@@ -15,19 +15,6 @@ const useStyles = createUseStyles({
   },
 });
 
-export const showPendingTooltip = (
-  snapshotStatus: string | undefined,
-  introspectStatus: string | undefined,
-) => {
-  if (!snapshotStatus && !introspectStatus) {
-    return 'Introspection or snapshotting is in progress';
-  } else if (snapshotStatus === 'running' || snapshotStatus === 'pending') {
-    return 'Snapshotting is in progress';
-  } else if (introspectStatus === 'Pending') {
-    return 'Introspection is in progress';
-  }
-};
-
 interface UseRowActionsProps {
   isRedHatRepository: boolean;
   introspectRepoForUuid: (uuid: string) => Promise<void>;
@@ -55,7 +42,7 @@ export default function useRowActions({
               {
                 isDisabled: !rowData.snapshot || !(rowData.snapshot && rowData.last_snapshot_uuid),
 
-                ouiaId: 'kebab_view_snapshots',
+                ouiaId: 'kebab-view-snapshots',
                 title:
                   rowData.snapshot && rowData.last_snapshot_uuid
                     ? 'View all snapshots'
@@ -72,7 +59,7 @@ export default function useRowActions({
                   {
                     isDisabled: rowData?.status === 'Pending',
                     title: 'Edit',
-                    ouiaId: 'kebab_edit',
+                    ouiaId: 'kebab-edit',
                     onClick: () => {
                       navigate(`${rowData.uuid}/${EDIT_ROUTE}`);
                     },
@@ -82,7 +69,7 @@ export default function useRowActions({
                         {
                           isDisabled: rowData?.status === 'Pending',
                           title: 'Upload content',
-                          ouiaId: 'kebab_upload_content',
+                          ouiaId: 'kebab-upload-content',
                           onClick: () => {
                             navigate(`${rowData.uuid}/${UPLOAD_ROUTE}`);
                           },
@@ -96,7 +83,7 @@ export default function useRowActions({
                   {
                     isDisabled: !rowData.last_snapshot_uuid,
                     title: rowData.last_snapshot_uuid ? 'View all snapshots' : 'No snapshots yet',
-                    ouiaId: 'kebab_view_snapshots',
+                    ouiaId: 'kebab-view-snapshots',
                     onClick: () => {
                       navigate(`${rowData.uuid}/snapshots`);
                     },
@@ -104,14 +91,14 @@ export default function useRowActions({
                   ...(rbac?.repoWrite && rowData.origin !== ContentOrigin.UPLOAD
                     ? [
                         {
-                          id: 'actions-column-snapshot',
+                          id: `actions-column-snapshot-${rowData.uuid}`,
                           className:
                             rowData?.status === 'Pending' || !rowData.snapshot
                               ? classes.disabledButton
                               : '',
                           isDisabled: rowData?.status === 'Pending' || !rowData.snapshot,
                           title: 'Trigger snapshot',
-                          ouiaId: 'kebab_trigger_snapshots',
+                          ouiaId: 'kebab-trigger-snapshots',
                           onClick: () => {
                             triggerIntrospectionAndSnapshot(rowData?.uuid);
                           },
@@ -120,8 +107,9 @@ export default function useRowActions({
                                 content: 'Snapshots disabled for this repository.',
                                 position: TooltipPosition.left,
                                 triggerRef: () =>
-                                  document.getElementById('actions-column-snapshot') ||
-                                  document.body,
+                                  document.getElementById(
+                                    `actions-column-snapshot-${rowData.uuid}`,
+                                  ) || document.body,
                               }
                             : undefined,
                         },
@@ -134,7 +122,7 @@ export default function useRowActions({
                   {
                     isDisabled: rowData?.status == 'Pending',
                     title: 'Introspect now',
-                    ouiaId: 'kebab_introspect_now',
+                    ouiaId: 'kebab-introspect-now',
                     onClick: () =>
                       introspectRepoForUuid(rowData?.uuid).then(clearSelectedRepositories),
                   },
@@ -145,7 +133,7 @@ export default function useRowActions({
                   { isSeparator: true },
                   {
                     title: 'Delete',
-                    ouiaId: 'kebab_delete',
+                    ouiaId: 'kebab-delete',
                     onClick: () => navigate(`${DELETE_ROUTE}?repoUUID=${rowData.uuid}`),
                   },
                 ]
@@ -163,5 +151,5 @@ export default function useRowActions({
     ],
   );
 
-  return { rowActions, showPendingTooltip };
+  return { rowActions };
 }

--- a/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.test.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.test.tsx
@@ -90,7 +90,7 @@ it('Render a loading state checking search disabled', () => {
     </ReactQueryTestWrapper>,
   );
 
-  expect(queryByPlaceholderText('Filter by name/url')).toHaveAttribute('disabled');
+  expect(queryByPlaceholderText('Filter by name or URL')).toHaveAttribute('disabled');
 });
 
 it('finds search box, enters text, and checks text occurrence', () => {
@@ -106,7 +106,7 @@ it('finds search box, enters text, and checks text occurrence', () => {
     </ReactQueryTestWrapper>,
   );
 
-  const searchBox = getByPlaceholderText('Filter by name/url');
+  const searchBox = getByPlaceholderText('Filter by name or URL');
   fireEvent.change(searchBox, { target: { value: 'yourSearchText' } });
 
   const occurrences = queryAllByText('yourSearchText', { exact: false });

--- a/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.tsx
@@ -317,7 +317,7 @@ const PopularRepositoriesTable = () => {
                   id='search'
                   customIcon={<SearchIcon />}
                   ouiaId='popular_filter_search'
-                  placeholder='Filter by name/url'
+                  placeholder='Filter by name or URL'
                   value={searchValue}
                   onChange={(_event, val) => setSearchValue(val)}
                 />
@@ -410,7 +410,7 @@ const PopularRepositoriesTable = () => {
             {searchValue !== '' && (
               <Flex>
                 <FlexItem fullWidth={{ default: 'fullWidth' }} className={classes.chipsContainer}>
-                  <LabelGroup categoryName='Name/URL'>
+                  <LabelGroup categoryName='Name'>
                     <Label variant='outline' key='search_chip' onClose={() => setSearchValue('')}>
                       {searchValue}
                     </Label>

--- a/src/Pages/Repositories/helpers.test.ts
+++ b/src/Pages/Repositories/helpers.test.ts
@@ -1,4 +1,8 @@
-import { hasOrigin, versionNameToApiValue } from './helpers';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import { hasOrigin, lastIntrospectionDisplay, versionNameToApiValue } from './helpers';
+
+dayjs.extend(relativeTime);
 
 describe('hasOrigin', () => {
   it('should return true if the value has an origin property', () => {
@@ -13,6 +17,21 @@ describe('hasOrigin', () => {
     expect(hasOrigin(null)).toBe(false);
     expect(hasOrigin(undefined)).toBe(false);
     expect(hasOrigin('string')).toBe(false);
+  });
+});
+
+describe('lastIntrospectionDisplay', () => {
+  it('should return "Never" for an empty string', () => {
+    expect(lastIntrospectionDisplay('')).toBe('Never');
+  });
+
+  it('should return "Never" for undefined', () => {
+    expect(lastIntrospectionDisplay(undefined)).toBe('Never');
+  });
+
+  it('should return a relative time string for a valid timestamp', () => {
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    expect(lastIntrospectionDisplay(fiveMinutesAgo)).toBe('5 minutes ago');
   });
 });
 

--- a/src/Pages/Repositories/helpers.test.ts
+++ b/src/Pages/Repositories/helpers.test.ts
@@ -1,6 +1,11 @@
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import { hasOrigin, lastIntrospectionDisplay, versionNameToApiValue } from './helpers';
+import {
+  hasOrigin,
+  lastIntrospectionDisplay,
+  showPendingTooltip,
+  versionNameToApiValue,
+} from './helpers';
 
 dayjs.extend(relativeTime);
 
@@ -32,6 +37,30 @@ describe('lastIntrospectionDisplay', () => {
   it('should return a relative time string for a valid timestamp', () => {
     const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
     expect(lastIntrospectionDisplay(fiveMinutesAgo)).toBe('5 minutes ago');
+  });
+});
+
+describe('showPendingTooltip', () => {
+  it('should indicate snapshotting when snapshot status is running', () => {
+    expect(showPendingTooltip('running', undefined)).toBe('Snapshotting is in progress');
+  });
+
+  it('should indicate snapshotting when snapshot status is pending', () => {
+    expect(showPendingTooltip('pending', undefined)).toBe('Snapshotting is in progress');
+  });
+
+  it('should indicate introspection when introspect status is Pending', () => {
+    expect(showPendingTooltip(undefined, 'Pending')).toBe('Introspection is in progress');
+  });
+
+  it('should indicate both when neither status is provided', () => {
+    expect(showPendingTooltip(undefined, undefined)).toBe(
+      'Introspection or snapshotting is in progress',
+    );
+  });
+
+  it('should return undefined when statuses do not match any condition', () => {
+    expect(showPendingTooltip('completed', 'Valid')).toBeUndefined();
   });
 });
 

--- a/src/Pages/Repositories/helpers.ts
+++ b/src/Pages/Repositories/helpers.ts
@@ -1,7 +1,11 @@
 import { ContentOrigin } from '../../services/Content/ContentApi';
+import dayjs from 'dayjs';
 
 export const hasOrigin = (value: unknown): value is { origin?: ContentOrigin } =>
   typeof value === 'object' && value !== null && 'origin' in value;
+
+export const lastIntrospectionDisplay = (time?: string): string =>
+  time === '' || time === undefined ? 'Never' : dayjs(time).fromNow();
 
 /**
  * Converts a version name like "RHEL 8.5" to "8.5" for use in the API. Returns an empty string if no version is found.

--- a/src/Pages/Repositories/helpers.ts
+++ b/src/Pages/Repositories/helpers.ts
@@ -7,6 +7,19 @@ export const hasOrigin = (value: unknown): value is { origin?: ContentOrigin } =
 export const lastIntrospectionDisplay = (time?: string): string =>
   time === '' || time === undefined ? 'Never' : dayjs(time).fromNow();
 
+export const showPendingTooltip = (
+  snapshotStatus: string | undefined,
+  introspectStatus: string | undefined,
+) => {
+  if (!snapshotStatus && !introspectStatus) {
+    return 'Introspection or snapshotting is in progress';
+  } else if (snapshotStatus === 'running' || snapshotStatus === 'pending') {
+    return 'Snapshotting is in progress';
+  } else if (introspectStatus === 'Pending') {
+    return 'Introspection is in progress';
+  }
+};
+
 /**
  * Converts a version name like "RHEL 8.5" to "8.5" for use in the API. Returns an empty string if no version is found.
  */

--- a/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/steps/CustomRepositoriesStep.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/steps/CustomRepositoriesStep.tsx
@@ -186,7 +186,7 @@ export default function CustomRepositoriesStep() {
                     isDisabled={isLoading}
                     id='name-url'
                     ouiaId='filter_name_url'
-                    placeholder='Filter by name/url'
+                    placeholder='Filter by name or URL'
                     value={searchQuery}
                     onChange={(_event, value) => setSearchQuery(value)}
                     type='search'


### PR DESCRIPTION
## Summary

The `ContentListTable` is currently our only table implemented using data-view. We plan to use AI to migrate the remaining tables to data-view, and this PR polishes the `ContentListTable` so the AI has a clean, well-structured example to work from alongside the general migration guidelines.

- Modularize table components: Extract `RepositoryCell` and `RepositoryActionCell` into their own components, and add a `useRowActions` hook to centralize row action logic. This reduces the main component from ~600 lines and makes the structure easier to follow and replicate.

- Standardize IDs, aria labels, and filters: Adopt kebab-case for all `ouiaId` values, add explicit `aria-label` props, and add `ouiaId` to the toolbar. This is consistent with how data-view components should be wired up. Remove the unused `data-ouia-component-id` prop in favor of the `ouiaId` prop that data-view components consume.

- Align filter placeholder copy: Researched the Console app to align our filter placeholders (e.g. "Filter by name or URL") with the conventions used across other apps.

- Replace custom CSS with PatternFly utilities: Remove custom CSS in favor of properly composing PatternFly UI components and using built-in utility classes.

<img width="3291" height="1948" alt="Screenshot From 2026-05-02 22-57-25" src="https://github.com/user-attachments/assets/89ee489b-1caf-4ee3-a2ea-2778b18ec1b4" />

## Notes
I noticed a few tricky spots (things that weren't exactly straightforward) while tweaking the repositories table and testing the AI migration guide on some simpler tables:

- Manual CSS tweaks were still necessary. We have a lot of legacy custom CSS, and the AI usually couldn't figure out how to strip it away on its own. Ideally, we want to drop almost all of that custom styling since DataView is built to handle the design for us.

- TypeScript types were a bit of a struggle. The AI couldn't always type things correctly, so I ended up pointing it toward specific DataView implementation files. This helped it use the actual exported types instead of just making up custom ones.

- Keeping ouiaId unique. To make sure these IDs stay unique across the app, I had to explicitly tell the AI to generate distinct IDs for each table rather than reusing them or sticking with generic names.

- PatternFly guidelines. Sometimes the AI didn't quite get the component composition right. I shared the [PatternFly UI guide](https://github.com/patternfly/patternfly-mcp/tree/main) with it to help keep things aligned.

- For some reason, the AI kept ignoring the instruction to use dynamic imports for DataView components, even though it is in the migration guide. Definitely double check your imports, you might need to remind the AI to stick to the dynamic ones.

- It didn't know how to handle tables with expandable rows because the library doesn't export a specific expandable row component yet. I tried a workaround using a standard PatternFly component, but I want to check with the DataView team to see if they have something official in the works. I will ask for their thoughts on my implementation and see if we can add it to the migration guide. I will keep everyone posted once I hear back.

Next steps: We should think about the best way to reuse repeating logic and UI patterns across our DataView tables. The Inventory team already dealt with this, so I am going to dig into their code to see how they managed it.

## Testing steps

1. Verify the repositories table loads, filters, and pagination work as before
2. Verify bulk actions (delete, introspect) still function correctly       
3. Jest tests pass
4. Playwright tests pass