### PR TITLE
HMS-9843: Fix template page pagination unhandle error

### DIFF
--- a/src/Hooks/useCompatibleSystems.ts
+++ b/src/Hooks/useCompatibleSystems.ts
@@ -22,6 +22,7 @@ const useCompatibleSystems = (uuid: string) => {
   const {
     isFetching,
     isError,
+    error,
     data = { data: [], meta: { total_items: 0, limit: 20, offset: 0 } },
     // Filter by the version and arch of the given template (and minor if it is an extended support template)
     // Use default values for other parameters as they're not relevant for this hook
@@ -33,6 +34,7 @@ const useCompatibleSystems = (uuid: string) => {
     hasCompatibleSystems,
     isFetchingCompatibility: isFetching,
     isCompatibilityError: isError,
+    compatibilityError: error,
   };
 };
 

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.test.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.test.tsx
@@ -45,9 +45,9 @@ jest.mock('middleware/AppContext');
 });
 
 (useListSystemsByTemplateId as jest.Mock).mockImplementation(() => ({
-  isLoading: false,
-  isFetching: false,
-  isError: false,
+  isTemplateSystemsLoading: false,
+  isTemplateSystemsFetching: false,
+  isTemplateSystemsError: false,
   data: {
     data: new Array(15).fill(defaultTemplateSystemsListItem).map((item: IDSystemItem, index) => ({
       ...item,
@@ -105,9 +105,9 @@ it('renders system list as read-only with disabled checkboxes when user lacks wr
 
 it("shows empty state with register action when there are no registered systems that match the template's requirements", async () => {
   (useListSystemsByTemplateId as jest.Mock).mockImplementation(() => ({
-    isLoading: false,
-    isFetching: false,
-    isError: false,
+    isTemplateSystemsLoading: false,
+    isTemplateSystemsFetching: false,
+    isTemplateSystemsError: false,
   }));
 
   (useCompatibleSystems as jest.Mock).mockReturnValue({
@@ -129,9 +129,9 @@ it("shows empty state with register action when there are no registered systems 
 
 it('shows empty state with both assign and register actions when compatible, registered systems are present', async () => {
   (useListSystemsByTemplateId as jest.Mock).mockImplementation(() => ({
-    isLoading: false,
-    isFetching: false,
-    isError: false,
+    isTemplateSystemsLoading: false,
+    isTemplateSystemsFetching: false,
+    isTemplateSystemsError: false,
   }));
 
   (useCompatibleSystems as jest.Mock).mockReturnValue({

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.test.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { useListSystemsByTemplateId } from 'services/Systems/SystemsQueries';
-import TemplateSystemsTab from './TemplateSystemsTab';
+import TemplateSystemsTab, { calculatePageAfterSystemsDelete } from './TemplateSystemsTab';
 import { defaultTemplateSystemsListItem } from 'testingHelpers';
 import type { IDSystemItem } from 'services/Systems/SystemsApi';
 import { useAppContext } from 'middleware/AppContext';
@@ -28,7 +28,7 @@ jest.mock('@tanstack/react-query');
 
 jest.mock('services/Systems/SystemsQueries', () => ({
   useListSystemsByTemplateId: jest.fn(),
-  useDeleteTemplateFromSystems: () => ({ mutate: () => undefined, isLoading: false }),
+  useDeleteTemplateFromSystems: () => ({ mutateAsync: () => Promise.resolve(), isPending: false }),
 }));
 
 jest.mock('middleware/AppContext');
@@ -150,4 +150,18 @@ it('shows empty state with both assign and register actions when compatible, reg
   const registerAction = await screen.findByRole('link', { name: 'Register and assign via API' });
   expect(registerAction).toBeInTheDocument();
   expect(registerAction).toHaveAttribute('href', expectedHref);
+});
+
+describe('calculatePageAfterSystemsDelete', () => {
+  it('returns the same page when deletions keep the current page valid', () => {
+    expect(calculatePageAfterSystemsDelete(2, 20, 50, 5)).toBe(2);
+  });
+
+  it('moves to the previous valid page when deleting the last item on page 2', () => {
+    expect(calculatePageAfterSystemsDelete(2, 20, 21, 1)).toBe(1);
+  });
+
+  it('calculates page 3 after deleting 30 systems from total 90 on page 4', () => {
+    expect(calculatePageAfterSystemsDelete(4, 20, 90, 30)).toBe(3);
+  });
 });

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.tsx
@@ -55,7 +55,7 @@ const useStyles = createUseStyles({
     justifyContent: 'space-between',
   },
   // Needed to fix styling when "Add repositories" button is disabled
-  ctions: {
+  actions: {
     display: 'flex',
     flexDirection: 'row',
   },
@@ -224,7 +224,7 @@ export default function TemplateSystemsTab() {
                 customIcon={<SearchIcon />}
               />
             </InputGroupItem>
-            <FlexItem className={classes.ctions}>
+            <FlexItem className={classes.actions}>
               <ConditionalTooltip
                 content={`You do not have the required ${missingRequirements} to perform this action.`}
                 show={isMissingRequirements}

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.tsx
@@ -63,6 +63,21 @@ const useStyles = createUseStyles({
 
 const perPageKey = 'TemplateSystemsPerPage';
 
+export const calculatePageAfterSystemsDelete = (
+  currentPage: number,
+  perPage: number,
+  totalItems: number,
+  deletedItemsCount: number,
+) => {
+  if (deletedItemsCount <= 0) {
+    return currentPage;
+  }
+
+  const nextTotalItems = Math.max(0, totalItems - deletedItemsCount);
+  const maxPage = Math.max(1, Math.ceil(nextTotalItems / perPage));
+  return Math.min(currentPage, maxPage);
+};
+
 export default function TemplateSystemsTab() {
   const classes = useStyles();
   const queryClient = useQueryClient();
@@ -130,13 +145,6 @@ export default function TemplateSystemsTab() {
     meta: { total_items = 0 },
   } = data;
 
-  useEffect(() => {
-    const maxPage = Math.max(1, Math.ceil(total_items / perPage));
-    if (page > maxPage) {
-      setPage(maxPage);
-    }
-  }, [page, perPage, setPage, total_items]);
-
   const allSelected = useMemo(
     () => systemsList.every(({ inventory_id }) => selectedList.has(inventory_id)),
     [selectedList, systemsList],
@@ -167,8 +175,16 @@ export default function TemplateSystemsTab() {
     }
   };
 
-  const deselectAll = () => {
-    setSelected([]);
+  const handleDeleteSystems = async (items: string[]) => {
+    const nextPage = calculatePageAfterSystemsDelete(page, perPage, total_items, items.length);
+    const deletedSystems = new Set(items);
+
+    if (nextPage !== page) {
+      setPage(nextPage);
+    }
+
+    await deleteFromSystems(items);
+    setSelected((prev) => prev.filter((selectedId) => !deletedSystems.has(selectedId)));
   };
 
   const onPerPageSelect = (_, newPerPage, newPage) => {
@@ -253,8 +269,7 @@ export default function TemplateSystemsTab() {
               setDisabled
             >
               <SystemsDeleteKebab
-                deleteFromSystems={deleteFromSystems}
-                deselectAll={deselectAll}
+                deleteFromSystems={handleDeleteSystems}
                 isDisabled={!rbac?.templateWrite || selected.length > TEMPLATE_SYSTEMS_UPDATE_LIMIT}
                 selected={selected}
               />
@@ -337,7 +352,7 @@ export default function TemplateSystemsTab() {
           allSelected={allSelected}
           perPage={perPage}
           selectAllToggle={selectAllToggle}
-          deleteFromSystems={deleteFromSystems}
+          deleteFromSystems={handleDeleteSystems}
           isLoadingOrDeleting={loadingOrDeleting}
           systemsList={systemsList}
           sortParams={sortParams}

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.tsx
@@ -108,13 +108,17 @@ export default function TemplateSystemsTab() {
     [activeSortIndex, activeSortDirection],
   );
 
-  const { hasCompatibleSystems, isFetchingCompatibility, isCompatibilityError } =
-    useCompatibleSystems(uuid);
+  const {
+    hasCompatibleSystems,
+    isFetchingCompatibility,
+    isCompatibilityError,
+    compatibilityError,
+  } = useCompatibleSystems(uuid);
 
   const {
-    isLoading,
-    error,
-    isError,
+    isTemplateSystemsLoading,
+    templateSystemsError,
+    isTemplateSystemsError,
     data = { data: [], meta: { total_items: 0, limit: 20, offset: 0 } },
   } = useListSystemsByTemplateId(uuid, page, perPage, debouncedSearchQuery, sortString);
 
@@ -125,6 +129,13 @@ export default function TemplateSystemsTab() {
     data: systemsList = [],
     meta: { total_items = 0 },
   } = data;
+
+  useEffect(() => {
+    const maxPage = Math.max(1, Math.ceil(total_items / perPage));
+    if (page > maxPage) {
+      setPage(maxPage);
+    }
+  }, [page, perPage, setPage, total_items]);
 
   const allSelected = useMemo(
     () => systemsList.every(({ inventory_id }) => selectedList.has(inventory_id)),
@@ -166,9 +177,7 @@ export default function TemplateSystemsTab() {
     localStorage.setItem(perPageKey, newPerPage.toString());
   };
 
-  const loadingOrDeleting = isLoading || isDeleting;
-
-  const errorState = isError || isCompatibilityError;
+  const loadingOrDeleting = isTemplateSystemsLoading || isDeleting;
 
   const sortParams = (columnIndex: number): ThProps['sort'] | undefined =>
     columnSortAttributes[columnIndex]
@@ -191,12 +200,12 @@ export default function TemplateSystemsTab() {
   const missingRequirements =
     rbac?.templateWrite && !hasRHELSubscription ? 'subscription (RHEL)' : 'permission';
 
-  if (isLoading || isFetchingCompatibility) {
+  if (isTemplateSystemsLoading || isFetchingCompatibility) {
     return <Loader />;
   }
 
-  if (errorState) {
-    throw error;
+  if (isTemplateSystemsError || isCompatibilityError) {
+    throw templateSystemsError ?? compatibilityError;
   }
 
   return (
@@ -286,7 +295,7 @@ export default function TemplateSystemsTab() {
                       id='addSystemsButton'
                       ouiaId='add_systems'
                       variant='primary'
-                      isDisabled={isLoading}
+                      isDisabled={isTemplateSystemsLoading}
                       onClick={() => {
                         const method = hasCompatibleSystems
                           ? '' // If there are some registered systems, open the system list view

--- a/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.test.tsx
@@ -37,10 +37,9 @@ jest.mock('middleware/AppContext', () => ({ useAppContext: () => ({}) }));
 
 it('Render delete modal where there are no systems', () => {
   (useListSystemsByTemplateId as jest.Mock).mockImplementation(() => ({
+    isTemplateSystemsLoading: false,
     data: {
-      isLoading: false,
       data: [],
-      count: 0,
       meta: { total_items: 0 },
     },
   }));
@@ -64,12 +63,15 @@ it('Render delete modal where there are no systems', () => {
 
 it('Render delete modal where template has one system', () => {
   (useListSystemsByTemplateId as jest.Mock).mockImplementation(() => ({
+    isTemplateSystemsLoading: false,
     data: {
-      isLoading: false,
       data: [defaultSystemsListItem],
-      count: 1,
-      meta: { total_items: 0 },
+      meta: { total_items: 1 },
     },
+  }));
+  (useFetchTemplate as jest.Mock).mockImplementation(() => ({
+    isLoading: false,
+    data: { name: 'test' },
   }));
 
   const { queryByText } = render(

--- a/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/DeleteTemplateModal.tsx
@@ -74,11 +74,11 @@ export default function DeleteTemplateModal() {
   }, []);
 
   const {
-    isLoading: isLoading,
+    isTemplateSystemsLoading,
     data: systems = { data: [], meta: { count: 0, limit: 1, offset: 0, total_items: 0 } },
   } = useListSystemsByTemplateId(uuid, 1, 1, '', '');
 
-  const actionTakingPlace = isLoading || isDeleting;
+  const actionTakingPlace = isTemplateSystemsLoading || isDeleting;
 
   return (
     <Modal
@@ -95,7 +95,7 @@ export default function DeleteTemplateModal() {
         titleIconVariant='warning'
       />
       <ModalBody>
-        <Hide hide={!isLoading && !isTemplateLoading}>
+        <Hide hide={!isTemplateSystemsLoading && !isTemplateLoading}>
           <Bullseye>
             <Spinner />
           </Bullseye>
@@ -118,7 +118,7 @@ export default function DeleteTemplateModal() {
             </Flex>
           </Alert>
         </Hide>
-        <Hide hide={isLoading || isTemplateLoading}>
+        <Hide hide={isTemplateSystemsLoading || isTemplateLoading}>
           <Content component='p' className={classes.description}>
             Template <b>{templateData?.name}</b> and all its data will be deleted. This action
             cannot be undone.

--- a/src/components/SharedTables/SystemsTable/Components/SystemsDeleteKebab.test.tsx
+++ b/src/components/SharedTables/SystemsTable/Components/SystemsDeleteKebab.test.tsx
@@ -14,7 +14,6 @@ it('renders with no checked systems', async () => {
   render(
     <SystemsDeleteKebab
       selected={selected}
-      deselectAll={jest.fn()}
       deleteFromSystems={jest.fn()}
       isDisabled={selected.length > TEMPLATE_SYSTEMS_UPDATE_LIMIT}
     />,
@@ -34,7 +33,6 @@ it('renders with checked systems', async () => {
   render(
     <SystemsDeleteKebab
       selected={selected}
-      deselectAll={jest.fn()}
       deleteFromSystems={jest.fn()}
       isDisabled={selected.length > TEMPLATE_SYSTEMS_UPDATE_LIMIT}
     />,
@@ -57,7 +55,6 @@ it('prevents unassigning a template when more than 1000 systems are selected', a
   render(
     <SystemsDeleteKebab
       selected={selected}
-      deselectAll={jest.fn()}
       deleteFromSystems={jest.fn()}
       isDisabled={selected.length > TEMPLATE_SYSTEMS_UPDATE_LIMIT}
     />,

--- a/src/components/SharedTables/SystemsTable/Components/SystemsDeleteKebab.tsx
+++ b/src/components/SharedTables/SystemsTable/Components/SystemsDeleteKebab.tsx
@@ -5,17 +5,15 @@ import { useState } from 'react';
 
 interface Props {
   selected: string[];
-  deselectAll: () => void;
-  deleteFromSystems: (items: string[]) => void;
+  deleteFromSystems: (items: string[]) => Promise<unknown> | void;
   isDisabled?: boolean;
 }
 
-const SystemsDeleteKebab = ({ deselectAll, isDisabled, selected, deleteFromSystems }: Props) => {
+const SystemsDeleteKebab = ({ isDisabled, selected, deleteFromSystems }: Props) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const onSelect = () => {
     setIsOpen(false);
-    deselectAll();
   };
 
   return (

--- a/src/components/SharedTables/SystemsTable/index.tsx
+++ b/src/components/SharedTables/SystemsTable/index.tsx
@@ -53,7 +53,7 @@ interface Props {
   selected: Set<string>;
   editAllowed: boolean;
   setSelected: (id: string) => void;
-  deleteFromSystems: (items: string[]) => void;
+  deleteFromSystems: (items: string[]) => Promise<unknown> | void;
   sortParams?: (columnIndex: number) => ThProps['sort'];
   selectAllToggle: () => void;
   allSelected: boolean;

--- a/src/services/Systems/SystemsApi.ts
+++ b/src/services/Systems/SystemsApi.ts
@@ -151,33 +151,6 @@ const emptyTemplateSystemsResponse = (limit: number, offset = 0): IDSystemsColle
   },
 });
 
-/** Patch 400 when offset is past the list (JSON:API errors or legacy `{ error: string }`). */
-const isInvalidOffsetPatchAxiosError = (err: unknown): boolean => {
-  if (!axios.isAxiosError(err) || err.response?.status !== 400) {
-    return false;
-  }
-
-  const data = err.response.data as
-    | {
-        error?: string;
-        errors?: Array<{ code?: string; source?: { pointer?: string; parameter?: string } }>;
-      }
-    | undefined;
-
-  const firstError = data?.errors?.[0];
-  // Backend currently returns { error: "Invalid offset" } for this case.
-  const isLegacyInvalidOffsetMessage = data?.error === 'Invalid offset';
-  const isInvalidOffsetCode = firstError?.code === 'INVALID_OFFSET';
-  const isOffsetParameter =
-    firstError?.source?.parameter === 'offset' || firstError?.source?.pointer === '/meta/offset';
-
-  return Boolean(isLegacyInvalidOffsetMessage || isInvalidOffsetCode || isOffsetParameter);
-};
-
-/** Invalid offset on page > 1 after the list shrinks (e.g. bulk unassign). */
-const isRecoverableTemplateSystemsPaginationError = (err: unknown, page: number): boolean =>
-  page > 1 && isInvalidOffsetPatchAxiosError(err);
-
 export const getSystemsList: (
   page: number,
   limit: number,
@@ -223,39 +196,20 @@ export const listSystemsByTemplateId: (
   search: string,
   sortBy?: string,
 ) => Promise<IDSystemsCollectionResponse> = async (templateId, page, limit, search, sortBy) => {
-  const requestPage = async (pageNum: number): Promise<IDSystemsCollectionResponse> => {
-    try {
-      const { data } = await axios.get<IDSystemsCollectionResponse>(
-        `${patchApiVersionUrl}/templates/${templateId}/systems?${objectToUrlParams({
-          offset: ((pageNum - 1) * limit).toString(),
-          limit: limit?.toString(),
-          search,
-          sort: sortBy,
-        })}`,
-      );
-      return data;
-    } catch (err) {
-      // The Patch API returns 404 when no systems are assigned to the template
-      if (axios.isAxiosError(err) && err.response?.status === 404) {
-        return emptyTemplateSystemsResponse(limit, (pageNum - 1) * limit);
-      }
-      throw err;
-    }
-  };
-
   try {
-    return await requestPage(page);
+    const { data } = await axios.get<IDSystemsCollectionResponse>(
+      `${patchApiVersionUrl}/templates/${templateId}/systems?${objectToUrlParams({
+        offset: ((page - 1) * limit).toString(),
+        limit: limit?.toString(),
+        search,
+        sort: sortBy,
+      })}`,
+    );
+    return data;
   } catch (err) {
-    // After bulk unassign, the UI can still be on a page whose offset is past the new total
-    if (isRecoverableTemplateSystemsPaginationError(err, page)) {
-      const firstPage = await requestPage(1);
-      const total = firstPage.meta?.total_items ?? 0;
-      const maxPage = Math.max(1, Math.ceil(total / limit));
-      const targetPage = Math.min(page, maxPage);
-      if (targetPage <= 1) {
-        return firstPage;
-      }
-      return requestPage(targetPage);
+    // The Patch API returns 404 when no systems are assigned to the template
+    if (axios.isAxiosError(err) && err.response?.status === 404) {
+      return emptyTemplateSystemsResponse(limit, (page - 1) * limit);
     }
     throw err;
   }

--- a/src/services/Systems/SystemsApi.ts
+++ b/src/services/Systems/SystemsApi.ts
@@ -36,7 +36,7 @@ export interface SystemAttributes {
   baseline_id: number;
   template_name: string;
   template_uuid: string;
-  groups: string[];
+  groups: SystemGroup[];
 }
 
 export interface SystemItem {
@@ -139,6 +139,45 @@ export interface PatchTemplatesResponse {
 
 const patchApiVersionUrl = '/api/patch/v3';
 
+const emptyTemplateSystemsResponse = (limit: number, offset = 0): IDSystemsCollectionResponse => ({
+  data: [],
+  links: { first: '', last: '' },
+  meta: {
+    total_items: 0,
+    limit,
+    offset,
+    has_systems: false,
+    subtotals: { patched: 0, stale: 0, unpatched: 0 },
+  },
+});
+
+/** Patch 400 when offset is past the list (JSON:API errors or legacy `{ error: string }`). */
+const isInvalidOffsetPatchAxiosError = (err: unknown): boolean => {
+  if (!axios.isAxiosError(err) || err.response?.status !== 400) {
+    return false;
+  }
+
+  const data = err.response.data as
+    | {
+        error?: string;
+        errors?: Array<{ code?: string; source?: { pointer?: string; parameter?: string } }>;
+      }
+    | undefined;
+
+  const firstError = data?.errors?.[0];
+  // Backend currently returns { error: "Invalid offset" } for this case.
+  const isLegacyInvalidOffsetMessage = data?.error === 'Invalid offset';
+  const isInvalidOffsetCode = firstError?.code === 'INVALID_OFFSET';
+  const isOffsetParameter =
+    firstError?.source?.parameter === 'offset' || firstError?.source?.pointer === '/meta/offset';
+
+  return Boolean(isLegacyInvalidOffsetMessage || isInvalidOffsetCode || isOffsetParameter);
+};
+
+/** Invalid offset on page > 1 after the list shrinks (e.g. bulk unassign). */
+const isRecoverableTemplateSystemsPaginationError = (err: unknown, page: number): boolean =>
+  page > 1 && isInvalidOffsetPatchAxiosError(err);
+
 export const getSystemsList: (
   page: number,
   limit: number,
@@ -146,70 +185,80 @@ export const getSystemsList: (
   filter: SystemsFilters,
   sortBy?: string,
 ) => Promise<SystemsCollectionResponse> = async (page, limit, search, filter, sortBy) => {
-  const { data } = await axios.get(
-    `${patchApiVersionUrl}/systems?${objectToUrlParams({
-      page: page.toString(),
-      limit: limit?.toString(),
-      offset: ((page - 1) * limit).toString(),
-      sort: sortBy,
-      search,
-      tags: filter.tags?.map((tag) => encodeURIComponent(tag)) || '',
-      [encodeURI('filter[id]')]: filter.ids ? encodeURI(`in:${filter.ids.join(',')}`) : '',
-      [encodeURI('filter[stale]')]: filter.stale
-        ? encodeURI(`in:${filter.stale}`)
-        : encodeURI('in:true,false'),
-      [encodeURI('filter[osname]')]: 'RHEL', // Hardcoded for now
-      [encodeURI('filter[osmajor]')]: filter.os,
-      ...(filter.osminor ? { [encodeURI('filter[osminor]')]: filter.osminor } : {}),
-      [encodeURI('filter[arch]')]: filter?.arch,
-    })}`,
-    {},
+  const queryString = objectToUrlParams({
+    page: page.toString(),
+    limit: limit?.toString(),
+    offset: ((page - 1) * limit).toString(),
+    sort: sortBy,
+    search,
+    tags: filter.tags?.map((tag) => encodeURIComponent(tag)) || '',
+    [encodeURI('filter[stale]')]: filter.stale
+      ? encodeURI(`in:${filter.stale}`)
+      : encodeURI('in:true,false'),
+    [encodeURI('filter[osname]')]: 'RHEL', // Hardcoded for now
+    [encodeURI('filter[osmajor]')]: filter.os,
+    ...(filter.osminor ? { [encodeURI('filter[osminor]')]: filter.osminor } : {}),
+    [encodeURI('filter[arch]')]: filter?.arch,
+  });
+
+  if (filter.ids?.length) {
+    const { data } = await axios.post<SystemsCollectionResponse>(
+      `${patchApiVersionUrl}/systems?${queryString}`,
+      { ids: filter.ids },
+    );
+    return data;
+  }
+
+  const { data } = await axios.get<SystemsCollectionResponse>(
+    `${patchApiVersionUrl}/systems?${queryString}`,
   );
   return data;
 };
 
+/** Lists systems assigned to a template via GET `/templates/{template_id}/systems`. */
 export const listSystemsByTemplateId: (
-  id: string,
+  templateId: string,
   page: number,
   limit: number,
   search: string,
   sortBy?: string,
-) => Promise<IDSystemsCollectionResponse> = async (id, page, limit, search, sortBy) => {
+) => Promise<IDSystemsCollectionResponse> = async (templateId, page, limit, search, sortBy) => {
+  const requestPage = async (pageNum: number): Promise<IDSystemsCollectionResponse> => {
+    try {
+      const { data } = await axios.get<IDSystemsCollectionResponse>(
+        `${patchApiVersionUrl}/templates/${templateId}/systems?${objectToUrlParams({
+          offset: ((pageNum - 1) * limit).toString(),
+          limit: limit?.toString(),
+          search,
+          sort: sortBy,
+        })}`,
+      );
+      return data;
+    } catch (err) {
+      // The Patch API returns 404 when no systems are assigned to the template
+      if (axios.isAxiosError(err) && err.response?.status === 404) {
+        return emptyTemplateSystemsResponse(limit, (pageNum - 1) * limit);
+      }
+      throw err;
+    }
+  };
+
   try {
-    const { data } = await axios.get(
-      `${patchApiVersionUrl}/templates/${id}/systems?${objectToUrlParams({
-        offset: ((page - 1) * limit).toString(),
-        limit: limit?.toString(),
-        search,
-        sort: sortBy,
-      })}`,
-    );
-    return data;
+    return await requestPage(page);
   } catch (err) {
-    // The Patch API returns 404 when no systems are assigned to the template
-    // We normalize this to an empty response to avoid the UI from crashing on the 404 error
-    if (axios.isAxiosError(err) && err.response?.status === 404) {
-      return {
-        data: [],
-        links: { first: '', last: '' },
-        meta: {
-          total_items: 0,
-          limit,
-          offset: 0,
-          has_systems: false,
-          subtotals: { patched: 0, stale: 0, unpatched: 0 },
-        },
-      };
+    // After bulk unassign, the UI can still be on a page whose offset is past the new total
+    if (isRecoverableTemplateSystemsPaginationError(err, page)) {
+      const firstPage = await requestPage(1);
+      const total = firstPage.meta?.total_items ?? 0;
+      const maxPage = Math.max(1, Math.ceil(total / limit));
+      const targetPage = Math.min(page, maxPage);
+      if (targetPage <= 1) {
+        return firstPage;
+      }
+      return requestPage(targetPage);
     }
     throw err;
   }
-};
-
-export const listSystemsIDsByTemplateId: (
-  id: string,
-) => Promise<SystemsCollectionResponse> = async (id) => {
-  const { data } = await axios.get(`${patchApiVersionUrl}/ids/templates/${id}/systems`);
-  return data;
 };
 
 export const addTemplateToSystems: (

--- a/src/services/Systems/SystemsQueries.ts
+++ b/src/services/Systems/SystemsQueries.ts
@@ -52,8 +52,8 @@ export const useListSystemsByTemplateId = (
   limit: number,
   searchQuery: string,
   sortBy?: string,
-) =>
-  useQuery({
+) => {
+  const pageQuery = useQuery({
     queryKey: [GET_TEMPLATE_SYSTEMS_KEY, id, page, limit, searchQuery, sortBy],
     queryFn: () => listSystemsByTemplateId(id, page, limit, searchQuery, sortBy),
     placeholderData: keepPreviousData,
@@ -63,9 +63,18 @@ export const useListSystemsByTemplateId = (
     refetchInterval: 20_000,
     meta: {
       title: 'Unable to fetch systems assigned to this template',
-      id: 'systems-list-error',
+      id: 'template-systems-page-query-error',
     },
   });
+
+  return {
+    ...pageQuery,
+    isTemplateSystemsLoading: pageQuery.isLoading,
+    isTemplateSystemsFetching: pageQuery.isFetching,
+    isTemplateSystemsError: pageQuery.isError,
+    templateSystemsError: pageQuery.error,
+  };
+};
 
 export const useAddTemplateToSystemsQuery = (
   queryClient: QueryClient,


### PR DESCRIPTION

## Summary
Fix template page pagination unhandle error

Patch template systems returns 400 when offset is past the new total; handle like existing 404 normalization and clamp UI page to meta.
[HMS-9843] [UI] Template page breaks when trying to unassign all systems from a template while being on the last page of the paginated system list

## Testing steps
    Test with UI running in local mode to see the fix
    Register minimum 11 systems to a template in console
    Choose to display 10 systems per page from pagination dropdown
    Select all systems from all the pages to unassign from the template
    Be on the last page and click on Unassign template kebab menu button

[HMS-9843]: https://redhat.atlassian.net/browse/HMS-9843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ