### PR TITLE
Test: Set dependabot ignore for major updates to ts-patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,9 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # ts-patch v4+ targets TypeScript 6; keep 3.x while the app stays on TypeScript 5.9.x
+      - dependency-name: "ts-patch"
+        update-types: ["version-update:semver-major"]
       # eslint-plugin-react is not yet compatible with ESLint 10 (context API)
       # TODO: Revert this change when possible (HMS-10187)
       - dependency-name: "eslint"

--- a/package.json
+++ b/package.json
@@ -119,13 +119,16 @@
     "prop-types": "15.8.1",
     "source-map": "^0.8.0-beta.0",
     "ts-jest": "^29.4.9",
-    "ts-patch": "^4.0.1",
+    "ts-patch": ">=3.3.0 <4.0.0",
     "typescript": "^5.9.2",
     "webpack-bundle-analyzer": "^5.2.0"
   },
   "insights": {
     "appname": "content-sources",
     "buildrepo": "git@github.com:RedHatInsights/content-sources-frontend-build.git"
+  },
+  "resolutions": {
+    "ts-patch": ">=3.3.0 <4.0.0"
   },
   "jest-junit": {
     "outputDirectory": "test-results",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10149,7 +10149,7 @@ resolve.exports@^2.0.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.3.tgz#41955e6f1b4013b7586f873749a635dea07ebe3f"
   integrity sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==
 
-resolve@^1.1.7, resolve@^1.20.0, resolve@^1.22.11, resolve@^1.22.12:
+resolve@^1.1.7, resolve@^1.20.0, resolve@^1.22.11, resolve@^1.22.2:
   version "1.22.12"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.12.tgz#f5b2a680897c69c238a13cd16b15671f8b73549f"
   integrity sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==
@@ -11219,16 +11219,16 @@ ts-loader@^9.4.4:
     semver "^7.3.4"
     source-map "^0.7.4"
 
-ts-patch@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/ts-patch/-/ts-patch-4.0.1.tgz#7f270d970c403232e3946b80e0b57ae83d991a54"
-  integrity sha512-pzXS6vZlsBwq3U+CUiPJfCAh0MJGco1j1C8bWsLgvtzDZLGZ7II1Usjtwm09mZ8Uoma+sg6sO3BlWHd6apCUww==
+"ts-patch@>=3.3.0 <4.0.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/ts-patch/-/ts-patch-3.3.0.tgz#a33a84b6c60c4b73848d7a7d95791722e1ee8e88"
+  integrity sha512-zAOzDnd5qsfEnjd9IGy1IRuvA7ygyyxxdxesbhMdutt8AHFjD8Vw8hU2rMF89HX1BKRWFYqKHrO8Q6lw0NeUZg==
   dependencies:
     chalk "^4.1.2"
     global-prefix "^4.0.0"
     minimist "^1.2.8"
-    resolve "^1.22.12"
-    semver "^7.7.4"
+    resolve "^1.22.2"
+    semver "^7.6.3"
     strip-ansi "^6.0.1"
 
 ts-pattern@^5.8.0:


### PR DESCRIPTION


## Summary
Set dependabot ignore for major updates to ts-patch
To prevent conflict with Typescript version
## Testing steps
