### PR TITLE
Build: update `yarn.lock` for version package alignment (data-view)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2168,10 +2168,21 @@
     "@parcel/watcher-win32-ia32" "2.5.6"
     "@parcel/watcher-win32-x64" "2.5.6"
 
-"@patternfly/react-component-groups@^6.0.0", "@patternfly/react-component-groups@^6.1.0":
+"@patternfly/react-component-groups@^6.0.0":
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/@patternfly/react-component-groups/-/react-component-groups-6.4.0.tgz#f657eefb059cd41ff91af2e273e14bf8c48f77a2"
   integrity sha512-vg0761nQ/7hfggbp6+XowRcQQSd9oIToh77+4lmsyrs41MkA5ppQIPBCZ4lUZW87kmEPhkHqglpJcVfsrrIM/g==
+  dependencies:
+    "@patternfly/react-core" "^6.0.0"
+    "@patternfly/react-icons" "^6.0.0"
+    "@patternfly/react-styles" "^6.0.0"
+    "@patternfly/react-table" "^6.0.0"
+    react-jss "^10.10.0"
+
+"@patternfly/react-component-groups@^6.1.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-component-groups/-/react-component-groups-6.5.0.tgz#8a2e839b638978f93a22a59012b3cb8532709a74"
+  integrity sha512-uvrAuUixZW618gsQY06nOcQWZclsCtOa5mixi6KQKOyrpH9GgtrihJ/fVJsA1a5HcZzC4SKIdd3wkXArs/vxEg==
   dependencies:
     "@patternfly/react-core" "^6.0.0"
     "@patternfly/react-icons" "^6.0.0"
@@ -2226,7 +2237,19 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-6.5.1.tgz#9e858d15a60586f0872d6af6a9c2db11c46337dc"
   integrity sha512-yQMzUbbf6qYM/v3JbPvaCJTgxRbOKoEw229XZmnnM8gDvp8ECiI7LqihrAOK/NA6T6M3DDgsRMd2JurUBhPDEw==
 
-"@patternfly/react-table@^6.0.0", "@patternfly/react-table@^6.3.1", "@patternfly/react-table@^6.4.0":
+"@patternfly/react-table@^6.0.0", "@patternfly/react-table@^6.4.0":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-6.5.1.tgz#39ac5a2c5dc4d89bd51acd4161131e95821c0a04"
+  integrity sha512-JpX66ctLsg5snRRheDhuF2fHvXDG4UDKYfP5403kCAQ4Dz2dPu3PhlHi4AJol+egEBD2HfS/U37j7noQ1Y7mpA==
+  dependencies:
+    "@patternfly/react-core" "^6.5.1"
+    "@patternfly/react-icons" "^6.5.1"
+    "@patternfly/react-styles" "^6.5.1"
+    "@patternfly/react-tokens" "^6.5.1"
+    lodash "^4.18.1"
+    tslib "^2.8.1"
+
+"@patternfly/react-table@^6.3.1":
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-6.4.3.tgz#1b99673c3f1c2cf92262f8b2d59e1ae80e95ccfc"
   integrity sha512-lPHjVOEkJpCtXMtE48pLGwMmLsCgYJvoiZpuW2/Vlg0y0pmg0nfYUVDBBTXfQ3dgskn/zb5SAgZr158VQQoBtw==


### PR DESCRIPTION
## Summary

PatternFly has released data-view v6.5.0 as a stable version. We have switched from the prerelease version to this stable release, as we no longer require any features specific to the prerelease.

### Changes

- Manually triggered the update of `yarn.lock` to ensure proper package version alignment, as it seems that Dependabot missed this during the initial switch

## Testing steps
