### PR TITLE
Build: Reinstate dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/' # Location of package manifests
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: '@patternfly/react-core'
+        versions: ['6.x.x']
+      - dependency-name: '@patternfly/react-icons'
+        versions: ['6.x.x']
+      - dependency-name: '@patternfly/react-table'
+        versions: ['6.x.x']
+      - dependency-name: 'react-router-dom'
+        versions: ['7.x.x']
+      - dependency-name: '@redhat-cloud-services/frontend-components-utilities'
+        versions: ['5.x.x']
+      - dependency-name: '@redhat-cloud-services/frontend-components'
+        versions: ['5.x.x']
+      - dependency-name: 'react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-dom'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'htmlparser2'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'jest'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'jest-environment-jsdom'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
+      # ts-patch v4+ targets TypeScript 6; keep 3.x while the app stays on TypeScript 5.9.x
+      - dependency-name: 'ts-patch'
+        update-types: ['version-update:semver-major']
+      # eslint-plugin-react is not yet compatible with ESLint 10 (context API)
+      # TODO: Revert this change when possible (HMS-10187)
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@eslint/js'
+        update-types: ['version-update:semver-major']
+    commit-message:
+      prefix: 'Build: '
+    groups:
+      npm:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   - package-ecosystem: 'npm' # See documentation for possible values
     directory: '/' # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
+    cooldown:
+      default-days: 5
     ignore:
       - dependency-name: '@patternfly/react-core'
         versions: ['6.x.x']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,71 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@eslint/js'
         update-types: ['version-update:semver-major']
+      # Compromised versions from https://www.stepsecurity.io/blog/multiple-redhat-cloud-services-npm-packages-compromised
+      - dependency-name: '@redhat-cloud-services/types'
+        versions: ['3.6.1', '3.6.2', '3.6.4']
+      - dependency-name: '@redhat-cloud-services/frontend-components-utilities'
+        versions: ['7.4.1', '7.4.2', '7.4.4']
+      - dependency-name: '@redhat-cloud-services/frontend-components'
+        versions: ['7.7.2', '7.7.3', '7.7.5']
+      - dependency-name: '@redhat-cloud-services/rbac-client'
+        versions: ['9.0.3', '9.0.4', '9.0.6']
+      - dependency-name: '@redhat-cloud-services/javascript-clients-shared'
+        versions: ['2.0.8', '2.0.9', '2.0.11']
+      - dependency-name: '@redhat-cloud-services/frontend-components-config-utilities'
+        versions: ['4.11.2', '4.11.3', '4.11.5']
+      - dependency-name: '@redhat-cloud-services/frontend-components-notifications'
+        versions: ['6.9.2', '6.9.3', '6.9.5']
+      - dependency-name: '@redhat-cloud-services/tsc-transform-imports'
+        versions: ['1.2.2', '1.2.4', '1.2.6']
+      - dependency-name: '@redhat-cloud-services/frontend-components-config'
+        versions: ['6.11.3', '6.11.4', '6.11.6']
+      - dependency-name: '@redhat-cloud-services/eslint-config-redhat-cloud-services'
+        versions: ['3.2.1', '3.2.2', '3.2.4']
+      - dependency-name: '@redhat-cloud-services/host-inventory-client'
+        versions: ['5.0.3', '5.0.4', '5.0.6']
+      - dependency-name: '@redhat-cloud-services/rule-components'
+        versions: ['4.7.2', '4.7.3', '4.7.5']
+      - dependency-name: '@redhat-cloud-services/frontend-components-remediations'
+        versions: ['4.9.2', '4.9.3', '4.9.5']
+      - dependency-name: '@redhat-cloud-services/frontend-components-translations'
+        versions: ['4.4.1', '4.4.2', '4.4.4']
+      - dependency-name: '@redhat-cloud-services/vulnerabilities-client'
+        versions: ['2.1.9', '2.1.11']
+      - dependency-name: '@redhat-cloud-services/frontend-components-advisor-components'
+        versions: ['3.8.2', '3.8.4', '3.8.6']
+      - dependency-name: '@redhat-cloud-services/entitlements-client'
+        versions: ['4.0.11', '4.0.12', '4.0.14']
+      - dependency-name: '@redhat-cloud-services/chrome'
+        versions: ['2.3.1', '2.3.2', '2.3.4']
+      - dependency-name: '@redhat-cloud-services/notifications-client'
+        versions: ['6.1.4', '6.1.5', '6.1.7']
+      - dependency-name: '@redhat-cloud-services/compliance-client'
+        versions: ['4.0.3', '4.0.4', '4.0.6']
+      - dependency-name: '@redhat-cloud-services/sources-client'
+        versions: ['3.0.10', '3.0.11', '3.0.13']
+      - dependency-name: '@redhat-cloud-services/integrations-client'
+        versions: ['6.0.4', '6.0.5', '6.0.7']
+      - dependency-name: '@redhat-cloud-services/frontend-components-testing'
+        versions: ['1.2.1', '1.2.2', '1.2.4']
+      - dependency-name: '@redhat-cloud-services/remediations-client'
+        versions: ['4.0.4', '4.0.5', '4.0.7']
+      - dependency-name: '@redhat-cloud-services/insights-client'
+        versions: ['4.0.4', '4.0.5', '4.0.7']
+      - dependency-name: '@redhat-cloud-services/topological-inventory-client'
+        versions: ['3.0.10', '3.0.11', '3.0.13']
+      - dependency-name: '@redhat-cloud-services/config-manager-client'
+        versions: ['5.0.4', '5.0.5', '5.0.7']
+      - dependency-name: '@redhat-cloud-services/hcc-pf-mcp'
+        versions: ['0.6.1', '0.6.2', '0.6.4']
+      - dependency-name: '@redhat-cloud-services/quickstarts-client'
+        versions: ['4.0.11', '4.0.12', '4.0.14']
+      - dependency-name: '@redhat-cloud-services/patch-client'
+        versions: ['4.0.4', '4.0.5', '4.0.7']
+      - dependency-name: '@redhat-cloud-services/hcc-feo-mcp'
+        versions: ['0.3.1', '0.3.2', '0.3.4']
+      - dependency-name: '@redhat-cloud-services/hcc-kessel-mcp'
+        versions: ['0.3.1', '0.3.2', '0.3.4']
     commit-message:
       prefix: 'Build: '
     groups:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
 _playwright-tests/test-utils/**/*
-.github/dependabot.yml

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     "schedule": [
         "on Monday after 3am and before 10am"
     ],
+    "minimumReleaseAge": "5 days",
     "ignorePaths": [
       ".pre-commit-config.yaml"
     ],


### PR DESCRIPTION
## Summary

This reverts the removal of dependabot config, adds a cooldown period, ignores affected pkg versions, and adds min release days to renovate.

## Testing steps
Tests pass