### PR TITLE
HMS-10509: dark mode compatibility fixes

### DIFF
--- a/src/Pages/Repositories/AdminTaskTable/components/StatusIcon.tsx
+++ b/src/Pages/Repositories/AdminTaskTable/components/StatusIcon.tsx
@@ -7,16 +7,16 @@ import {
 import { Flex, FlexItem, Spinner } from '@patternfly/react-core';
 import StatusText from 'components/StatusText/StatusText';
 import {
-  t_global_color_status_danger_100 as global_danger_color_100,
-  t_global_color_status_success_100 as global_success_color_100,
-  t_global_color_status_warning_100 as global_warning_color_100,
+  t_global_color_status_danger_default,
+  t_global_color_status_success_default,
+  t_global_color_status_warning_default,
 } from '@patternfly/react-tokens';
 import { createUseStyles } from 'react-jss';
 import { AdminTask } from 'services/Admin/AdminTaskApi';
 
-const red = global_danger_color_100.value;
-const green = global_success_color_100.value;
-const gold = global_warning_color_100.value;
+const red = t_global_color_status_danger_default.var;
+const green = t_global_color_status_success_default.var;
+const gold = t_global_color_status_warning_default.var;
 
 const useStyles = createUseStyles({
   spinner: {
@@ -54,7 +54,7 @@ const StatusIcon = ({ status, removeText = false }: Props) => {
           </FlexItem>
           {!removeText && (
             <FlexItem>
-              <StatusText color='blue'>Running</StatusText>
+              <StatusText>Running</StatusText>
             </FlexItem>
           )}
         </Flex>
@@ -67,7 +67,7 @@ const StatusIcon = ({ status, removeText = false }: Props) => {
           </FlexItem>
           {!removeText && (
             <FlexItem>
-              <StatusText color='red'>Failed</StatusText>
+              <StatusText>Failed</StatusText>
             </FlexItem>
           )}
         </Flex>
@@ -80,7 +80,7 @@ const StatusIcon = ({ status, removeText = false }: Props) => {
           </FlexItem>
           {!removeText && (
             <FlexItem>
-              <StatusText color='green'>Completed</StatusText>
+              <StatusText>Completed</StatusText>
             </FlexItem>
           )}
         </Flex>
@@ -93,7 +93,7 @@ const StatusIcon = ({ status, removeText = false }: Props) => {
           </FlexItem>
           {!removeText && (
             <FlexItem>
-              <StatusText color='red'>Canceled</StatusText>
+              <StatusText>Canceled</StatusText>
             </FlexItem>
           )}
         </Flex>
@@ -106,7 +106,7 @@ const StatusIcon = ({ status, removeText = false }: Props) => {
           </FlexItem>
           {!removeText && (
             <FlexItem>
-              <StatusText color='gold'>Pending</StatusText>
+              <StatusText>Pending</StatusText>
             </FlexItem>
           )}
         </Flex>

--- a/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
@@ -37,8 +37,10 @@ import { isEmpty } from 'lodash';
 import useDeepCompareEffect from 'Hooks/useDeepCompareEffect';
 import { ActionButtons } from 'components/ActionButtons/ActionButtons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { modalTableSurfaceStyles } from 'helpers';
 
 const useStyles = createUseStyles({
+  modalTableScope: modalTableSurfaceStyles,
   removeButton: {
     marginRight: '36px',
     transition: 'unset!important',
@@ -184,7 +186,7 @@ export default function DeleteContentModal() {
           </Stack>
         }
       />
-      <ModalBody>
+      <ModalBody className={classes.modalTableScope}>
         <Hide hide={!isLoading}>
           <Bullseye>
             <Spinner />

--- a/src/Pages/Repositories/ContentListTable/components/PackageModal/PackageModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/PackageModal/PackageModal.tsx
@@ -26,8 +26,10 @@ import useRootPath from 'Hooks/useRootPath';
 import { useAppContext } from 'middleware/AppContext';
 import PackagesTable from 'components/SharedTables/PackagesTable';
 import { REPOSITORIES_ROUTE } from 'Routes/constants';
+import { modalTableSurfaceStyles } from 'helpers';
 
 const useStyles = createUseStyles({
+  modalTableScope: modalTableSurfaceStyles,
   mainContainer: {
     display: 'flex',
     flexDirection: 'column',
@@ -119,7 +121,7 @@ export default function PackageModal() {
         descriptorId='rpm-package-modal-description'
       />
       <InnerScrollContainer>
-        <Grid className={classes.mainContainer}>
+        <Grid className={`${classes.modalTableScope} ${classes.mainContainer}`}>
           <InputGroup className={classes.topContainer}>
             <InputGroupItem>
               <TextInput

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.tsx
@@ -21,8 +21,10 @@ import { createUseStyles } from 'react-jss';
 import { SnapshotSelector } from './SnapshotSelector';
 import { REPOSITORIES_ROUTE } from 'Routes/constants';
 import { SnapshotErrataTab } from './Tabs/SnapshotErrataTab';
+import { modalTableSurfaceStyles } from 'helpers';
 
 const useStyles = createUseStyles({
+  modalTableScope: modalTableSurfaceStyles,
   modalBody: {
     padding: '24px 24px 0 24px',
   },
@@ -84,7 +86,7 @@ export default function SnapshotDetailsModal() {
     >
       <ModalHeader title='Snapshot detail' labelId='snapshot-details-modal-title' />
       <InnerScrollContainer>
-        <Stack className={classes.modalBody}>
+        <Stack className={`${classes.modalTableScope} ${classes.modalBody}`}>
           <StackItem className={classes.topContainer}>
             <SnapshotSelector />
             <Button variant='secondary' onClick={onBackClick}>

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotSelector.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotSelector.tsx
@@ -60,6 +60,7 @@ export function SnapshotSelector() {
         fieldId='snapshot'
       >
         <Dropdown
+          isScrollable={true}
           onSelect={(_, val) => {
             setSelected(val as string);
             setSelectorOpen(false);

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/DeleteSnapshotsModal/DeleteSnapshotsModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/DeleteSnapshotsModal/DeleteSnapshotsModal.tsx
@@ -30,11 +30,12 @@ import { SnapshotItem } from 'services/Content/ContentApi';
 import { useBulkDeleteSnapshotsMutate, useGetSnapshotList } from 'services/Content/ContentQueries';
 import { TemplateItem } from 'services/Templates/TemplateApi';
 import { useFetchTemplatesForSnapshots } from 'services/Templates/TemplateQueries';
-import { formatDateDDMMMYYYY } from 'helpers';
+import { formatDateDDMMMYYYY, modalTableSurfaceStyles } from 'helpers';
 import ChangedArrows from '../components/ChangedArrows';
 import { SnapshotDetailTab } from '../../SnapshotDetailsModal/SnapshotDetailsModal';
 
 const useStyles = createUseStyles({
+  modalTableScope: modalTableSurfaceStyles,
   description: {
     paddingTop: '12px', // 4px on the title bottom padding makes this the "standard" 16 total padding
   },
@@ -143,7 +144,7 @@ export default function DeleteSnapshotsModal() {
           </>
         }
       />
-      <ModalBody>
+      <ModalBody className={classes.modalTableScope}>
         <Hide hide={!isLoading}>
           <Bullseye>
             <Spinner />

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
@@ -36,11 +36,12 @@ import { useAppContext } from 'middleware/AppContext';
 import RepoConfig from './components/RepoConfig';
 import { DELETE_ROUTE, REPOSITORIES_ROUTE } from 'Routes/constants';
 import { SnapshotDetailTab } from '../SnapshotDetailsModal/SnapshotDetailsModal';
-import { formatDateDDMMMYYYY } from 'helpers';
+import { formatDateDDMMMYYYY, modalTableSurfaceStyles } from 'helpers';
 import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip';
 import LatestRepoConfig from './components/LatestRepoConfig';
 
 const useStyles = createUseStyles({
+  modalTableScope: modalTableSurfaceStyles,
   mainContainer: {
     display: 'flex',
     flexDirection: 'column',
@@ -233,7 +234,7 @@ const SnapshotListModal = () => {
           descriptorId='snapshot-list-modal-description'
         />
         <InnerScrollContainer>
-          <Grid className={classes.mainContainer}>
+          <Grid className={`${classes.modalTableScope} ${classes.mainContainer}`}>
             <Hide hide={loadingOrZeroCount}>
               <Flex className={classes.topContainer}>
                 <Hide hide={isRedHatRepository || isEPELRepository}>

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/components/ChangedArrows.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/components/ChangedArrows.tsx
@@ -1,8 +1,8 @@
 import { LongArrowAltDownIcon, LongArrowAltUpIcon } from '@patternfly/react-icons';
 import { Flex, FlexItem } from '@patternfly/react-core';
 import {
-  t_global_color_status_danger_100,
-  t_global_color_status_success_100,
+  t_global_color_status_danger_default,
+  t_global_color_status_success_default,
 } from '@patternfly/react-tokens';
 import text from '@patternfly/react-styles/css/utilities/Text/text';
 
@@ -16,7 +16,7 @@ const ChangedArrows = ({ addedCount, removedCount }: Props) => (
     <Flex
       gap={{ default: 'gapXs' }}
       alignItems={{ default: 'alignItemsCenter' }}
-      style={{ color: t_global_color_status_success_100.value }}
+      style={{ color: t_global_color_status_success_default.var }}
     >
       <FlexItem>
         <LongArrowAltUpIcon />
@@ -26,7 +26,7 @@ const ChangedArrows = ({ addedCount, removedCount }: Props) => (
     <Flex
       gap={{ default: 'gapXs' }}
       alignItems={{ default: 'alignItemsCenter' }}
-      style={{ color: t_global_color_status_danger_100.value }}
+      style={{ color: t_global_color_status_danger_default.var }}
     >
       <FlexItem>
         <LongArrowAltDownIcon />

--- a/src/Pages/Repositories/ContentListTable/components/StatusIcon.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/StatusIcon.tsx
@@ -15,9 +15,9 @@ import {
 } from '@patternfly/react-core';
 import StatusText from 'components/StatusText/StatusText';
 import {
-  t_global_color_status_danger_100 as global_danger_color_100,
-  t_global_color_status_success_100 as global_success_color_100,
-  t_global_color_status_warning_100 as global_warning_color_100,
+  t_global_color_status_danger_default,
+  t_global_color_status_success_default,
+  t_global_color_status_warning_default,
 } from '@patternfly/react-tokens';
 import { createUseStyles } from 'react-jss';
 import dayjs from 'dayjs';
@@ -29,9 +29,9 @@ import Hide from 'components/Hide/Hide';
 
 dayjs.extend(relativeTime);
 
-const red = global_danger_color_100.value;
-const green = global_success_color_100.value;
-const gold = global_warning_color_100.value;
+const red = t_global_color_status_danger_default.var;
+const green = t_global_color_status_success_default.var;
+const gold = t_global_color_status_warning_default.var;
 
 const useStyles = createUseStyles({
   spinner: {
@@ -147,7 +147,7 @@ const StatusIcon = ({
             <CheckCircleIcon color={green} />
           </FlexItem>
           <FlexItem>
-            <StatusText color='green'>Valid</StatusText>
+            <StatusText>Valid</StatusText>
           </FlexItem>
         </Flex>
       );
@@ -181,9 +181,7 @@ const StatusIcon = ({
               }
             >
               <Button variant='link' isInline>
-                <StatusText color='red' isLink>
-                  Invalid
-                </StatusText>
+                <StatusText isLink>Invalid</StatusText>
               </Button>
             </Popover>
           </FlexItem>
@@ -218,9 +216,7 @@ const StatusIcon = ({
                 <PopoverFooter retryHandler={retryHandler} uuid={uuid} origin={origin} />
               }
             >
-              <StatusText color='gold' isLink>
-                Unavailable
-              </StatusText>
+              <StatusText isLink>Unavailable</StatusText>
             </Popover>
           </FlexItem>
         </Flex>
@@ -244,7 +240,7 @@ const StatusIcon = ({
               <Spinner size='md' className={classes.spinner} />
             </FlexItem>
             <FlexItem>
-              <StatusText color='blue'>In progress</StatusText>
+              <StatusText>In progress</StatusText>
             </FlexItem>
           </Flex>
         </Tooltip>

--- a/src/Pages/Templates/TemplateDetails/components/AssignTemplateModal/AddSystemModal.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/AssignTemplateModal/AddSystemModal.tsx
@@ -46,8 +46,10 @@ import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip
 import useNotification from 'Hooks/useNotification';
 import TagsFilter from 'components/TagsFilter/TagsFilter';
 import { isVersionLockedSystem } from '../../../TemplatesTable/helpers';
+import { modalTableSurfaceStyles } from 'helpers';
 
 const useStyles = createUseStyles({
+  modalTableScope: modalTableSurfaceStyles,
   mainContainer: {
     display: 'flex',
     flexDirection: 'column',
@@ -327,7 +329,7 @@ export default function AddSystemModal() {
         }
       />
       <InnerScrollContainer>
-        <Grid className={classes.mainContainer}>
+        <Grid className={`${classes.modalTableScope} ${classes.mainContainer}`}>
           <InputGroup className={classes.topContainer}>
             <InputGroupItem>
               <InputGroup>

--- a/src/Pages/Templates/TemplateDetails/components/AssignTemplateModal/AssignTemplateModal.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/AssignTemplateModal/AssignTemplateModal.tsx
@@ -34,8 +34,15 @@ import {
   TEMPLATE_SYSTEMS_UPDATE_LIMIT,
   TEMPLATES_DOCS_URL,
 } from 'Pages/Templates/TemplatesTable/constants';
+import { modalTableSurfaceStyles } from 'helpers';
+import { createUseStyles } from 'react-jss';
+
+const useStyles = createUseStyles({
+  modalTableScope: modalTableSurfaceStyles,
+});
 
 const AssignTemplateModal = () => {
+  const classes = useStyles();
   const queryClient = useQueryClient();
   const { notify } = useNotification();
 
@@ -211,7 +218,7 @@ const AssignTemplateModal = () => {
         }
       />
 
-      <ModalBody>
+      <ModalBody className={classes.modalTableScope}>
         {template ? (
           (() => {
             switch (assignmentMethod) {

--- a/src/Pages/Templates/TemplatesTable/components/StatusIcon.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/StatusIcon.tsx
@@ -2,16 +2,16 @@ import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons'
 import { Button, Flex, FlexItem, Popover, Spinner, Tooltip } from '@patternfly/react-core';
 import StatusText from 'components/StatusText/StatusText';
 import {
-  t_global_color_status_danger_100 as global_danger_color_100,
-  t_global_color_status_success_100 as global_success_color_100,
+  t_global_color_status_danger_default,
+  t_global_color_status_success_default,
 } from '@patternfly/react-tokens';
 import { createUseStyles } from 'react-jss';
 import { AdminTask } from 'services/Admin/AdminTaskApi';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { useMemo } from 'react';
 
-const red = global_danger_color_100.value;
-const green = global_success_color_100.value;
+const red = t_global_color_status_danger_default.var;
+const green = t_global_color_status_success_default.var;
 
 const useStyles = createUseStyles({
   spinner: {
@@ -61,7 +61,7 @@ const StatusIcon = ({ uuid, last_update_snapshot_error, last_update_task }: Prop
           <CheckCircleIcon color={green} />
         </FlexItem>
         <FlexItem>
-          <StatusText color='green'>Valid</StatusText>
+          <StatusText>Valid</StatusText>
         </FlexItem>
       </Flex>
     );
@@ -82,7 +82,7 @@ const StatusIcon = ({ uuid, last_update_snapshot_error, last_update_task }: Prop
             <Spinner size='md' className={classes.spinner} />
           </FlexItem>
           <FlexItem>
-            <StatusText color='blue'>In progress</StatusText>
+            <StatusText>In progress</StatusText>
           </FlexItem>
         </Flex>
       </Tooltip>
@@ -107,9 +107,7 @@ const StatusIcon = ({ uuid, last_update_snapshot_error, last_update_task }: Prop
             position='left'
           >
             <Button variant='link' isInline>
-              <StatusText color='red' isLink>
-                Invalid
-              </StatusText>
+              <StatusText isLink>Invalid</StatusText>
             </Button>
           </Popover>
         </FlexItem>

--- a/src/components/SharedTables/AdvisoriesTable/index.tsx
+++ b/src/components/SharedTables/AdvisoriesTable/index.tsx
@@ -15,8 +15,8 @@ import Hide from '../../Hide/Hide';
 import { Flex, FlexItem, Grid, Stack, Content } from '@patternfly/react-core';
 import { SkeletonTable } from '@patternfly/react-component-groups';
 import {
-  t_global_color_status_danger_100,
-  t_global_color_status_success_100,
+  t_global_color_status_danger_default,
+  t_global_color_status_success_default,
 } from '@patternfly/react-tokens';
 import { createUseStyles } from 'react-jss';
 import useDeepCompareEffect from 'Hooks/useDeepCompareEffect';
@@ -29,8 +29,8 @@ import SeverityWithIcon from '../../SeverityWithIcon/SeverityWithIcon';
 import UrlWithExternalIcon from '../../UrlWithLinkIcon/UrlWithLinkIcon';
 import EmptyTableState from 'components/EmptyTableState/EmptyTableState';
 
-const red = t_global_color_status_danger_100.value;
-const green = t_global_color_status_success_100.value;
+const red = t_global_color_status_danger_default.var;
+const green = t_global_color_status_success_default.var;
 
 const useStyles = createUseStyles({
   mainContainer: {

--- a/src/components/StatusText/StatusText.tsx
+++ b/src/components/StatusText/StatusText.tsx
@@ -1,18 +1,7 @@
 import { createUseStyles } from 'react-jss';
-import {
-  t_global_color_status_danger_100,
-  t_color_blue_70,
-  t_global_color_status_success_100,
-  t_global_color_status_warning_100,
-} from '@patternfly/react-tokens';
-
-const red = t_global_color_status_danger_100.value;
-const green = t_global_color_status_success_100.value;
-const gold = t_global_color_status_warning_100.value;
-const blue = t_color_blue_70.value;
+import { t_global_text_color_regular } from '@patternfly/react-tokens';
 
 interface Props {
-  color: 'red' | 'green' | 'gold' | 'blue';
   isLink?: boolean;
   children?: React.ReactNode;
 }
@@ -20,7 +9,6 @@ interface Props {
 const useStyles = ({ isLink }: Props) =>
   createUseStyles({
     fontStyle: {
-      fontWeight: 'bold',
       fontSize: '14px',
       ...(isLink
         ? {
@@ -28,18 +16,15 @@ const useStyles = ({ isLink }: Props) =>
             cursor: 'pointer',
           }
         : {}),
+      color: t_global_text_color_regular.var,
     },
-    red: { extend: 'fontStyle', color: red },
-    green: { extend: 'fontStyle', color: green },
-    gold: { extend: 'fontStyle', color: gold },
-    blue: { extend: 'fontStyle', color: blue },
   });
 
 const StatusText = (props: Props) => {
   const classes = useStyles(props)();
-  const { color, children } = props;
+  const { children } = props;
 
-  return <span className={classes[color]}>{children}</span>;
+  return <span className={classes.fontStyle}>{children}</span>;
 };
 
 export default StatusText;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import { t_global_background_color_floating_default as floatingBackground } from '@patternfly/react-tokens';
 
 // Removes null values and builds url params from a given object.
 export const objectToUrlParams = (obj: {
@@ -75,4 +76,19 @@ export const isEPELUrl = (repoUrl) => {
     'https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/',
   ];
   return epelUrls.includes(repoUrl);
+};
+
+const floatingBackgroundColor = floatingBackground.var;
+
+// Scope modal-only table surfaces without affecting shared tables on full pages.
+export const modalTableSurfaceStyles = {
+  '& .pf-v6-c-table': {
+    '--pf-v6-c-table--BackgroundColor': floatingBackgroundColor,
+    '--pf-v6-c-table__control-row--BackgroundColor': floatingBackgroundColor,
+    '--pf-v6-c-table__expandable-row-content--BackgroundColor': floatingBackgroundColor,
+    '--pf-v6-c-table__tr--m-ghost-row--BackgroundColor': floatingBackgroundColor,
+  },
+  '& .pf-v6-c-pagination.pf-m-bottom': {
+    '--pf-v6-c-pagination--m-bottom--BackgroundColor': floatingBackgroundColor,
+  },
 };


### PR DESCRIPTION
## Summary
This makes two changes for dark mode compatibility:
- It applies the default background for floating elements to tables and paginations inside of modals, so that they have the same look as in light mode. _(this solution will also work for data view tables down the line)_
- This changes the token used for status colors to the default version which change with the applied theme. Also makes the text uncolored per UX request.

> ⬆️ IMO, we might wanna revisit this later, at the upcoming SPUR maybe, but these are the proposed changes by UX currently 😅 

_Additionally, makes a one-liner fix for the snapshot selector so it's scrollable and can be actually used for repos with a lot of snapshots._

## Testing steps
- Verify that all tables, that are inside of modals (raw modals, not wizard) look good 💅🏼 
- Check that status colors are now readable/visible in dark mode 👓 
