### PR TITLE
HMS-9614: UI for remove rpm packages

### DIFF
--- a/_playwright-tests/UI/DeletePackages.spec.ts
+++ b/_playwright-tests/UI/DeletePackages.spec.ts
@@ -1,0 +1,170 @@
+import path from 'path';
+import type { Page } from '@playwright/test';
+
+import {
+  test,
+  expect,
+  cleanupRepositories,
+  randomName,
+  waitWhileRepositoryIsPending,
+} from 'test-utils';
+import { BULK_TASK_TIMEOUT_MS } from '../testConstants';
+import {
+  closeGenericPopupsIfExist,
+  getRowByNameOrUrl,
+  retry,
+  waitForValidStatus,
+} from './helpers/helpers';
+import { navigateToRepositories } from './helpers/navHelpers';
+
+const uploadRepoNamePrefix = 'package-modal-delete-upload';
+const externalRepoNamePrefix = 'package-modal-delete-external';
+const externalRepoUrl = 'https://jlsherrill.fedorapeople.org/fake-repos/signed/';
+const packageName = 'bear';
+
+const openPackagesModal = async (page: Page, repoName: string) => {
+  const row = await getRowByNameOrUrl(page, repoName);
+  await row.getByTestId('package_count_button').click();
+  const packagesModal = page.getByRole('dialog', { name: 'Packages' });
+  await expect(packagesModal).toBeVisible();
+  await expect(packagesModal.getByTestId('packages_table')).toBeVisible();
+  return packagesModal;
+};
+
+test.describe('PackageModal delete packages', () => {
+  test('Upload repository can delete a package from PackageModal', async ({
+    page,
+    client,
+    cleanup,
+  }) => {
+    const uploadRepoName = `${uploadRepoNamePrefix}-${randomName()}`;
+
+    await cleanup.runAndAdd(() => cleanupRepositories(client, uploadRepoNamePrefix));
+    await closeGenericPopupsIfExist(page);
+    await navigateToRepositories(page);
+
+    await test.step('Create upload repository and upload an RPM', async () => {
+      // click add button
+      await page.getByRole('button', { name: 'Add repositories' }).first().click();
+
+      // fill name and check upload checkbox, that is all that is needed
+      await page.getByPlaceholder('Enter name').fill(uploadRepoName);
+      await page.getByLabel('Upload', { exact: true }).check();
+
+      // click save and other modal will get shown
+      const [, bulkCreateResponse] = await Promise.all([
+        page.getByRole('button', { name: 'Save and upload content' }).click(),
+        page.waitForResponse(
+          (resp) =>
+            resp.url().includes('/bulk_create/') && resp.status() >= 200 && resp.status() < 300,
+          { timeout: BULK_TASK_TIMEOUT_MS },
+        ),
+      ]);
+
+      // wait until check repository status becomes valid and "drag and drop" with upload button shows
+      const bulkCreateData = await bulkCreateResponse.json();
+      const repoUuid = bulkCreateData[0]?.uuid;
+      expect(repoUuid).toBeTruthy();
+      const repo = await waitWhileRepositoryIsPending(client, repoUuid);
+      expect(repo.status).toBe('Valid');
+      await expect(page.getByText('Drag and drop files here')).toBeVisible();
+
+      // put in the file to upload
+      const filePath = path.join(__dirname, './fixtures/bear-4.1-1.noarch.rpm');
+      await retry(page, async (page) => {
+        await page.locator('input[type=file]').first().setInputFiles(filePath);
+      });
+      await expect(page.getByText('All uploads completed!')).toBeVisible();
+      await page.getByRole('button', { name: 'Confirm changes' }).click();
+
+      await waitForValidStatus(page, uploadRepoName);
+    });
+
+    await test.step('Delete package via row actions in PackageModal', async () => {
+      // click on number of package to open the packages modal
+      let packagesModal = await openPackagesModal(page, uploadRepoName);
+
+      let row = await getRowByNameOrUrl(packagesModal, packageName);
+
+      // check that bulk select and delete kebab is visible
+      await expect(packagesModal.locator('.pf-v6-c-table__td.pf-v6-c-table__check')).toBeVisible();
+      await expect(packagesModal.getByTestId('delete-kebab')).toBeVisible();
+
+      // click on the package to delete
+      const packageRow = packagesModal.getByRole('row').filter({ hasText: packageName });
+      await expect(packageRow).toBeVisible();
+      await row.getByRole('button', { name: 'Kebab toggle' }).click();
+      await page.getByRole('menuitem', { name: 'Delete package' }).click();
+
+      // expect that new delete packages? confirm modal shows up
+      await expect(page.getByTestId('delete_packages')).toBeVisible();
+      await expect(page.getByText('Delete packages?')).toBeVisible();
+      await expect(
+        page.getByTestId('confirm_delete_packages_table').getByText(packageName),
+      ).toBeVisible();
+
+      // confirm to delete the package
+      await Promise.all([
+        page.waitForResponse(
+          (resp) =>
+            resp.url().includes('/rpms/bulk_remove') && resp.status() >= 200 && resp.status() < 300,
+        ),
+        page.getByTestId('delete_packages_confirm').click(),
+      ]);
+
+      row = await getRowByNameOrUrl(page, uploadRepoName);
+      await waitForValidStatus(page, uploadRepoName);
+      await expect(row.getByTestId('package_count_button').getByText('0')).toBeVisible();
+
+      // verify that no packages show up in the package modal
+      packagesModal = await openPackagesModal(page, uploadRepoName);
+      await expect(packagesModal.getByRole('heading', { name: 'No packages' })).toBeVisible();
+      await packagesModal.getByRole('button').getByText('Close').click();
+    });
+  });
+
+  test('Non-upload repository does not show delete controls in PackageModal', async ({
+    page,
+    client,
+    cleanup,
+  }) => {
+    const externalRepoName = `${externalRepoNamePrefix}-${randomName()}`;
+
+    await cleanup.runAndAdd(() =>
+      cleanupRepositories(client, externalRepoNamePrefix, externalRepoUrl),
+    );
+    await closeGenericPopupsIfExist(page);
+    await navigateToRepositories(page);
+
+    await test.step('Create external snapshot repository', async () => {
+      // create external repository
+      await page.getByRole('button', { name: 'Add repositories' }).first().click();
+
+      await page.getByRole('textbox', { name: 'Name', exact: true }).fill(externalRepoName);
+      await page.getByLabel('Snapshotting').click();
+      await page.getByRole('textbox', { name: 'URL', exact: true }).fill(externalRepoUrl);
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+      await waitForValidStatus(page, externalRepoName);
+    });
+
+    await test.step('Verify delete controls are not available in PackageModal', async () => {
+      const packagesModal = await openPackagesModal(page, externalRepoName);
+
+      await expect(
+        packagesModal
+          .getByTestId('packages_table')
+          .getByRole('row')
+          .filter({ has: page.getByRole('gridcell') })
+          .first(),
+      ).toBeVisible();
+      await expect(
+        packagesModal
+          .getByTestId('packages_table')
+          .getByRole('row')
+          .filter({ has: page.getByRole('gridcell') })
+          .first()
+          .getByRole('button', { name: 'Kebab toggle' }),
+      ).toBeHidden();
+    });
+  });
+});

--- a/_playwright-tests/UI/IntrospectRepo.spec.ts
+++ b/_playwright-tests/UI/IntrospectRepo.spec.ts
@@ -58,7 +58,14 @@ test.describe('Introspect Repositories', () => {
       const modal = page.getByTestId('rpm_package_modal');
       const row = modal.getByRole('row').filter({ has: page.getByText(testPackage) });
       await Promise.all([
-        expect(modal.locator('tbody')).toHaveCount(8),
+        expect(
+          modal
+            .getByTestId('packages_table')
+            .getByRole('row')
+            .filter({
+              has: page.getByRole('gridcell'),
+            }),
+        ).toHaveCount(8),
         expect((await getRowCellByHeader(page, row, 'Name')).getByText(testPackage)).toBeVisible(),
         expect(
           (await getRowCellByHeader(page, row, 'Version')).getByText(repoVersion),

--- a/_playwright-tests/UI/RepositoryPackages.spec.ts
+++ b/_playwright-tests/UI/RepositoryPackages.spec.ts
@@ -73,11 +73,13 @@ test.describe('Snapshot Package Count and List', () => {
       const editedRow = await getRowByNameOrUrl(page, editedRepo);
       await editedRow.getByTestId('package_count_button').click();
       await expect(page.getByRole('dialog', { name: 'Packages' })).toBeVisible();
-      await page.getByRole('searchbox', { name: 'Filter by name' }).fill('bear');
-      await expect(page.getByText('bear')).toBeVisible();
+      await page.getByRole('textbox', { name: 'Name filter' }).fill('bear');
+      await expect(
+        page.getByTestId('packages_table_noselect-td-0-0').getByText('bear'),
+      ).toBeVisible();
       // check that non exixiting package is not visible in the list
-      await page.getByRole('searchbox', { name: 'Filter by name' }).fill('non-existing-package');
-      await expect(page.getByText('non-existing-package')).toBeHidden();
+      await page.getByRole('textbox', { name: 'Name filter' }).fill('non-existing-package');
+      await expect(page.getByRole('grid').getByText('non-existing-package')).toBeHidden();
       await expect(
         page.getByRole('heading', { name: 'No packages match the filter criteria' }),
       ).toBeVisible();

--- a/src/Hooks/navigation/navigationPaths.ts
+++ b/src/Hooks/navigation/navigationPaths.ts
@@ -1,0 +1,37 @@
+import { ContentOrigin } from 'services/Content/ContentApi';
+
+import { PACKAGES_ROUTE, REPOSITORIES_ROUTE } from 'Routes/constants';
+
+export type DestinationKey = 'repositories' | 'packagesLatest' | 'root';
+
+type NavigationPaths = Record<DestinationKey, BuildDestinationPath>;
+type BuildDestinationPath = (params: DestinationParams) => string;
+type DestinationParams = {
+  contentOrigin: ContentOrigin[];
+  rootPath: string;
+  repoUUID: string;
+};
+
+/**
+ * Record that builds appropriate location string based on runtime parameters.
+ *
+ * To create a new destination, put (1) a new key into DestinationKey type.
+ * (2) for this key define a new function that builds the final destination string.
+ * You can use already defined DestinaionParams or define in the type new ones
+ * if something is missing. In that case you also need to make appropriate
+ * changes in the useNavigationTo hook.
+ */
+export const navigationPaths: NavigationPaths = {
+  root: ({ rootPath, contentOrigin }) =>
+    rootPath +
+    (contentOrigin.length === 1 && contentOrigin[0] === ContentOrigin.REDHAT
+      ? `?origin=${contentOrigin}`
+      : ''),
+  packagesLatest: ({ rootPath, repoUUID }) =>
+    `${rootPath}/${REPOSITORIES_ROUTE}/${repoUUID}/${PACKAGES_ROUTE}`,
+  repositories: ({ rootPath, contentOrigin }) =>
+    `${rootPath}/${REPOSITORIES_ROUTE}` +
+    (contentOrigin.length === 1 && contentOrigin[0] === ContentOrigin.REDHAT
+      ? `?origin=${contentOrigin}`
+      : ''),
+};

--- a/src/Hooks/navigation/useNavigateTo.ts
+++ b/src/Hooks/navigation/useNavigateTo.ts
@@ -1,0 +1,27 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import useRootPath from 'Hooks/useRootPath';
+import useSafeUUIDParam from 'Hooks/useSafeUUIDParam';
+
+import { useAppContext } from 'middleware/AppContext';
+import { DestinationKey, navigationPaths } from './navigationPaths';
+
+/**
+ * Relocates to a destination based on the DestinationKey type.
+ *
+ * To add a new destination, look inside navigationPaths.ts file/
+ * @param destinationKey - define the destination to be relocated to (eg. 'repositories')
+ * @returns () => void
+ */
+export const useNavigateTo = (destinationKey: DestinationKey) => {
+  const { contentOrigin } = useAppContext();
+  const navigate = useNavigate();
+  const rootPath = useRootPath();
+  const repoUUID = useSafeUUIDParam('repoUUID');
+
+  return useCallback(() => {
+    const path = navigationPaths[destinationKey];
+    return navigate(path({ rootPath, repoUUID, contentOrigin }));
+  }, [contentOrigin, rootPath, repoUUID]);
+};

--- a/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
@@ -502,12 +502,12 @@ const ContentListTable = () => {
   const pageSelectableRows = rows.filter((row) => !shouldDisableSelect(row));
 
   // How many of those selectable rows are currently selected
-  const pageSelectionCount = pageSelectableRows.filter(isSelected).length;
+  const numberOfRowsSelected = pageSelectableRows.filter(isSelected).length;
 
   const isPageSelected =
-    pageSelectableRows.length > 0 && pageSelectionCount === pageSelectableRows.length;
+    pageSelectableRows.length > 0 && numberOfRowsSelected === pageSelectableRows.length;
 
-  const isPagePartiallySelected = pageSelectionCount > 0 && !isPageSelected;
+  const isPagePartiallySelected = numberOfRowsSelected > 0 && !isPageSelected;
 
   const ouiaId = 'repositories-table';
 
@@ -539,6 +539,14 @@ const ContentListTable = () => {
     activeState === DataViewState.empty ||
     activeState === DataViewState.loading ||
     areNoSelectableRows;
+
+  const deleteRepoText = useMemo(
+    () =>
+      numberOfRowsSelected <= 1
+        ? 'Delete repository'
+        : `Delete ${numberOfRowsSelected} repositories`,
+    [numberOfRowsSelected],
+  );
 
   return (
     <>
@@ -698,9 +706,8 @@ const ContentListTable = () => {
                       contentOrigin.length === 0 ||
                       (isCommunityAndCustom && areNoSelectableRows)
                     }
-                    atLeastOneRepoChecked={pageSelectionCount > 0}
-                    numberOfReposChecked={pageSelectionCount}
-                    toggleOuiaId='repositories-kebab-toggle'
+                    atLeastOneRepoChecked={numberOfRowsSelected > 0}
+                    text={deleteRepoText}
                   />
                 </ConditionalTooltip>
               </FlexItem>

--- a/src/Pages/Repositories/ContentListTable/components/PackageModal/PackageModal.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/PackageModal/PackageModal.test.tsx
@@ -1,12 +1,14 @@
 import { render } from '@testing-library/react';
 import PackageModal from './PackageModal';
 import { defaultPackageItem, ReactQueryTestWrapper } from 'testingHelpers';
-import { useGetPackagesQuery } from 'services/Content/ContentQueries';
+import { useFetchContent, useGetPackagesQuery } from 'services/Content/ContentQueries';
+import { ContentOrigin } from 'services/Content/ContentApi';
 
 jest.mock('Hooks/useRootPath', () => () => 'someUrl');
 
 jest.mock('services/Content/ContentQueries', () => ({
   useGetPackagesQuery: jest.fn(),
+  useFetchContent: jest.fn(),
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -14,15 +16,31 @@ jest.mock('react-router-dom', () => ({
   useParams: () => ({
     repoUUID: 'some-uuid',
   }),
+  Outlet: () => null,
 }));
 
 jest.mock('middleware/AppContext', () => ({
   useAppContext: () => ({ rbac: { read: true, write: true } }),
+  contentOrigin: [],
 }));
+
+const basePackagesQueryResult = {
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useFetchContent as jest.Mock).mockReturnValue({
+    data: { origin: ContentOrigin.EXTERNAL },
+    isError: false,
+  });
+});
 
 it('Render 1 item', () => {
   (useGetPackagesQuery as jest.Mock).mockImplementation(() => ({
-    isLoading: false,
+    ...basePackagesQueryResult,
     data: {
       data: [defaultPackageItem],
       meta: { count: 1, limit: 20, offset: 0 },
@@ -45,7 +63,7 @@ it('Render 1 item', () => {
 
 it('Render with no packages (after an unsuccessful search)', () => {
   (useGetPackagesQuery as jest.Mock).mockImplementation(() => ({
-    isLoading: false,
+    ...basePackagesQueryResult,
     data: {
       data: [],
       meta: { count: 0, limit: 20, offset: 0 },

--- a/src/Pages/Repositories/ContentListTable/components/PackageModal/PackageModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/PackageModal/PackageModal.tsx
@@ -24,7 +24,7 @@ import useDebounce from 'Hooks/useDebounce';
 import { useNavigate, useParams } from 'react-router-dom';
 import useRootPath from 'Hooks/useRootPath';
 import { useAppContext } from 'middleware/AppContext';
-import PackagesTable from 'components/SharedTables/PackagesTable';
+import PackagesTableWithToolbars from 'components/Tables/Packages/PackagesTableWithToolbars';
 import { REPOSITORIES_ROUTE } from 'Routes/constants';
 import { modalTableSurfaceStyles } from 'helpers';
 
@@ -147,7 +147,7 @@ export default function PackageModal() {
               />
             </Hide>
           </InputGroup>
-          <PackagesTable
+          <PackagesTableWithToolbars
             packagesList={packagesList}
             isFetchingOrLoading={fetchingOrLoading}
             isLoadingOrZeroCount={loadingOrZeroCount}

--- a/src/Pages/Repositories/ContentListTable/components/PackageModal/PackageModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/PackageModal/PackageModal.tsx
@@ -1,184 +1,112 @@
-import {
-  Button,
-  Flex,
-  FlexItem,
-  Grid,
-  InputGroup,
-  InputGroupItem,
-  Modal,
-  ModalFooter,
-  ModalHeader,
-  ModalVariant,
-  Pagination,
-  PaginationVariant,
-  TextInput,
-} from '@patternfly/react-core';
+import { Button, Modal, ModalFooter, ModalHeader, ModalVariant } from '@patternfly/react-core';
 import { InnerScrollContainer } from '@patternfly/react-table';
-import { useEffect, useState } from 'react';
-import { createUseStyles } from 'react-jss';
-import Hide from 'components/Hide/Hide';
-import { ContentOrigin } from 'services/Content/ContentApi';
+import { useCallback, useEffect, useMemo } from 'react';
+import { PackageWithUUID } from 'services/Content/ContentApi';
 import { useGetPackagesQuery } from 'services/Content/ContentQueries';
-import { SearchIcon } from '@patternfly/react-icons';
-import useDebounce from 'Hooks/useDebounce';
-import { useNavigate, useParams } from 'react-router-dom';
-import useRootPath from 'Hooks/useRootPath';
-import { useAppContext } from 'middleware/AppContext';
+import { Outlet, useOutletContext } from 'react-router-dom';
 import PackagesTableWithToolbars from 'components/Tables/Packages/PackagesTableWithToolbars';
-import { REPOSITORIES_ROUTE } from 'Routes/constants';
-import { modalTableSurfaceStyles } from 'helpers';
-
-const useStyles = createUseStyles({
-  modalTableScope: modalTableSurfaceStyles,
-  mainContainer: {
-    display: 'flex',
-    flexDirection: 'column',
-    height: '100%',
-  },
-  topContainer: {
-    justifyContent: 'space-between',
-    padding: '16px 24px',
-    height: 'fit-content',
-  },
-  bottomContainer: {
-    justifyContent: 'space-between',
-  },
-});
+import { useTablePaginationLocalStorage } from 'components/Tables/Generic/hooks/useTablePaginationLocalStorage';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import useSafeUUIDParam from 'Hooks/useSafeUUIDParam';
+import { usePackageTableFilters } from 'components/Tables/Packages/hooks/usePackageTableFilters';
+import { useEnableDelete } from './hooks/useEnableDelete';
+import { useDataViewSelection } from '@patternfly/react-data-view/dist/dynamic/Hooks';
+import { useNavigateTo } from 'Hooks/navigation/useNavigateTo';
 
 const perPageKey = 'packagePerPage';
 
 export default function PackageModal() {
-  const { contentOrigin } = useAppContext();
-  const classes = useStyles();
-  const { repoUUID: uuid } = useParams();
-  const rootPath = useRootPath();
-  const navigate = useNavigate();
-  const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
-  const [page, setPage] = useState(1);
-  const [perPage, setPerPage] = useState(storedPerPage);
-  const [searchQuery, setSearchQuery] = useState('');
+  const repoUUID = useSafeUUIDParam('repoUUID');
 
-  const debouncedSearchQuery = useDebounce(searchQuery, !searchQuery ? 0 : 500);
+  const onClose = useNavigateTo('repositories');
 
-  useEffect(() => {
-    setPage(1);
-  }, [debouncedSearchQuery]);
+  const filterData = usePackageTableFilters();
+  const { debouncedSearch } = filterData;
+
+  const [isUploadRepository, isFetchRepoError] = useEnableDelete(repoUUID);
+
+  const selection = useDataViewSelection({ matchOption: (a, b) => a.id === b.id });
+  const { onSelect, selected } = selection;
+
+  const paginationData = useTablePaginationLocalStorage({ key: perPageKey });
+  const { page, perPage } = paginationData;
 
   const {
     isLoading,
     isFetching,
     isError,
     data = { data: [], meta: { count: 0, limit: 20, offset: 0 } },
-  } = useGetPackagesQuery(uuid as string, page, perPage, debouncedSearchQuery);
+  } = useGetPackagesQuery(repoUUID, page, perPage, debouncedSearch);
 
   useEffect(() => {
-    if (isError) {
+    if (isError || isFetchRepoError) {
       onClose();
     }
-  }, [isError]);
-
-  const onSetPage = (_, newPage) => setPage(newPage);
-
-  const onPerPageSelect = (_, newPerPage, newPage) => {
-    // Save this value through page refresh for use on next reload
-    setPerPage(newPerPage);
-    setPage(newPage);
-    localStorage.setItem(perPageKey, newPerPage.toString());
-  };
-
-  const onClose = () =>
-    navigate(
-      `${rootPath}/${REPOSITORIES_ROUTE}` +
-        (contentOrigin.length === 1 && contentOrigin[0] === ContentOrigin.REDHAT
-          ? `?origin=${contentOrigin}`
-          : ''),
-    );
+  }, [isError, isFetchRepoError]);
 
   const {
     data: packagesList = [],
     meta: { count = 0 },
   } = data;
 
-  const fetchingOrLoading = isFetching || isLoading;
+  // required for outlet to confirm delete packages
+  const clearSelectedPackages = useCallback(() => onSelect(false), [onSelect]);
 
-  const loadingOrZeroCount = fetchingOrLoading || !count;
+  const selectedPackages = useMemo(() => {
+    const ids = selected.map((s) => s.id);
+    return packagesList.filter((p) => ids.includes(p.uuid));
+  }, [selected, packagesList]);
+
+  const outletData = { clearSelectedPackages, deletionContext: { selectedPackages } };
 
   return (
-    <Modal
-      key={uuid}
-      position='top'
-      ouiaId='rpm_package_modal'
-      variant={ModalVariant.medium}
-      isOpen
-      onClose={onClose}
-      aria-labelledby='rpm-package-modal-title'
-      aria-describedby='rpm-package-modal-description'
-    >
-      <ModalHeader
-        title='Packages'
-        labelId='rpm-package-modal-title'
-        description='View list of packages'
-        descriptorId='rpm-package-modal-description'
-      />
-      <InnerScrollContainer>
-        <Grid className={`${classes.modalTableScope} ${classes.mainContainer}`}>
-          <InputGroup className={classes.topContainer}>
-            <InputGroupItem>
-              <TextInput
-                id='search'
-                type='search'
-                customIcon={<SearchIcon />}
-                ouiaId='name_search'
-                placeholder='Filter by name'
-                value={searchQuery}
-                onChange={(_event, value) => setSearchQuery(value)}
-              />
-            </InputGroupItem>
-            <Hide hide={loadingOrZeroCount}>
-              <Pagination
-                id='top-pagination-id'
-                widgetId='topPaginationWidgetId'
-                itemCount={count}
-                perPage={perPage}
-                page={page}
-                onSetPage={onSetPage}
-                isCompact
-                onPerPageSelect={onPerPageSelect}
-              />
-            </Hide>
-          </InputGroup>
-          <PackagesTableWithToolbars
-            packagesList={packagesList}
-            isFetchingOrLoading={fetchingOrLoading}
-            isLoadingOrZeroCount={loadingOrZeroCount}
-            clearSearch={() => setSearchQuery('')}
-            search={debouncedSearchQuery}
-            perPage={perPage}
-          />
-          <Flex className={classes.bottomContainer}>
-            <FlexItem />
-            <FlexItem>
-              <Hide hide={loadingOrZeroCount}>
-                <Pagination
-                  id='bottom-pagination-id'
-                  widgetId='bottomPaginationWidgetId'
-                  itemCount={count}
-                  perPage={perPage}
-                  page={page}
-                  onSetPage={onSetPage}
-                  variant={PaginationVariant.bottom}
-                  onPerPageSelect={onPerPageSelect}
-                />
-              </Hide>
-            </FlexItem>
-          </Flex>
-        </Grid>
-      </InnerScrollContainer>
-      <ModalFooter>
-        <Button key='close' variant='secondary' onClick={onClose}>
-          Close
-        </Button>
-      </ModalFooter>
-    </Modal>
+    <>
+      <Outlet context={outletData} />
+      <Modal
+        key={repoUUID}
+        position='top'
+        ouiaId='rpm_package_modal'
+        variant={ModalVariant.medium}
+        isOpen
+        onClose={onClose}
+        aria-labelledby='rpm-package-modal-title'
+        aria-describedby='rpm-package-modal-description'
+      >
+        <ModalHeader
+          title='Packages'
+          labelId='rpm-package-modal-title'
+          description='View list of packages'
+          descriptorId='rpm-package-modal-description'
+        />
+        <InnerScrollContainer>
+          <div className={spacing.pSm}>
+            <PackagesTableWithToolbars
+              packagesList={packagesList}
+              paginationData={paginationData}
+              isFetching={isFetching}
+              isLoading={isLoading}
+              count={count}
+              filterProps={{ ...filterData }}
+              selection={selection}
+              enabledBulkDelete={isUploadRepository}
+              enabledRowActions={isUploadRepository}
+            />
+          </div>
+        </InnerScrollContainer>
+        <ModalFooter>
+          <Button key='close' variant='secondary' onClick={onClose}>
+            Close
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </>
   );
 }
+
+export const usePackageModalOutletContext = () =>
+  useOutletContext<{
+    clearSelectedPackages: () => void;
+    deletionContext: {
+      selectedPackages: PackageWithUUID[];
+    };
+  }>();

--- a/src/Pages/Repositories/ContentListTable/components/PackageModal/hooks/useEnableDelete.ts
+++ b/src/Pages/Repositories/ContentListTable/components/PackageModal/hooks/useEnableDelete.ts
@@ -1,0 +1,8 @@
+import { ContentOrigin } from 'services/Content/ContentApi';
+import { useFetchContent } from 'services/Content/ContentQueries';
+
+export const useEnableDelete = (repoUUID) => {
+  const { data: repository, isError } = useFetchContent(repoUUID);
+  const isUploadRepository = repository?.origin === ContentOrigin.UPLOAD;
+  return [isUploadRepository, isError];
+};

--- a/src/Pages/Repositories/ContentListTable/components/PackagesDeleteModal/PackagesDeleteModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/PackagesDeleteModal/PackagesDeleteModal.tsx
@@ -1,0 +1,89 @@
+import {
+  Button,
+  Content,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
+import { usePackageModalOutletContext } from '../PackageModal/PackageModal';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { useBulkRemoveRepositoryRpmsMutate } from 'services/Content/ContentQueries';
+
+import useSafeUUIDParam from 'Hooks/useSafeUUIDParam';
+import { PackagesTableBasic } from 'components/Tables/Packages/PackagesTableBasic';
+import { useNavigateTo } from 'Hooks/navigation/useNavigateTo';
+
+const PackagesDeleteModal = () => {
+  const queryClient = useQueryClient();
+  const onClose = useNavigateTo('packagesLatest');
+  const navigateToRepos = useNavigateTo('repositories');
+  const repoUUID = useSafeUUIDParam('repoUUID');
+
+  const {
+    clearSelectedPackages,
+    deletionContext: { selectedPackages },
+  } = usePackageModalOutletContext();
+
+  const { mutateAsync: removeRpms, isPending } = useBulkRemoveRepositoryRpmsMutate(
+    queryClient,
+    repoUUID,
+  );
+
+  useEffect(() => {
+    if (!selectedPackages.length) {
+      onClose();
+    }
+  }, [selectedPackages, onClose]);
+
+  const onConfirm = async () => {
+    const uuids = selectedPackages.map((p) => p.uuid);
+    await removeRpms(uuids);
+    clearSelectedPackages();
+    navigateToRepos();
+  };
+
+  return (
+    <Modal
+      onClose={onClose}
+      position='top'
+      variant={ModalVariant.large}
+      ouiaId='delete_packages'
+      aria-labelledby='delete-packages-modal'
+      isOpen
+    >
+      <ModalHeader
+        title='Delete packages?'
+        labelId='delete-packages-modal'
+        titleIconVariant='warning'
+      />
+      <ModalBody>
+        <Content component='p'>
+          {selectedPackages.length === 1
+            ? 'Are you sure you want to delete this package? A new snapshot will be created without this package.'
+            : `Are you sure you want to delete these ${selectedPackages.length} packages? A new snapshot will be created without these packages.`}
+        </Content>
+        <PackagesTableBasic items={selectedPackages} />
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          key='confirm'
+          ouiaId='delete_packages_confirm'
+          variant='danger'
+          isLoading={isPending}
+          isDisabled={isPending || !selectedPackages.length}
+          onClick={onConfirm}
+        >
+          Delete
+        </Button>
+        <Button key='cancel' variant='link' onClick={onClose} isDisabled={isPending}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default PackagesDeleteModal;

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataTab.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataTab.tsx
@@ -26,7 +26,7 @@ const useStyles = createUseStyles({
   },
   topContainer: {
     justifyContent: 'space-between',
-    padding: '16px 24px 16px 0',
+    padding: '0.5rem',
     height: 'fit-content',
     display: 'flex',
     flexDirection: 'row',

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotPackagesTab.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotPackagesTab.tsx
@@ -18,7 +18,7 @@ import useDebounce from 'Hooks/useDebounce';
 import useRootPath from 'Hooks/useRootPath';
 import { useAppContext } from 'middleware/AppContext';
 import { useGetSnapshotPackagesQuery } from 'services/Content/ContentQueries';
-import PackagesTable from 'components/SharedTables/PackagesTable';
+import PackagesTableWithToolbars from 'components/Tables/Packages/PackagesTableWithToolbars';
 
 const useStyles = createUseStyles({
   mainContainer: {
@@ -120,7 +120,7 @@ export function SnapshotPackagesTab() {
           />
         </Hide>
       </InputGroup>
-      <PackagesTable
+      <PackagesTableWithToolbars
         packagesList={packagesList}
         isFetchingOrLoading={fetchingOrLoading}
         isLoadingOrZeroCount={loadingOrZeroCount}

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotPackagesTab.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotPackagesTab.tsx
@@ -1,150 +1,50 @@
-import {
-  Grid,
-  InputGroup,
-  InputGroupItem,
-  TextInput,
-  Pagination,
-  Flex,
-  FlexItem,
-  PaginationVariant,
-} from '@patternfly/react-core';
-import { SearchIcon } from '@patternfly/react-icons';
-import Hide from 'components/Hide/Hide';
-import { ContentOrigin } from 'services/Content/ContentApi';
-import { createUseStyles } from 'react-jss';
-import { useEffect, useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import useDebounce from 'Hooks/useDebounce';
-import useRootPath from 'Hooks/useRootPath';
-import { useAppContext } from 'middleware/AppContext';
+import { useEffect } from 'react';
 import { useGetSnapshotPackagesQuery } from 'services/Content/ContentQueries';
 import PackagesTableWithToolbars from 'components/Tables/Packages/PackagesTableWithToolbars';
-
-const useStyles = createUseStyles({
-  mainContainer: {
-    display: 'flex',
-    flexDirection: 'column',
-    height: '100%',
-  },
-  topContainer: {
-    justifyContent: 'space-between',
-    padding: '16px 24px 16px 0',
-    height: 'fit-content',
-  },
-  bottomContainer: {
-    justifyContent: 'space-between',
-  },
-});
+import { useTablePaginationLocalStorage } from 'components/Tables/Generic/hooks/useTablePaginationLocalStorage';
+import useSafeUUIDParam from 'Hooks/useSafeUUIDParam';
+import { usePackageTableFilters } from 'components/Tables/Packages/hooks/usePackageTableFilters';
+import { useNavigateTo } from 'Hooks/navigation/useNavigateTo';
 
 const perPageKey = 'snapshotPackagePerPage';
 
 export function SnapshotPackagesTab() {
-  const classes = useStyles();
-  const { contentOrigin } = useAppContext();
+  const snapshotUUID = useSafeUUIDParam('snapshotUUID');
 
-  const { snapshotUUID = '' } = useParams();
-  const rootPath = useRootPath();
-  const navigate = useNavigate();
-  const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
-  const [page, setPage] = useState(1);
-  const [perPage, setPerPage] = useState(storedPerPage);
-  const [searchQuery, setSearchQuery] = useState('');
+  const onClose = useNavigateTo('root');
 
-  const debouncedSearchQuery = useDebounce(searchQuery, !searchQuery ? 0 : 500);
+  const filterData = usePackageTableFilters();
+  const { debouncedSearch } = filterData;
 
-  useEffect(() => {
-    setPage(1);
-  }, [debouncedSearchQuery]);
+  const paginationData = useTablePaginationLocalStorage({ key: perPageKey });
+  const { page, perPage } = paginationData;
 
   const {
     isLoading,
     isFetching,
     isError,
     data = { data: [], meta: { count: 0, limit: 20, offset: 0 } },
-  } = useGetSnapshotPackagesQuery(snapshotUUID, page, perPage, debouncedSearchQuery);
+  } = useGetSnapshotPackagesQuery(snapshotUUID, page, perPage, debouncedSearch);
 
   useEffect(() => {
     if (isError) {
       onClose();
     }
-  }, [isError]);
-
-  const onSetPage = (_, newPage) => setPage(newPage);
-
-  const onPerPageSelect = (_, newPerPage, newPage) => {
-    setPerPage(newPerPage);
-    setPage(newPage);
-    localStorage.setItem(perPageKey, newPerPage.toString());
-  };
-
-  const onClose = () =>
-    navigate(
-      rootPath +
-        (contentOrigin.length === 1 && contentOrigin[0] === ContentOrigin.REDHAT
-          ? `?origin=${contentOrigin}`
-          : ''),
-    );
+  }, [isError, onClose]);
 
   const {
     data: packagesList = [],
     meta: { count = 0 },
   } = data;
 
-  const fetchingOrLoading = isFetching || isLoading;
-
-  const loadingOrZeroCount = fetchingOrLoading || !count;
   return (
-    <Grid className={classes.mainContainer}>
-      <InputGroup className={classes.topContainer}>
-        <InputGroupItem>
-          <TextInput
-            id='search'
-            ouiaId='name_search'
-            placeholder='Filter by name'
-            value={searchQuery}
-            type='search'
-            customIcon={<SearchIcon />}
-            onChange={(_event, value) => setSearchQuery(value)}
-          />
-        </InputGroupItem>
-        <Hide hide={isLoading}>
-          <Pagination
-            id='top-pagination-id'
-            widgetId='topPaginationWidgetId'
-            itemCount={count}
-            perPage={perPage}
-            page={page}
-            onSetPage={onSetPage}
-            isCompact
-            onPerPageSelect={onPerPageSelect}
-          />
-        </Hide>
-      </InputGroup>
-      <PackagesTableWithToolbars
-        packagesList={packagesList}
-        isFetchingOrLoading={fetchingOrLoading}
-        isLoadingOrZeroCount={loadingOrZeroCount}
-        clearSearch={() => setSearchQuery('')}
-        perPage={perPage}
-        search={debouncedSearchQuery}
-      />
-      <Flex className={classes.bottomContainer}>
-        <FlexItem />
-        <FlexItem>
-          <Hide hide={isLoading}>
-            <Pagination
-              id='bottom-pagination-id'
-              widgetId='bottomPaginationWidgetId'
-              itemCount={count}
-              perPage={perPage}
-              page={page}
-              onSetPage={onSetPage}
-              variant={PaginationVariant.bottom}
-              onPerPageSelect={onPerPageSelect}
-            />
-          </Hide>
-        </FlexItem>
-      </Flex>
-    </Grid>
+    <PackagesTableWithToolbars
+      packagesList={packagesList}
+      paginationData={paginationData}
+      isFetching={isFetching}
+      isLoading={isLoading}
+      count={count}
+      filterProps={{ ...filterData }}
+    />
   );
 }

--- a/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.tsx
+++ b/src/Pages/Repositories/PopularRepositoriesTable/PopularRepositoriesTable.tsx
@@ -186,6 +186,13 @@ const PopularRepositoriesTable = () => {
     [checkedRepositoriesToAdd],
   );
 
+  const deleteRepoText = useMemo(() => {
+    const numberOfReposChecked = checkedRepositoriesToDelete.size;
+    return numberOfReposChecked <= 1
+      ? 'Delete repository'
+      : `Delete ${numberOfReposChecked} repositories`;
+  }, [checkedRepositoriesToDelete]);
+
   const areAllReposSelected = useMemo(
     () =>
       data.data.every((repo) => {
@@ -399,9 +406,8 @@ const PopularRepositoriesTable = () => {
                   >
                     <DeleteKebab
                       atLeastOneRepoChecked={atLeastOneRepoToDeleteChecked}
-                      numberOfReposChecked={checkedRepositoriesToDelete.size}
-                      toggleOuiaId='popular_repositories_kebab_toggle'
                       isDisabled={!rbac?.repoWrite}
+                      text={deleteRepoText}
                     />
                   </ConditionalTooltip>
                 </FlexItem>

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateErrataTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateErrataTab.tsx
@@ -28,7 +28,7 @@ const useStyles = createUseStyles({
   },
   topContainer: {
     justifyContent: 'space-between',
-    padding: '16px 24px',
+    padding: '1rem',
     height: 'fit-content',
   },
   topContainerWithFilterHeight: { extend: 'topContainer', minHeight: '128px' },

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplatePackageTab.test.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplatePackageTab.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import { defaultPackageItem } from 'testingHelpers';
 import TemplatePackageTab from './TemplatePackageTab';
 import { useFetchTemplatePackages } from 'services/Templates/TemplateQueries';
-import type { PackageItem } from 'services/Content/ContentApi';
+import type { Package } from 'services/Content/ContentApi';
 
 const bananaUUID = 'banana-uuid';
 
@@ -27,7 +27,7 @@ jest.mock('services/Templates/TemplateQueries', () => ({
   isLoading: false,
   isFetching: false,
   data: {
-    data: new Array(15).fill(defaultPackageItem).map((item: PackageItem, index) => ({
+    data: new Array(15).fill(defaultPackageItem).map((item: Package, index) => ({
       ...item,
       name: item.name + index,
     })),

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplatePackageTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplatePackageTab.tsx
@@ -1,135 +1,42 @@
-import {
-  Flex,
-  FlexItem,
-  Grid,
-  InputGroup,
-  InputGroupItem,
-  Pagination,
-  PaginationVariant,
-  TextInput,
-} from '@patternfly/react-core';
-
-import { useEffect, useState } from 'react';
-import { createUseStyles } from 'react-jss';
-import { SearchIcon } from '@patternfly/react-icons';
-import useDebounce from 'Hooks/useDebounce';
-import { useParams } from 'react-router-dom';
 import PackagesTableWithToolbars from 'components/Tables/Packages/PackagesTableWithToolbars';
 import { useFetchTemplatePackages } from 'services/Templates/TemplateQueries';
-import Loader from 'components/Loader';
-
-const useStyles = createUseStyles({
-  description: {
-    paddingTop: '12px', // 4px on the title bottom padding makes this the "standard" 16 total padding
-    paddingBottom: '8px',
-  },
-  mainContainer: {
-    display: 'flex',
-    flexDirection: 'column',
-    height: '100%',
-  },
-  topContainer: {
-    justifyContent: 'space-between',
-    padding: '16px 24px',
-    height: 'fit-content',
-  },
-  bottomContainer: {
-    justifyContent: 'space-between',
-  },
-});
+import { useTablePaginationLocalStorage } from 'components/Tables/Generic/hooks/useTablePaginationLocalStorage';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import useSafeUUIDParam from 'Hooks/useSafeUUIDParam';
+import { usePackageTableFilters } from 'components/Tables/Packages/hooks/usePackageTableFilters';
 
 const perPageKey = 'TemplatePackagePerPage';
 
 export default function TemplatePackageTab() {
-  const classes = useStyles();
-  const { templateUUID: uuid } = useParams();
-  const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
-  const [page, setPage] = useState(1);
-  const [perPage, setPerPage] = useState(storedPerPage);
-  const [searchQuery, setSearchQuery] = useState('');
+  const templateUUID = useSafeUUIDParam('templateUUID');
 
-  const debouncedSearchQuery = useDebounce(searchQuery, !searchQuery ? 0 : 500);
+  const filterData = usePackageTableFilters();
+  const { debouncedSearch } = filterData;
 
-  useEffect(() => {
-    setPage(1);
-  }, [debouncedSearchQuery]);
+  const paginationData = useTablePaginationLocalStorage({ key: perPageKey });
+  const { page, perPage } = paginationData;
 
   const {
     isLoading,
     isFetching,
     data = { data: [], meta: { count: 0, limit: 20, offset: 0 } },
-  } = useFetchTemplatePackages(page, perPage, debouncedSearchQuery, uuid as string);
-
-  const onSetPage = (_, newPage) => setPage(newPage);
-
-  const onPerPageSelect = (_, newPerPage, newPage) => {
-    // Save this value through page refresh for use on next reload
-    setPerPage(newPerPage);
-    setPage(newPage);
-    localStorage.setItem(perPageKey, newPerPage.toString());
-  };
+  } = useFetchTemplatePackages(page, perPage, debouncedSearch, templateUUID);
 
   const {
     data: packagesList = [],
     meta: { count = 0 },
   } = data;
 
-  const fetchingOrLoading = isFetching || isLoading;
-
-  const loadingOrZeroCount = fetchingOrLoading || !count;
-
-  if (isLoading) {
-    return <Loader />;
-  }
-
   return (
-    <Grid className={classes.mainContainer}>
-      <InputGroup className={classes.topContainer}>
-        <InputGroupItem>
-          <TextInput
-            id='search'
-            ouiaId='name_search'
-            placeholder='Filter by name'
-            value={searchQuery}
-            onChange={(_event, value) => setSearchQuery(value)}
-            type='search'
-            customIcon={<SearchIcon />}
-          />
-        </InputGroupItem>
-        <Pagination
-          id='top-pagination-id'
-          widgetId='topPaginationWidgetId'
-          itemCount={count}
-          perPage={perPage}
-          page={page}
-          onSetPage={onSetPage}
-          isCompact
-          onPerPageSelect={onPerPageSelect}
-        />
-      </InputGroup>
+    <div className={spacing.pSm}>
       <PackagesTableWithToolbars
         packagesList={packagesList}
-        isFetchingOrLoading={fetchingOrLoading}
-        isLoadingOrZeroCount={loadingOrZeroCount}
-        clearSearch={() => setSearchQuery('')}
-        perPage={perPage}
-        search={debouncedSearchQuery}
+        isFetching={isFetching}
+        isLoading={isLoading}
+        paginationData={paginationData}
+        count={count}
+        filterProps={{ ...filterData }}
       />
-      <Flex className={classes.bottomContainer}>
-        <FlexItem />
-        <FlexItem>
-          <Pagination
-            id='bottom-pagination-id'
-            widgetId='bottomPaginationWidgetId'
-            itemCount={count}
-            perPage={perPage}
-            page={page}
-            onSetPage={onSetPage}
-            variant={PaginationVariant.bottom}
-            onPerPageSelect={onPerPageSelect}
-          />
-        </FlexItem>
-      </Flex>
-    </Grid>
+    </div>
   );
 }

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplatePackageTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplatePackageTab.tsx
@@ -14,7 +14,7 @@ import { createUseStyles } from 'react-jss';
 import { SearchIcon } from '@patternfly/react-icons';
 import useDebounce from 'Hooks/useDebounce';
 import { useParams } from 'react-router-dom';
-import PackagesTable from 'components/SharedTables/PackagesTable';
+import PackagesTableWithToolbars from 'components/Tables/Packages/PackagesTableWithToolbars';
 import { useFetchTemplatePackages } from 'services/Templates/TemplateQueries';
 import Loader from 'components/Loader';
 
@@ -107,7 +107,7 @@ export default function TemplatePackageTab() {
           onPerPageSelect={onPerPageSelect}
         />
       </InputGroup>
-      <PackagesTable
+      <PackagesTableWithToolbars
         packagesList={packagesList}
         isFetchingOrLoading={fetchingOrLoading}
         isLoadingOrZeroCount={loadingOrZeroCount}

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateRepositoriesTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateRepositoriesTab.tsx
@@ -31,7 +31,7 @@ const useStyles = createUseStyles({
   },
   topContainer: {
     justifyContent: 'space-between',
-    padding: '16px 24px',
+    padding: '1rem',
     height: 'fit-content',
   },
   bottomContainer: {

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -41,6 +41,7 @@ import UploadContent from 'Pages/Repositories/ContentListTable/components/Upload
 import DeleteSnapshotsModal from 'Pages/Repositories/ContentListTable/components/SnapshotListModal/DeleteSnapshotsModal/DeleteSnapshotsModal';
 import AdminFeaturesTable from 'Pages/Repositories/AdminFeaturesTable/AdminFeaturesTable';
 import AssignTemplateModal from '../Pages/Templates/TemplateDetails/components/AssignTemplateModal/AssignTemplateModal';
+import PackagesDeleteModal from 'Pages/Repositories/ContentListTable/components/PackagesDeleteModal/PackagesDeleteModal';
 
 export default function RepositoriesRoutes() {
   const key = useMemo(() => Math.random(), []);
@@ -100,7 +101,13 @@ export default function RepositoriesRoutes() {
               key={`:repoUUID/${PACKAGES_ROUTE}`}
               path={`:repoUUID/${PACKAGES_ROUTE}`}
               element={<PackageModal />}
-            />
+            >
+              {rbac?.repoWrite ? (
+                <Route key={DELETE_ROUTE} path={DELETE_ROUTE} element={<PackagesDeleteModal />} />
+              ) : (
+                ''
+              )}
+            </Route>
           </Route>
           {...features?.admintasks?.enabled && features.admintasks?.accessible
             ? [

--- a/src/components/DeleteKebab/DeleteKebab.test.tsx
+++ b/src/components/DeleteKebab/DeleteKebab.test.tsx
@@ -12,7 +12,7 @@ jest.mock('react-router-dom', () => ({
 
 it('Render no checked repos', async () => {
   const { getByRole } = render(
-    <DeleteKebab atLeastOneRepoChecked={false} numberOfReposChecked={0} />,
+    <DeleteKebab atLeastOneRepoChecked={false} text='Delete repository' />,
   );
 
   const kebab = getByRole('button', { name: 'plain kebab' });
@@ -26,7 +26,7 @@ it('Render no checked repos', async () => {
 it('Render with checked repos', async () => {
   const repos = 100;
   const { queryByText } = render(
-    <DeleteKebab atLeastOneRepoChecked={true} numberOfReposChecked={repos} />,
+    <DeleteKebab atLeastOneRepoChecked={true} text={`Delete ${repos} repositories`} />,
   );
 
   const kebab = document.getElementById('delete-kebab');

--- a/src/components/DeleteKebab/DeleteKebab.tsx
+++ b/src/components/DeleteKebab/DeleteKebab.tsx
@@ -7,12 +7,11 @@ import { EllipsisVIcon } from '@patternfly/react-icons';
 
 interface Props {
   atLeastOneRepoChecked: boolean;
-  numberOfReposChecked: number;
-  toggleOuiaId?: string;
   isDisabled?: boolean;
+  text: string;
 }
 
-const DeleteKebab = ({ atLeastOneRepoChecked, numberOfReposChecked, isDisabled }: Props) => {
+const DeleteKebab = ({ atLeastOneRepoChecked, isDisabled, text }: Props) => {
   const navigate = useNavigate();
   const [isOpen, setIsOpen] = useState(false);
 
@@ -53,11 +52,7 @@ const DeleteKebab = ({ atLeastOneRepoChecked, numberOfReposChecked, isDisabled }
           show={!atLeastOneRepoChecked}
           setDisabled
         >
-          <DropdownItem onClick={() => navigate(DELETE_ROUTE)}>
-            {numberOfReposChecked <= 1
-              ? 'Delete repository'
-              : `Delete ${numberOfReposChecked} repositories`}
-          </DropdownItem>
+          <DropdownItem onClick={() => navigate(DELETE_ROUTE)}>{text}</DropdownItem>
         </ConditionalTooltip>
       </DropdownList>
     </Dropdown>

--- a/src/components/SharedTables/PackagesTable/index.tsx
+++ b/src/components/SharedTables/PackagesTable/index.tsx
@@ -1,5 +1,5 @@
 import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { PackageItem } from 'services/Content/ContentApi';
+import { Package } from 'services/Content/ContentApi';
 import Hide from '../../Hide/Hide';
 import { Grid } from '@patternfly/react-core';
 import { SkeletonTable } from '@patternfly/react-component-groups';
@@ -18,7 +18,7 @@ const useStyles = createUseStyles({
 interface Props {
   isFetchingOrLoading: boolean;
   isLoadingOrZeroCount: boolean;
-  packagesList: PackageItem[];
+  packagesList: Package[];
   clearSearch: () => void;
   perPage: number;
   search: string;
@@ -63,7 +63,7 @@ export default function PackagesTable({
               </Tr>
             </Thead>
           </Hide>
-          {packagesList.map(({ name, version, release, arch }: PackageItem, index: number) => (
+          {packagesList.map(({ name, version, release, arch }: Package, index: number) => (
             <Tbody key={name + index}>
               <Tr>
                 <Td>{name}</Td>

--- a/src/components/Tables/Generic/hooks/useTablePaginationLocalStorage.ts
+++ b/src/components/Tables/Generic/hooks/useTablePaginationLocalStorage.ts
@@ -1,0 +1,37 @@
+import { OnSetPage } from '@patternfly/react-core';
+import { useCallback, useState } from 'react';
+
+type TablePaginationLocalStorage = {
+  key: string;
+};
+
+export type PaginationLocalStorage = {
+  perPage: number;
+  page: number;
+  onSetPage: OnSetPage;
+  onPerPageSelect: (
+    e: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    perPage: number,
+    newPage: number,
+  ) => void;
+  setPage: (page: number) => void;
+};
+
+export const useTablePaginationLocalStorage = ({ key }: TablePaginationLocalStorage) => {
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(Number(localStorage.getItem(key)) || 20);
+
+  const onPerPageSelect = useCallback(
+    (_, newPerPage, newPage) => {
+      // Save this value through page refresh for use on next reload
+      setPerPage(newPerPage);
+      setPage(newPage);
+      localStorage.setItem(key, newPerPage.toString());
+    },
+    [key],
+  );
+
+  const onSetPage = useCallback((_, newPage) => setPage(newPage), []);
+
+  return { page, perPage, onPerPageSelect, onSetPage, setPage };
+};

--- a/src/components/Tables/Packages/PackagesTableBasic.tsx
+++ b/src/components/Tables/Packages/PackagesTableBasic.tsx
@@ -1,0 +1,61 @@
+import { Package } from 'services/Content/ContentApi';
+import EmptyTableDataView from 'components/EmptyTableDataView/EmptyTableDataView';
+import { SkeletonTableBody } from '@patternfly/react-component-groups';
+import { DataView } from '@patternfly/react-data-view/dist/dynamic/DataView';
+import {
+  DataViewTable,
+  DataViewTh,
+  DataViewTrObject,
+} from '@patternfly/react-data-view/dist/dynamic/DataViewTable';
+
+type BasicTable = {
+  items: Package[];
+};
+
+export const PackagesTableBasic = ({ items = [] }: BasicTable) => {
+  // rows and columns
+  const columns = [{ name: 'Name' }, { name: 'Architecture' }];
+  const dataViewColumns: DataViewTh[] = columns.map(({ name }) => ({ cell: name }));
+  const dataViewRows: DataViewTrObject[] = items.map((packageRpm) => {
+    const { name, arch } = packageRpm;
+    const cells = [{ cell: name }, { cell: arch }];
+
+    if (packageRpm.uuid !== undefined) {
+      return {
+        id: packageRpm.uuid,
+        row: cells,
+      };
+    }
+    return {
+      id: `${name}-${arch}`,
+      row: cells,
+    };
+  });
+
+  // table states
+  const ouiaId = 'confirm_delete_packages_table';
+  const emptyStateTable = (
+    <EmptyTableDataView
+      ouiaId={ouiaId}
+      variant='zero'
+      itemName='packages'
+      zeroBody='You may need to add packages to delete.'
+      colSpan={columns.length}
+    />
+  );
+  const loadingStateTable = (
+    <SkeletonTableBody rowsCount={items.length} columnsCount={columns.length} />
+  );
+  return (
+    <DataView data-ouia-component-id='packages_for_deletion_table'>
+      <DataViewTable
+        aria-label='Confirm Delete Packages Table'
+        ouiaId={ouiaId}
+        variant='compact'
+        columns={dataViewColumns}
+        rows={dataViewRows}
+        bodyStates={{ empty: emptyStateTable, loading: loadingStateTable }}
+      />
+    </DataView>
+  );
+};

--- a/src/components/Tables/Packages/PackagesTableWithToolbars.tsx
+++ b/src/components/Tables/Packages/PackagesTableWithToolbars.tsx
@@ -1,89 +1,274 @@
-import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { ActionsColumn, IAction } from '@patternfly/react-table';
 import { Package } from 'services/Content/ContentApi';
-import Hide from '../../Hide/Hide';
-import { Grid } from '@patternfly/react-core';
-import { SkeletonTable } from '@patternfly/react-component-groups';
-import { createUseStyles } from 'react-jss';
-import { useEffect, useState } from 'react';
-import EmptyTableState from 'components/EmptyTableState/EmptyTableState';
+import { SkeletonTableBody } from '@patternfly/react-component-groups';
+import { useCallback, useMemo } from 'react';
+import DeleteKebab from 'components/DeleteKebab/DeleteKebab';
 
-const useStyles = createUseStyles({
-  mainContainer: {
-    display: 'flex',
-    flexDirection: 'column',
-    height: '100%',
-  },
-});
+import { useDataViewSelection } from '@patternfly/react-data-view/dist/dynamic/Hooks';
+import {
+  BulkSelect,
+  BulkSelectValue,
+} from '@patternfly/react-component-groups/dist/dynamic/BulkSelect';
 
-interface Props {
-  isFetchingOrLoading: boolean;
-  isLoadingOrZeroCount: boolean;
+import { DataView, DataViewState } from '@patternfly/react-data-view/dist/dynamic/DataView';
+import {
+  DataViewTable,
+  DataViewTh,
+  DataViewTrObject,
+} from '@patternfly/react-data-view/dist/dynamic/DataViewTable';
+
+import { DataViewFilters } from '@patternfly/react-data-view/dist/dynamic/DataViewFilters';
+import { DataViewToolbar } from '@patternfly/react-data-view/dist/dynamic/DataViewToolbar';
+import { DataViewTextFilter } from '@patternfly/react-data-view/dist/dynamic/DataViewTextFilter';
+
+import EmptyTableDataView from 'components/EmptyTableDataView/EmptyTableDataView';
+import { useNavigate } from 'react-router-dom';
+import { DELETE_ROUTE } from 'Routes/constants';
+
+import { Pagination } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { FilterProps } from 'components/Tables/Packages/hooks/usePackageTableFilters';
+import { PaginationLocalStorage } from '../Generic/hooks/useTablePaginationLocalStorage';
+
+interface PackagesTableProps {
+  isFetching: boolean;
+  isLoading: boolean;
+  count: number;
   packagesList: Package[];
-  clearSearch: () => void;
-  perPage: number;
-  search: string;
+  enabledBulkDelete?: boolean;
+  enabledRowActions?: boolean;
+  paginationData: PaginationLocalStorage;
+  filterProps: FilterProps;
+  selection?: ReturnType<typeof useDataViewSelection>;
 }
 
 const PackagesTableWithToolbars = ({
-  isFetchingOrLoading,
-  isLoadingOrZeroCount,
   packagesList,
-  clearSearch,
-  perPage,
-  search,
-}: Props) => {
-  const classes = useStyles();
-  const [prevLength, setPrev] = useState(perPage || 10);
+  paginationData,
+  enabledBulkDelete = false,
+  enabledRowActions = false,
+  isFetching,
+  isLoading,
+  count,
+  filterProps,
+  selection = {
+    selected: [],
+    onSelect: () => {},
+    isSelected: () => false,
+    setSelected: () => {},
+  },
+}: PackagesTableProps) => {
+  const navigate = useNavigate();
 
-  useEffect(() => {
-    setPrev(packagesList.length || 10);
-  }, [packagesList.length]);
+  const { selected, onSelect, isSelected } = selection;
 
-  const columnHeaders = ['Name', 'Version', 'Release', 'Architecture'];
+  const paginationProps = {
+    ...paginationData,
+    itemCount: count,
+  };
+
+  // table states
+  const isFetchingOrLoading = isFetching || isLoading;
+  const isLoadingOrZeroCount = isFetchingOrLoading || !count;
+
+  const activeState = useMemo(() => {
+    if (isFetchingOrLoading) {
+      return DataViewState.loading;
+    } else if (isLoadingOrZeroCount) {
+      return DataViewState.empty;
+    } else {
+      return undefined;
+    }
+  }, [isFetchingOrLoading, isLoadingOrZeroCount]);
+
+  // delete single rpm through kebab
+  const handleSingleRowDelete = useCallback(
+    (packageUuid: string) => {
+      onSelect(false);
+      onSelect(true, [{ id: packageUuid, row: [] } as DataViewTrObject]);
+      navigate(DELETE_ROUTE);
+    },
+    [navigate, onSelect],
+  );
+
+  const rowActions = useCallback(
+    (packageUuid: string): IAction[] => [
+      {
+        title: 'Delete package',
+        ouiaId: 'kebab_delete_package',
+        onClick: () => handleSingleRowDelete(packageUuid),
+      },
+    ],
+    [handleSingleRowDelete],
+  );
+
+  const kebab = (uuid) =>
+    enabledRowActions
+      ? [{ cell: <ActionsColumn items={rowActions(uuid)} />, props: { isActionCell: true } }]
+      : [];
+
+  // DataView table props, rows and columns
+  const ouiaId =
+    enabledRowActions && enabledBulkDelete ? 'packages_table_select' : 'packages_table_noselect';
+  const columns = [
+    { name: 'Name' },
+    { name: 'Version' },
+    { name: 'Release' },
+    { name: 'Architecture' },
+  ];
+
+  const dataViewColumns: DataViewTh[] = columns.map(({ name }) => ({ cell: name }));
+  const dataViewRows: DataViewTrObject[] = packagesList.map((packageRpm) => {
+    const { name, version, release, arch } = packageRpm;
+    const cells = [{ cell: name }, { cell: version }, { cell: release }, { cell: arch }];
+
+    if (packageRpm.uuid !== undefined) {
+      return {
+        id: packageRpm.uuid,
+        row: [...cells, ...kebab(packageRpm.uuid)],
+      };
+    }
+    return {
+      id: `${name}-${version}-${release}-${arch}`,
+      row: cells,
+    };
+  });
+
+  // filter handlers
+  const { clearAllFilters, filters, onSetFilters } = filterProps;
+  const { setPage } = paginationProps;
+  const clearAllFiltersAndResetPage = useCallback(() => {
+    clearAllFilters();
+    setPage(1);
+    // setter functions from useState have a stable identity across re-renders, therefore setPage is not in the dependency array
+  }, [clearAllFilters]);
+
+  // paginations
+  const bottomPagination = (
+    <Pagination
+      id='bottom-pagination-id'
+      widgetId='bottomPaginationWidgetId'
+      {...paginationProps}
+      variant='bottom'
+    />
+  );
+
+  const topPagination = (
+    <Pagination
+      id='top-pagination-id'
+      widgetId='topPaginationWidgetId'
+      {...paginationProps}
+      isCompact
+      isDisabled={isFetchingOrLoading}
+    />
+  );
+
+  // filter by rpm name
+  const handleFilterChange = (_key, newValues) => {
+    onSetFilters(newValues);
+    setPage(1);
+  };
+  const searchFilter = (
+    <DataViewFilters values={filters} onChange={handleFilterChange}>
+      <DataViewTextFilter
+        filterId='search'
+        ouiaId='filter_packages_search'
+        title='Name'
+        placeholder='Filter by name'
+        isDisabled={isFetchingOrLoading}
+      />
+    </DataViewFilters>
+  );
+
+  // bulk select for delete
+  const handleBulkSelect = (value: BulkSelectValue) => {
+    if (value === BulkSelectValue.none) {
+      onSelect(false);
+    } else if (value === BulkSelectValue.page) {
+      onSelect(false);
+      onSelect(true, dataViewRows);
+    } else if (value === BulkSelectValue.nonePage) {
+      onSelect(false, dataViewRows);
+    }
+  };
+
+  const pageSelectionCount = dataViewRows.filter(isSelected).length;
+  const isPageSelected = dataViewRows.length > 0 && pageSelectionCount === dataViewRows.length;
+  const isPagePartiallySelected = pageSelectionCount > 0 && !isPageSelected;
+
+  const bulkSelect = (
+    <BulkSelect
+      isDataPaginated
+      onSelect={handleBulkSelect}
+      selectedCount={selected.length}
+      pageCount={dataViewRows.length}
+      pageSelected={isPageSelected}
+      pagePartiallySelected={isPagePartiallySelected}
+      menuToggleCheckboxProps={{
+        id: 'bulk-select-packages-checkbox',
+        isDisabled: isLoadingOrZeroCount,
+      }}
+    />
+  );
+
+  // delete items through kebab
+  const deleteRpmsText = useMemo(() => {
+    const count = pageSelectionCount;
+    const text = count <= 1 ? 'Delete package' : `Delete ${count} packages`;
+    return text;
+  }, [pageSelectionCount]);
+
+  const deleteKebab = (
+    <DeleteKebab
+      isDisabled={isLoadingOrZeroCount}
+      atLeastOneRepoChecked={pageSelectionCount > 0}
+      text={deleteRpmsText}
+    />
+  );
+
+  const bulkDeleteProps = {
+    bulkSelect,
+    actions: deleteKebab,
+  };
+
+  // table states
+  const emptyStateTable = (
+    <EmptyTableDataView
+      ouiaId={ouiaId}
+      variant={filters.search ? 'filtered' : 'zero'}
+      itemName='packages'
+      zeroBody='You may need to add repositories that contain packages.'
+      colSpan={columns.length}
+      onClearFilters={clearAllFiltersAndResetPage}
+    />
+  );
+  const loadingStateTable = (
+    <SkeletonTableBody rowsCount={paginationProps.perPage} columnsCount={columns.length} />
+  );
 
   return (
-    <>
-      <Hide hide={!isFetchingOrLoading}>
-        <Grid className={classes.mainContainer}>
-          <SkeletonTable
-            rows={prevLength}
-            columnsCount={columnHeaders.length}
-            variant={TableVariant.compact}
-          />
-        </Grid>
-      </Hide>
-      <Hide hide={isFetchingOrLoading}>
-        <Table aria-label='packages table' ouiaId='packages_table' variant='compact'>
-          <Hide hide={isLoadingOrZeroCount}>
-            <Thead>
-              <Tr>
-                {columnHeaders.map((columnHeader) => (
-                  <Th key={columnHeader + '_column'}>{columnHeader}</Th>
-                ))}
-              </Tr>
-            </Thead>
-          </Hide>
-          {packagesList.map(({ name, version, release, arch }: Package, index: number) => (
-            <Tbody key={name + index}>
-              <Tr>
-                <Td>{name}</Td>
-                <Td>{version}</Td>
-                <Td>{release}</Td>
-                <Td>{arch}</Td>
-              </Tr>
-            </Tbody>
-          ))}
-        </Table>
-        <Hide hide={!isLoadingOrZeroCount}>
-          <EmptyTableState
-            notFiltered={!search?.length}
-            clearFilters={clearSearch}
-            itemName='packages'
-            notFilteredBody='You may need to add repositories that contain packages.'
-          />
-        </Hide>
-      </Hide>
-    </>
+    <DataView
+      data-ouia-component-id='packages_table'
+      activeState={activeState}
+      {...(enabledBulkDelete && activeState === undefined ? { selection } : {})}
+    >
+      <DataViewToolbar
+        className={spacing.pSm}
+        {...(enabledBulkDelete ? { ...bulkDeleteProps } : {})}
+        clearAllFilters={clearAllFiltersAndResetPage}
+        filters={searchFilter}
+        pagination={topPagination}
+      />
+      <DataViewTable
+        aria-label='Packages table'
+        ouiaId={ouiaId}
+        variant='compact'
+        columns={dataViewColumns}
+        rows={dataViewRows}
+        bodyStates={{ empty: emptyStateTable, loading: loadingStateTable }}
+      />
+      <DataViewToolbar pagination={bottomPagination} />
+    </DataView>
   );
 };
 

--- a/src/components/Tables/Packages/PackagesTableWithToolbars.tsx
+++ b/src/components/Tables/Packages/PackagesTableWithToolbars.tsx
@@ -24,14 +24,14 @@ interface Props {
   search: string;
 }
 
-export default function PackagesTable({
+const PackagesTableWithToolbars = ({
   isFetchingOrLoading,
   isLoadingOrZeroCount,
   packagesList,
   clearSearch,
   perPage,
   search,
-}: Props) {
+}: Props) => {
   const classes = useStyles();
   const [prevLength, setPrev] = useState(perPage || 10);
 
@@ -85,4 +85,6 @@ export default function PackagesTable({
       </Hide>
     </>
   );
-}
+};
+
+export default PackagesTableWithToolbars;

--- a/src/components/Tables/Packages/hooks/usePackageTableFilters.ts
+++ b/src/components/Tables/Packages/hooks/usePackageTableFilters.ts
@@ -1,0 +1,22 @@
+import { useDataViewFilters } from '@patternfly/react-data-view/dist/dynamic/Hooks';
+import useDebounce from 'Hooks/useDebounce';
+
+export type PackageTableFilters = { search: string; category: string[] };
+export const initialPackageFilters: PackageTableFilters = {
+  search: '',
+  category: [],
+};
+
+export type FilterProps = ReturnType<typeof useDataViewFilters<PackageTableFilters>> & {
+  debouncedSearch: string;
+};
+
+export const usePackageTableFilters = (): FilterProps => {
+  const filterProps = useDataViewFilters<PackageTableFilters>({
+    initialFilters: initialPackageFilters,
+  });
+  const { filters } = filterProps;
+  const debouncedSearch = useDebounce(filters.search, !filters.search ? 0 : 500);
+
+  return { ...filterProps, debouncedSearch };
+};

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -640,3 +640,14 @@ export const addUploads: (chunkRequest: AddUploadRequest) => Promise<AddUploadRe
   );
   return data;
 };
+
+export const bulkRemoveRepositoryRpms: (
+  repoUuid: string,
+  uuids: string[],
+) => Promise<void> = async (repoUuid: string, rpm_uuids: string[]) => {
+  const { data } = await axios.post(
+    `/api/content-sources/v1.0/repositories/${repoUuid}/rpms/bulk_remove/`,
+    { rpm_uuids },
+  );
+  return data;
+};

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -178,7 +178,7 @@ export type ValidationResponse = {
   gpg_key?: ValidateItem;
 };
 
-export interface PackageItem {
+interface PackageBase {
   arch: string;
   epoch: string;
   name: string;
@@ -187,6 +187,15 @@ export interface PackageItem {
   summary: string;
   version: string;
 }
+
+type PackageWithoutUUID = PackageBase & {
+  uuid?: never;
+};
+export type PackageWithUUID = PackageBase & {
+  uuid: string;
+};
+
+export type Package = PackageWithoutUUID | PackageWithUUID;
 
 export interface ErrataItem {
   id: string;
@@ -203,7 +212,13 @@ export interface ErrataItem {
 }
 
 export type PackagesResponse = {
-  data: PackageItem[];
+  data: PackageWithoutUUID[];
+  links: Links;
+  meta: Meta;
+};
+
+export type PackagesWithUUIDResponse = {
+  data: PackageWithUUID[];
   links: Links;
   meta: Meta;
 };
@@ -460,7 +475,7 @@ export const getPackages: (
   limit: number,
   search: string,
   sortBy?: string,
-) => Promise<PackagesResponse> = async (
+) => Promise<PackagesWithUUIDResponse> = async (
   uuid: string,
   page: number,
   limit: number,

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -47,6 +47,7 @@ import {
   deleteSnapshots,
   getLatestRepoConfigFile,
   PopularRepository,
+  bulkRemoveRepositoryRpms,
 } from './ContentApi';
 import { ADMIN_TASK_LIST_KEY } from '../Admin/AdminTaskQueries';
 import useErrorNotification from 'Hooks/useErrorNotification';
@@ -656,6 +657,7 @@ export const useGetPackagesQuery = (
     queryKey: [PACKAGES_KEY, uuid, page, limit, searchQuery, sortBy],
     queryFn: () => getPackages(uuid, page, limit, searchQuery, sortBy),
     placeholderData: keepPreviousData,
+    refetchOnMount: 'always',
     staleTime: 60000,
     meta: {
       title: 'Unable to find packages with the given UUID.',
@@ -907,6 +909,35 @@ export const useBulkDeleteSnapshotsMutate = (
         'An error occured',
         err,
         'bulk-delete-error',
+      );
+    },
+  });
+};
+
+export const useBulkRemoveRepositoryRpmsMutate = (queryClient: QueryClient, repoUuid: string) => {
+  const errorNotifier = useErrorNotification();
+  const { notify } = useNotification();
+
+  return useMutation({
+    mutationFn: (uuids: string[]) => bulkRemoveRepositoryRpms(repoUuid, uuids),
+    onSuccess: (_data, uuids) => {
+      notify({
+        variant: AlertVariant.success,
+        title:
+          uuids.length === 1
+            ? 'The package was successfully removed from the repository.'
+            : `${uuids.length} packages were successfully removed from the repository.`,
+      });
+      queryClient.invalidateQueries({ queryKey: [PACKAGES_KEY, repoUuid] });
+      queryClient.invalidateQueries({ queryKey: [CONTENT_LIST_KEY] });
+      queryClient.invalidateQueries({ queryKey: [CONTENT_ITEM_KEY, repoUuid] });
+    },
+    onError: (err) => {
+      errorNotifier(
+        'Error removing packages from the repository',
+        'An error occurred',
+        err,
+        'bulk-remove-rpms-error',
       );
     },
   });

--- a/src/services/Templates/TemplateApi.ts
+++ b/src/services/Templates/TemplateApi.ts
@@ -3,7 +3,7 @@ import {
   Links,
   Meta,
   type ErrataResponse,
-  type PackageItem,
+  type Package,
   SnapshotListResponse,
   SnapshotItem,
 } from '../Content/ContentApi';
@@ -57,7 +57,7 @@ export interface TemplateCollectionResponse {
 }
 
 export interface SnapshotRpmCollectionResponse {
-  data: Array<PackageItem>;
+  data: Array<Package>;
   links: Links;
   meta: Meta;
 }

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -10,7 +10,7 @@ import {
   SnapshotItem,
   ValidationResponse,
   type ErrataItem,
-  type PackageItem,
+  type Package,
   ContentOrigin,
 } from 'services/Content/ContentApi';
 import { AdminTask } from 'services/Admin/AdminTaskApi';
@@ -578,7 +578,7 @@ export const defaultTemplateSystemsListItem: IDSystemItem = {
   type: 'system',
 };
 
-export const defaultPackageItem: PackageItem = {
+export const defaultPackageItem: Package = {
   name: 'banana-base-libs',
   arch: 'x86_64',
   version: '1.2.3',


### PR DESCRIPTION
## Summary
Users can now delete rpm packages in the Package Modal
accessible from the repositories list. Only upload
repositories can be deleted.

The underlying packages table was changed to use DataView
components, so bulk delete can be enabled. Pagination
and filter by name was also delegated to DataView,
which made the consuming components significantly shorter.
Delete bulk and delete single package is only visible
for Package Modal.

This is the UI for the backend endpoint `/api/content-sources/v1.0/repositories/${repoUuid}/rpms/bulk_remove/` that was recently added.

## Testing steps
1) All the tests pass, specifically `PackageModal.test.tsx` unit test and UI tests in `DeletePackages.spec.ts`.
2) Manually go and create upload repo, add packages there and then go and delete a package or a couple of packages. Confirm that everything works.

Note: AssignEUSTemplateToSystem is failing currently due to an unrelated reason.

#testwith https://github.com/content-services/content-sources-backend/pull/1499
