### PR TITLE
HMS-10421: copy templates

### DIFF
--- a/_playwright-tests/UI/Templates.spec.ts
+++ b/_playwright-tests/UI/Templates.spec.ts
@@ -1,6 +1,11 @@
-import { test, expect } from 'test-utils';
-import { navigateToTemplates } from './helpers/navHelpers';
-import { closeGenericPopupsIfExist } from './helpers/helpers';
+import { test, expect, cleanupRepositories, cleanupTemplates, randomName } from 'test-utils';
+import { navigateToRepositories, navigateToTemplates } from './helpers/navHelpers';
+import {
+  closeGenericPopupsIfExist,
+  getRowByNameOrUrl,
+  waitForValidStatus,
+} from './helpers/helpers';
+import { createCustomRepo } from './helpers/createRepositories';
 
 test.describe('Templates', () => {
   test('Navigate to templates, make sure the Create template button can be clicked', async ({
@@ -48,6 +53,107 @@ test.describe('Templates', () => {
       await expect(
         docsPage.getByText('A content template is a set of repository snapshots').first(),
       ).toBeVisible();
+    });
+  });
+
+  test('Copying templates', async ({ page, client, cleanup, unusedRepoUrl }) => {
+    const smallRHRepo = 'Red Hat CodeReady Linux Builder for RHEL 9 ARM 64 (RPMs)';
+
+    const repoNamePrefix = 'copy-template-custom-repo';
+    const repoName = `${repoNamePrefix}-${randomName()}`;
+    const templateNamePrefix = 'copy-template-test';
+    const templateName = `${templateNamePrefix}-${randomName()}`;
+    const templateDescription = 'To be copied..';
+    const copyName = `copied-template-${randomName()}`;
+
+    await test.step('Pre-test setup', async () => {
+      await cleanup.runAndAdd(() => cleanupRepositories(client, repoNamePrefix));
+      await cleanup.runAndAdd(() => cleanupTemplates(client, templateName));
+      await cleanup.runAndAdd(() => cleanupTemplates(client, copyName));
+    });
+
+    await test.step('Create testing repo', async () => {
+      await navigateToRepositories(page);
+      await closeGenericPopupsIfExist(page);
+
+      await createCustomRepo(page, repoName, unusedRepoUrl);
+      await waitForValidStatus(page, repoName);
+    });
+
+    await test.step('Navigate to the templates page', async () => {
+      await navigateToTemplates(page);
+      await closeGenericPopupsIfExist(page);
+    });
+
+    await test.step('Create a template', async () => {
+      await page.getByRole('button', { name: 'Create template' }).click();
+      await page.getByRole('button', { name: 'filter OS version' }).click();
+      await page.getByRole('menuitem', { name: 'RHEL 9' }).click();
+      await page.getByRole('button', { name: 'filter architecture' }).click();
+      await page.getByRole('menuitem', { name: 'aarch64' }).click();
+      await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+      const modalPage = page.getByTestId('add_template_modal');
+      const rowRHELRepo = await getRowByNameOrUrl(modalPage, smallRHRepo);
+      await rowRHELRepo.getByLabel('Select row').click();
+      await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+      const rowRepo = await getRowByNameOrUrl(modalPage, repoName);
+      await rowRepo.getByLabel('Select row').click();
+      await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+      await page.getByText('Use the latest content', { exact: true }).click();
+      await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+      await expect(page.getByText('Enter template details')).toBeVisible();
+      await page.getByPlaceholder('Enter name').fill(templateName);
+      await page.getByPlaceholder('Enter name').press('Enter');
+      await page.getByPlaceholder('Description').fill(templateDescription);
+      await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+      await page.getByRole('button', { name: 'Create other options' }).click();
+      await page.getByText('Create template only', { exact: true }).click();
+
+      await waitForValidStatus(page, templateName);
+    });
+
+    await test.step('Copy the created template, verify the modal is correctly pre-filled', async () => {
+      const rowTemplate = await waitForValidStatus(page, templateName);
+      await rowTemplate.getByLabel('Kebab toggle').click();
+      await page.getByRole('menuitem', { name: 'Copy' }).click();
+
+      const modal = page.getByTestId('add_template_modal');
+      await expect(modal).toBeVisible();
+      await expect(modal.getByText('Enter template details')).toBeVisible();
+      await expect(modal.getByText('A template with this name already exists.')).toBeVisible();
+
+      await modal.getByRole('button', { name: 'Content', exact: true }).click();
+      await modal.getByRole('button', { name: 'OS and architecture', exact: true }).click();
+
+      await expect(modal.getByText('RHEL 9')).toBeVisible();
+      await expect(modal.getByText('aarch64')).toBeVisible();
+      await modal.getByRole('button', { name: 'Next', exact: true }).click();
+
+      const rowRHELRepo = await getRowByNameOrUrl(modal, smallRHRepo);
+      await expect(rowRHELRepo.getByLabel('Select row')).toBeChecked();
+      await modal.getByRole('button', { name: 'Next', exact: true }).click();
+
+      const rowRepo = await getRowByNameOrUrl(modal, repoName);
+      await expect(rowRepo.getByLabel('Select row')).toBeChecked();
+      await modal.getByRole('button', { name: 'Next', exact: true }).click();
+
+      await expect(modal.getByLabel('Use the latest content')).toBeChecked();
+      await modal.getByRole('button', { name: 'Next', exact: true }).click();
+
+      await modal.getByPlaceholder('Enter name').fill(copyName);
+      await expect(modal.getByText('A template with this name already exists.')).toBeHidden();
+      await expect(modal.getByText(templateDescription)).toBeVisible();
+      await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+      await page.getByRole('button', { name: 'Create other options' }).click();
+      await page.getByText('Create template only', { exact: true }).click();
+
+      await waitForValidStatus(page, copyName);
     });
   });
 });

--- a/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.test.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.test.tsx
@@ -31,5 +31,6 @@ it('expect TemplateActionDropdown to render all buttons', async () => {
 
   await waitFor(() => fireEvent.click(queryByText('Actions') as Element));
   expect(queryByText('Edit')).toBeInTheDocument();
+  expect(queryByText('Copy')).toBeInTheDocument();
   expect(queryByText('Delete')).toBeInTheDocument();
 });

--- a/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.test.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.test.tsx
@@ -1,12 +1,16 @@
 import { fireEvent, render, waitFor } from '@testing-library/react';
+import { useNavigate } from 'react-router-dom';
 import TemplateActionDropdown from './TemplateActionDropdown';
-import { TEMPLATES_ROUTE } from 'Routes/constants';
+import { COPY_ROUTE, DELETE_ROUTE, EDIT_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
 import { ReactQueryTestWrapper } from 'testingHelpers';
+
+const mockNavigate = jest.fn();
+const templateUUID = 'templateUUID';
 
 jest.mock('react-router-dom', () => ({
   useNavigate: jest.fn(),
-  useParams: () => ({ templateUUID: 'templateUUID' }),
-  useLocation: () => ({ pathname: `/something/${TEMPLATES_ROUTE}/else` }),
+  useParams: () => ({ templateUUID }),
+  useLocation: () => ({ pathname: `/app/${TEMPLATES_ROUTE}/${templateUUID}/systems` }),
 }));
 
 jest.mock('services/Templates/TemplateQueries', () => ({
@@ -20,6 +24,15 @@ jest.mock('middleware/AppContext', () => ({
   }),
 }));
 
+beforeEach(() => {
+  mockNavigate.mockClear();
+  (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+});
+
+const openActionsMenu = async (queryByText: (text: string) => HTMLElement | null) => {
+  await waitFor(() => fireEvent.click(queryByText('Actions') as Element));
+};
+
 it('expect TemplateActionDropdown to render all buttons', async () => {
   const { queryByText } = render(
     <ReactQueryTestWrapper>
@@ -29,8 +42,57 @@ it('expect TemplateActionDropdown to render all buttons', async () => {
 
   expect(queryByText('Actions')).toBeInTheDocument();
 
-  await waitFor(() => fireEvent.click(queryByText('Actions') as Element));
+  await openActionsMenu(queryByText);
   expect(queryByText('Edit')).toBeInTheDocument();
   expect(queryByText('Copy')).toBeInTheDocument();
   expect(queryByText('Delete')).toBeInTheDocument();
+});
+
+describe('TemplateActionDropdown navigation', () => {
+  it('navigates to edit route with details state', async () => {
+    const { queryByText } = render(
+      <ReactQueryTestWrapper>
+        <TemplateActionDropdown />
+      </ReactQueryTestWrapper>,
+    );
+
+    await openActionsMenu(queryByText);
+    fireEvent.click(queryByText('Edit') as Element);
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/app/${TEMPLATES_ROUTE}/${templateUUID}/${EDIT_ROUTE}`,
+      { state: { from: 'details' } },
+    );
+  });
+
+  it('navigates to copy route with details state', async () => {
+    const { queryByText } = render(
+      <ReactQueryTestWrapper>
+        <TemplateActionDropdown />
+      </ReactQueryTestWrapper>,
+    );
+
+    await openActionsMenu(queryByText);
+    fireEvent.click(queryByText('Copy') as Element);
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/app/${TEMPLATES_ROUTE}/${templateUUID}/${COPY_ROUTE}`,
+      { state: { from: 'details' } },
+    );
+  });
+
+  it('navigates to delete route from details', async () => {
+    const { queryByText } = render(
+      <ReactQueryTestWrapper>
+        <TemplateActionDropdown />
+      </ReactQueryTestWrapper>,
+    );
+
+    await openActionsMenu(queryByText);
+    fireEvent.click(queryByText('Delete') as Element);
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/app/${TEMPLATES_ROUTE}/${templateUUID}/${DELETE_ROUTE}`,
+    );
+  });
 });

--- a/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/TemplateActionDropdown.tsx
@@ -8,7 +8,7 @@ import {
   TooltipPosition,
 } from '@patternfly/react-core';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { DELETE_ROUTE, EDIT_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
+import { COPY_ROUTE, DELETE_ROUTE, EDIT_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
 import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip';
 import { useAppContext } from 'middleware/AppContext';
 import { createUseStyles } from 'react-jss';
@@ -38,6 +38,10 @@ export default function TemplateActionDropdown() {
     switch (value) {
       case 'edit':
         navigate(`${baseRoute}/${uuid}/${EDIT_ROUTE}`, { state: { from: 'details' } });
+        setIsOpen(false);
+        break;
+      case 'copy':
+        navigate(`${baseRoute}/${uuid}/${COPY_ROUTE}`, { state: { from: 'details' } });
         setIsOpen(false);
         break;
       case 'delete':
@@ -90,6 +94,22 @@ export default function TemplateActionDropdown() {
           }
         >
           Edit
+        </DropdownItem>
+        <DropdownItem
+          className={isMissingRequirements ? classes.disabledButton : ''}
+          value='copy'
+          isDisabled={isMissingRequirements}
+          tooltipProps={
+            isMissingRequirements
+              ? {
+                  isVisible: isMissingRequirements,
+                  content: `You do not have the required ${missingRequirements} to perform this action.`,
+                  position: TooltipPosition.left,
+                }
+              : undefined
+          }
+        >
+          Copy
         </DropdownItem>
         <DropdownItem value='delete'>Delete</DropdownItem>
       </DropdownList>

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.test.tsx
@@ -1,10 +1,14 @@
 import { fireEvent, render, waitFor } from '@testing-library/react';
+import { useNavigate } from 'react-router-dom';
 import TemplatesTable from './TemplatesTable';
 import { useTemplateList } from 'services/Templates/TemplateQueries';
 import { useTemplateSystemCounts } from 'services/Systems/SystemsQueries';
 import { ReactQueryTestWrapper, defaultTemplateItem } from 'testingHelpers';
 import { formatDateDDMMMYYYY } from 'helpers';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import { COPY_ROUTE, DELETE_ROUTE, EDIT_ROUTE } from 'Routes/constants';
+
+const mockNavigate = jest.fn();
 
 jest.mock('services/Templates/TemplateQueries', () => ({
   useTemplateList: jest.fn(),
@@ -45,6 +49,11 @@ jest.mock('@unleash/proxy-client-react', () => ({
 (useChrome as jest.Mock).mockImplementation(() => ({
   getEnvironment: () => 'stage',
 }));
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
+});
 
 const mockSystemCountsDefault = () => {
   (useTemplateSystemCounts as jest.Mock).mockImplementation(() => ({
@@ -114,6 +123,60 @@ it('expect TemplatesTable to render all action items', async () => {
     expect(queryByText('Edit')).toBeInTheDocument();
     expect(queryByText('Copy')).toBeInTheDocument();
     expect(queryByText('Delete')).toBeInTheDocument();
+  });
+});
+
+describe('TemplatesTable action navigation', () => {
+  const renderTableWithRow = () => {
+    (useTemplateList as jest.Mock).mockImplementation(() => ({
+      data: {
+        data: [defaultTemplateItem],
+        meta: { limit: 10, offset: 0, count: 1 },
+        isLoading: false,
+      },
+    }));
+    mockSystemCountsDefault();
+
+    const view = render(
+      <ReactQueryTestWrapper>
+        <TemplatesTable />
+      </ReactQueryTestWrapper>,
+    );
+
+    fireEvent.click(view.getByRole('button', { name: 'Kebab toggle' }));
+
+    return view;
+  };
+
+  it('navigates to edit route with table state', async () => {
+    const { queryByText } = renderTableWithRow();
+
+    await waitFor(() => expect(queryByText('Edit')).toBeInTheDocument());
+    fireEvent.click(queryByText('Edit') as Element);
+
+    expect(mockNavigate).toHaveBeenCalledWith(`${EDIT_ROUTE}/${defaultTemplateItem.uuid}`, {
+      state: { from: 'table' },
+    });
+  });
+
+  it('navigates to copy route with table state', async () => {
+    const { queryByText } = renderTableWithRow();
+
+    await waitFor(() => expect(queryByText('Copy')).toBeInTheDocument());
+    fireEvent.click(queryByText('Copy') as Element);
+
+    expect(mockNavigate).toHaveBeenCalledWith(`${COPY_ROUTE}/${defaultTemplateItem.uuid}`, {
+      state: { from: 'table' },
+    });
+  });
+
+  it('navigates to delete route from table', async () => {
+    const { queryByText } = renderTableWithRow();
+
+    await waitFor(() => expect(queryByText('Delete')).toBeInTheDocument());
+    fireEvent.click(queryByText('Delete') as Element);
+
+    expect(mockNavigate).toHaveBeenCalledWith(`${DELETE_ROUTE}/${defaultTemplateItem.uuid}`);
   });
 });
 

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import TemplatesTable from './TemplatesTable';
 import { useTemplateList } from 'services/Templates/TemplateQueries';
 import { useTemplateSystemCounts } from 'services/Systems/SystemsQueries';
@@ -28,7 +28,8 @@ jest.mock('Hooks/useRootPath', () => () => 'someUrl');
 
 jest.mock('middleware/AppContext', () => ({
   useAppContext: () => ({
-    rbac: { repoWrite: true, templateRead: true },
+    rbac: { repoWrite: true, templateRead: true, templateWrite: true },
+    subscriptions: { red_hat_enterprise_linux: true },
     setContentOrigin: () => {},
   }),
 }));
@@ -90,6 +91,30 @@ it('expect TemplatesTable to render a single row', () => {
 
   expect(queryByText(defaultTemplateItem.name)).toBeInTheDocument();
   expect(queryByText(formatDateDDMMMYYYY(defaultTemplateItem.date))).toBeInTheDocument();
+});
+
+it('expect TemplatesTable to render all action items', async () => {
+  (useTemplateList as jest.Mock).mockImplementation(() => ({
+    data: {
+      data: [defaultTemplateItem],
+      meta: { limit: 10, offset: 0, count: 1 },
+      isLoading: false,
+    },
+  }));
+  mockSystemCountsDefault();
+
+  const { getByRole, queryByText } = render(
+    <ReactQueryTestWrapper>
+      <TemplatesTable />
+    </ReactQueryTestWrapper>,
+  );
+
+  fireEvent.click(getByRole('button', { name: 'Kebab toggle' }));
+  await waitFor(() => {
+    expect(queryByText('Edit')).toBeInTheDocument();
+    expect(queryByText('Copy')).toBeInTheDocument();
+    expect(queryByText('Delete')).toBeInTheDocument();
+  });
 });
 
 it('expect TemplatesTable to display the system count for a template', () => {

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -37,7 +37,13 @@ import TemplateFilters from './components/TemplateFilters';
 import { formatDateDDMMMYYYY, formatDateUTC } from 'helpers';
 import Header from 'components/Header/Header';
 import useRootPath from 'Hooks/useRootPath';
-import { DELETE_ROUTE, SYSTEMS_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
+import {
+  COPY_ROUTE,
+  DELETE_ROUTE,
+  EDIT_ROUTE,
+  SYSTEMS_ROUTE,
+  TEMPLATES_ROUTE,
+} from 'Routes/constants';
 import useDistributionDetails from '../../../Hooks/useDistributionDetails';
 import { useTemplateList } from 'services/Templates/TemplateQueries';
 import { useTemplateSystemCounts } from 'services/Systems/SystemsQueries';
@@ -425,6 +431,24 @@ const TemplatesTable = () => {
                                       position: TooltipPosition.left,
                                       triggerRef: () =>
                                         document.getElementById('actions-column-edit') ||
+                                        document.body,
+                                    }
+                                  : undefined,
+                              },
+                              {
+                                id: 'actions-column-copy',
+                                className: isMissingRequirements ? classes.disabledButton : '',
+                                title: 'Copy',
+                                onClick: () =>
+                                  navigate(`${COPY_ROUTE}/${uuid}`, { state: { from: 'table' } }),
+                                isDisabled: isMissingRequirements,
+                                tooltipProps: isMissingRequirements
+                                  ? {
+                                      isVisible: isMissingRequirements,
+                                      content: `You do not have the required ${missingRequirements} to perform this action.`,
+                                      position: TooltipPosition.left,
+                                      triggerRef: () =>
+                                        document.getElementById('actions-column-copy') ||
                                         document.body,
                                     }
                                   : undefined,

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -334,6 +334,7 @@ const TemplatesTable = () => {
                           <FlexItem>
                             <Button
                               variant='link'
+                              isInline
                               onClick={() => navigate(`${rootPath}/${TEMPLATES_ROUTE}/${uuid}`)}
                             >
                               {name}

--- a/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/src/Pages/Templates/TemplatesTable/TemplatesTable.tsx
@@ -415,7 +415,7 @@ const TemplatesTable = () => {
                                 className: isMissingRequirements ? classes.disabledButton : '',
                                 title: 'Edit',
                                 onClick: () =>
-                                  navigate(`${uuid}/edit`, { state: { from: 'table' } }),
+                                  navigate(`${EDIT_ROUTE}/${uuid}`, { state: { from: 'table' } }),
                                 isDisabled: isMissingRequirements,
                                 tooltipProps: isMissingRequirements
                                   ? {
@@ -431,7 +431,7 @@ const TemplatesTable = () => {
                               { isSeparator: true },
                               {
                                 title: 'Delete',
-                                onClick: () => navigate(`${uuid}/${DELETE_ROUTE}`),
+                                onClick: () => navigate(`${DELETE_ROUTE}/${uuid}`),
                               },
                             ]}
                           />

--- a/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/AddOrEditTemplateContext.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/AddOrEditTemplateContext.tsx
@@ -40,6 +40,8 @@ export interface AddOrEditTemplateContextInterface {
   setSelectedCustomRepos: (uuidSet: Set<string>) => void;
   redHatCoreRepos: Set<string>;
   hasInvalidSteps: (index: number) => boolean;
+  /** False while fetching and merging an existing template (edit / copy). Always true for add flow. */
+  isSourceTemplateReady: boolean;
   isExtendedSupportAvailable: boolean;
   isEdit?: boolean;
   editUUID?: string;
@@ -49,7 +51,11 @@ export const AddOrEditTemplateContext = createContext({} as AddOrEditTemplateCon
 
 export const AddOrEditTemplateContextProvider = ({ children }: { children: ReactNode }) => {
   const uuid = useSafeUUIDParam('templateUUID');
-  const { data: editTemplateData, isError } = useFetchTemplate(uuid, !!uuid);
+  const {
+    data: editTemplateData,
+    isError,
+    isSuccess: isTemplateQuerySuccess,
+  } = useFetchTemplate(uuid, !!uuid);
 
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -65,6 +71,7 @@ export const AddOrEditTemplateContextProvider = ({ children }: { children: React
   const [redHatCoreRepos, setRedHatCoreRepos] = useState<Set<string>>(new Set());
   const [selectedRedHatRepos, setSelectedRedHatRepos] = useState<Set<string>>(new Set());
   const [selectedCustomRepos, setSelectedCustomRepos] = useState<Set<string>>(new Set());
+  const [isSourceTemplateReady, setIsSourceTemplateReady] = useState(!uuid);
 
   const hasLoadedEditData = useRef(false);
   const lastLoadedMinorVersion = useRef<string | undefined>();
@@ -164,59 +171,99 @@ export const AddOrEditTemplateContextProvider = ({ children }: { children: React
     }
   }, [coreRepos?.data, uuid, extended_release_version]);
 
-  const { data: existingRepositoryInformation, isLoading } = useContentListQuery(
-    1,
-    10,
-    { uuids: editTemplateData?.repository_uuids },
-    '',
-    [ContentOrigin.ALL],
-    !!uuid && !!editTemplateData?.repository_uuids.length,
-  );
+  const { data: existingRepositoryInformation, isLoading: isReposQueryLoading } =
+    useContentListQuery(
+      1,
+      10,
+      { uuids: editTemplateData?.repository_uuids },
+      '',
+      [ContentOrigin.ALL],
+      !!uuid && !!editTemplateData?.repository_uuids.length,
+    );
 
-  // If editing, we want to load the data from the existing template
+  // Hydrate wizard state when editing/copying — block the wizard until done so step validation/nav match loaded data.
   useEffect(() => {
-    const shouldLoadEditData =
-      uuid &&
-      !!editTemplateData &&
-      !isLoading &&
-      !!existingRepositoryInformation &&
-      !hasLoadedEditData.current;
+    if (!uuid) {
+      setIsSourceTemplateReady(true);
+      return;
+    }
 
-    if (shouldLoadEditData) {
+    if (isError) {
+      // Exit the loading state when the query has errored so the UI
+      // doesn't stay in a perpetual "loading" spinner state.
+      setIsSourceTemplateReady(true);
+      return;
+    }
+
+    if (!isTemplateQuerySuccess || !editTemplateData) {
+      setIsSourceTemplateReady(false);
+      return;
+    }
+
+    if (hasLoadedEditData.current) {
+      setIsSourceTemplateReady(true);
+      return;
+    }
+
+    const repoUuidList = editTemplateData.repository_uuids ?? [];
+
+    if (repoUuidList.length === 0) {
       const { extended_release, extended_release_version } = editTemplateData;
 
       if (extended_release && extended_release_version) {
         lastLoadedMinorVersion.current = extended_release_version;
       }
 
-      const startingState = {
+      setTemplateRequest({
         ...editTemplateData,
         extended_release: extended_release || STANDARD_STREAM.label,
-      };
-
-      setTemplateRequest(startingState);
-
-      const redHatReposToAdd: string[] = [];
-      const customReposToAdd: string[] = [];
-
-      existingRepositoryInformation?.data.forEach((item) => {
-        if (item.org_id === '-1') {
-          redHatReposToAdd.push(item.uuid);
-        } else {
-          customReposToAdd.push(item.uuid);
-        }
       });
-
-      if (redHatReposToAdd.length) {
-        setSelectedRedHatRepos(new Set([...selectedRedHatRepos, ...redHatReposToAdd]));
-      }
-
-      if (customReposToAdd.length) {
-        setSelectedCustomRepos(new Set(customReposToAdd));
-      }
+      setSelectedRedHatRepos(new Set());
+      setSelectedCustomRepos(new Set());
       hasLoadedEditData.current = true;
+      setIsSourceTemplateReady(true);
+      return;
     }
-  }, [editTemplateData, isLoading, existingRepositoryInformation]);
+
+    if (isReposQueryLoading || !existingRepositoryInformation) {
+      setIsSourceTemplateReady(false);
+      return;
+    }
+
+    const { extended_release, extended_release_version } = editTemplateData;
+
+    if (extended_release && extended_release_version) {
+      lastLoadedMinorVersion.current = extended_release_version;
+    }
+
+    setTemplateRequest({
+      ...editTemplateData,
+      extended_release: extended_release || STANDARD_STREAM.label,
+    });
+
+    const redHatReposToAdd: string[] = [];
+    const customReposToAdd: string[] = [];
+
+    for (const item of existingRepositoryInformation.data ?? []) {
+      if (item.org_id === '-1') {
+        redHatReposToAdd.push(item.uuid);
+      } else {
+        customReposToAdd.push(item.uuid);
+      }
+    }
+
+    setSelectedRedHatRepos(new Set(redHatReposToAdd));
+    setSelectedCustomRepos(new Set(customReposToAdd));
+
+    hasLoadedEditData.current = true;
+    setIsSourceTemplateReady(true);
+  }, [
+    uuid,
+    editTemplateData,
+    isReposQueryLoading,
+    isTemplateQuerySuccess,
+    existingRepositoryInformation,
+  ]);
 
   const templateRequestDependencies = useMemo(
     () => [...selectedCustomRepos, ...selectedRedHatRepos],
@@ -247,6 +294,7 @@ export const AddOrEditTemplateContextProvider = ({ children }: { children: React
         setSelectedCustomRepos,
         redHatCoreRepos,
         hasInvalidSteps,
+        isSourceTemplateReady,
         isExtendedSupportAvailable,
         isEdit: !!uuid,
         editUUID: uuid,

--- a/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/AddOrEditTemplateContext.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/AddOrEditTemplateContext.tsx
@@ -18,10 +18,11 @@ import {
   ExtendedReleaseStream,
 } from 'services/Content/ContentApi';
 import { useNavigate } from 'react-router-dom';
-import { useFetchTemplate } from 'services/Templates/TemplateQueries';
+import { useFetchTemplate, useTemplateNameAvailability } from 'services/Templates/TemplateQueries';
 import useRootPath from 'Hooks/useRootPath';
-import { isDateValid } from 'helpers';
+import { formatDateForPicker, isDateValid } from 'helpers';
 import useSafeUUIDParam from 'Hooks/useSafeUUIDParam';
+import useDebounce from 'Hooks/useDebounce';
 import { getRedHatCoreRepoUrls, isExtendedSupportTemplate } from '../../helpers';
 import { STANDARD_STREAM } from '../../constants';
 import { useAppContext } from 'middleware/AppContext';
@@ -42,6 +43,8 @@ export interface AddOrEditTemplateContextInterface {
   hasInvalidSteps: (index: number) => boolean;
   /** False while fetching and merging an existing template (edit / copy). Always true for add flow. */
   isSourceTemplateReady: boolean;
+  isNameTaken: boolean;
+  isNameCheckPending: boolean;
   isExtendedSupportAvailable: boolean;
   isEdit?: boolean;
   editUUID?: string;
@@ -107,21 +110,41 @@ export const AddOrEditTemplateContextProvider = ({ children }: { children: React
     isExtendedSupportAvailable &&
     isExtendedSupportTemplate(extended_release, extended_release_version);
 
+  const debouncedName = useDebounce(templateRequest.name?.trim() ?? '', 400);
+  const nameCheckEnabled = debouncedName.length > 0 && debouncedName.length <= 255;
+  const {
+    isNameTaken,
+    isFetching: isNameCheckPending,
+    isFetched: isNameCheckFetched,
+  } = useTemplateNameAvailability(debouncedName, isEdit ? uuid : undefined);
+
   // Step validation //
 
   const stepValidationSequence = useMemo(() => {
-    const { arch, date, name, version, use_latest, extended_release_version } = templateRequest;
+    const { arch, date, version, use_latest, extended_release_version } = templateRequest;
     const isPlatformDefined = arch && version;
+    const isNameFormatValid = debouncedName.length > 0 && debouncedName.length <= 255;
+    const isNameCheckComplete = !nameCheckEnabled || (isNameCheckFetched && !isNameCheckPending);
+    const isNameUnique = !isNameTaken;
 
     return [
       true, // [0] No step
       usesExtendedSupportStream ? isPlatformDefined && extended_release_version : isPlatformDefined, // [1] "OS and architecture" step
       !!selectedRedHatRepos.size, // [2] "Red Hat repositories" step
       true, // [3] "Other repositories" step - optional step
-      use_latest || isDateValid(date ?? ''), // [4] "Setup date" step
-      !!name && name.length < 256, // [5] "Detail" step
+      use_latest || isDateValid(date ? formatDateForPicker(date) : ''), // [4] "Setup date" step
+      isNameFormatValid && isNameUnique && isNameCheckComplete, // [5] "Detail" step
     ] as boolean[];
-  }, [templateRequest, selectedRedHatRepos.size, usesExtendedSupportStream]);
+  }, [
+    templateRequest,
+    selectedRedHatRepos.size,
+    usesExtendedSupportStream,
+    debouncedName,
+    nameCheckEnabled,
+    isNameTaken,
+    isNameCheckFetched,
+    isNameCheckPending,
+  ]);
 
   const hasInvalidSteps = useCallback(
     (stepIndex: number) => {
@@ -295,6 +318,8 @@ export const AddOrEditTemplateContextProvider = ({ children }: { children: React
         redHatCoreRepos,
         hasInvalidSteps,
         isSourceTemplateReady,
+        isNameTaken,
+        isNameCheckPending: nameCheckEnabled && isNameCheckPending,
         isExtendedSupportAvailable,
         isEdit: !!uuid,
         editUUID: uuid,

--- a/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/AddOrEditTemplateContext.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/AddOrEditTemplateContext.tsx
@@ -17,7 +17,7 @@ import {
   DistributionMinorVersion,
   ExtendedReleaseStream,
 } from 'services/Content/ContentApi';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useFetchTemplate, useTemplateNameAvailability } from 'services/Templates/TemplateQueries';
 import useRootPath from 'Hooks/useRootPath';
 import { formatDateForPicker, isDateValid } from 'helpers';
@@ -47,6 +47,7 @@ export interface AddOrEditTemplateContextInterface {
   isNameCheckPending: boolean;
   isExtendedSupportAvailable: boolean;
   isEdit?: boolean;
+  isCopy?: boolean;
   editUUID?: string;
 }
 
@@ -59,6 +60,10 @@ export const AddOrEditTemplateContextProvider = ({ children }: { children: React
     isError,
     isSuccess: isTemplateQuerySuccess,
   } = useFetchTemplate(uuid, !!uuid);
+
+  const location = useLocation();
+  const isCopy = location.pathname.includes('/copy');
+  const isEdit = !!uuid && !isCopy;
 
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -321,7 +326,8 @@ export const AddOrEditTemplateContextProvider = ({ children }: { children: React
         isNameTaken,
         isNameCheckPending: nameCheckEnabled && isNameCheckPending,
         isExtendedSupportAvailable,
-        isEdit: !!uuid,
+        isEdit,
+        isCopy,
         editUUID: uuid,
       }}
     >

--- a/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/AddOrEditTemplateModal.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/AddOrEditTemplateModal.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useLocation } from 'react-router-dom';
+import { AddOrEditTemplateModal } from './AddOrEditTemplateModal';
+import { useAddOrEditTemplateContext } from './AddOrEditTemplateContext';
+import { defaultTemplateItem } from 'testingHelpers';
+import { TEMPLATES_ROUTE } from 'Routes/constants';
+
+const mockNavigate = jest.fn();
+const mockSetSearchParams = jest.fn();
+
+jest.mock('./steps/OSAndArchitectureStep', () => ({ __esModule: true, default: () => null }));
+jest.mock('./steps/RedHatRepositoriesStep', () => ({ __esModule: true, default: () => null }));
+jest.mock('./steps/CustomRepositoriesStep', () => ({ __esModule: true, default: () => null }));
+jest.mock('./steps/SetUpDateStep', () => ({ __esModule: true, default: () => null }));
+jest.mock('./steps/DetailStep', () => ({ __esModule: true, default: () => null }));
+jest.mock('./steps/ReviewStep', () => ({ __esModule: true, default: () => null }));
+jest.mock('./AddTemplateButton', () => ({
+  AddTemplateButton: () => null,
+}));
+
+jest.mock('services/Templates/TemplateQueries', () => ({
+  useCreateTemplateQuery: () => ({ mutateAsync: jest.fn(), isPending: false }),
+  useEditTemplateQuery: () => ({ mutateAsync: jest.fn(), isPending: false }),
+}));
+
+jest.mock('Hooks/useRootPath', () => () => '/app');
+
+jest.mock('./AddOrEditTemplateContext', () => ({
+  AddOrEditTemplateContextProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  useAddOrEditTemplateContext: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useLocation: jest.fn(),
+  useSearchParams: () => [new URLSearchParams('tab=os-and-architecture'), mockSetSearchParams],
+}));
+
+const mockContext = (overrides = {}) => ({
+  isEdit: true,
+  isCopy: false,
+  templateRequest: defaultTemplateItem,
+  hasInvalidSteps: () => false,
+  editUUID: defaultTemplateItem.uuid,
+  isSourceTemplateReady: true,
+  isNameTaken: false,
+  queryClient: {} as never,
+  ...overrides,
+});
+
+const mockLocation = (from?: 'table' | 'details') => ({
+  pathname: `/app/templates/edit/${defaultTemplateItem.uuid}`,
+  state: from ? { from } : {},
+});
+
+describe('AddOrEditTemplateModal navigation', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockSetSearchParams.mockClear();
+    (useAddOrEditTemplateContext as jest.Mock).mockImplementation(() => mockContext());
+    (useLocation as jest.Mock).mockImplementation(() => mockLocation('table'));
+  });
+
+  it('navigates to templates list on cancel when opened from table', async () => {
+    const user = userEvent.setup();
+
+    render(<AddOrEditTemplateModal />);
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith(`/app/${TEMPLATES_ROUTE}`);
+  });
+
+  it('navigates to template details on cancel when opened from details', async () => {
+    (useLocation as jest.Mock).mockImplementation(() => mockLocation('details'));
+    const user = userEvent.setup();
+
+    render(<AddOrEditTemplateModal />);
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/app/${TEMPLATES_ROUTE}/${defaultTemplateItem.uuid}`,
+    );
+  });
+
+  it('navigates to template details on cancel when copying from details', async () => {
+    (useLocation as jest.Mock).mockImplementation(() => ({
+      pathname: `/app/templates/copy/${defaultTemplateItem.uuid}`,
+      state: { from: 'details' },
+    }));
+    (useAddOrEditTemplateContext as jest.Mock).mockImplementation(() =>
+      mockContext({ isEdit: false, isCopy: true }),
+    );
+    const user = userEvent.setup();
+
+    render(<AddOrEditTemplateModal />);
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/app/${TEMPLATES_ROUTE}/${defaultTemplateItem.uuid}`,
+    );
+  });
+});

--- a/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/AddOrEditTemplateModal.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/AddOrEditTemplateModal.tsx
@@ -82,7 +82,8 @@ const AddOrEditTemplateBase = () => {
   // Store the original 'from' value on mount (before step navigation changes location.state)
   const fromRef = useRef(location.state?.from);
 
-  const { isEdit, templateRequest, hasInvalidSteps, editUUID } = useAddOrEditTemplateContext();
+  const { isEdit, isCopy, templateRequest, hasInvalidSteps, editUUID, isSourceTemplateReady } =
+    useAddOrEditTemplateContext();
 
   // useSafeUUIDParam in AddOrEditTemplateContext already validates the UUID
   // If in edit mode and UUID is invalid, it will be an empty string
@@ -174,7 +175,13 @@ const AddOrEditTemplateBase = () => {
                 key='os-and-architecture-key'
                 footer={{ ...sharedFooterProps, isNextDisabled: hasInvalidSteps(1) }}
               >
-                <OSAndArchitectureStep />
+                {(isEdit) && !isSourceTemplateReady ? (
+                  <Bullseye>
+                    <Spinner size='xl' />
+                  </Bullseye>
+                ) : (
+                  <OSAndArchitectureStep />
+                )}
               </WizardStep>,
               <WizardStep
                 isDisabled={hasInvalidSteps(1)}

--- a/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/AddOrEditTemplateModal.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/AddOrEditTemplateModal.tsx
@@ -82,8 +82,15 @@ const AddOrEditTemplateBase = () => {
   // Store the original 'from' value on mount (before step navigation changes location.state)
   const fromRef = useRef(location.state?.from);
 
-  const { isEdit, isCopy, templateRequest, hasInvalidSteps, editUUID, isSourceTemplateReady } =
-    useAddOrEditTemplateContext();
+  const {
+    isEdit,
+    isCopy,
+    templateRequest,
+    hasInvalidSteps,
+    editUUID,
+    isSourceTemplateReady,
+    isNameTaken,
+  } = useAddOrEditTemplateContext();
 
   // useSafeUUIDParam in AddOrEditTemplateContext already validates the UUID
   // If in edit mode and UUID is invalid, it will be an empty string
@@ -217,6 +224,7 @@ const AddOrEditTemplateBase = () => {
             footer={{ ...sharedFooterProps, isNextDisabled: hasInvalidSteps(5) }}
             name='Detail'
             id='detail'
+            status={isSourceTemplateReady && isNameTaken ? 'error' : 'default'}
           >
             <DetailStep />
           </WizardStep>

--- a/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/AddOrEditTemplateModal.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/AddOrEditTemplateModal.tsx
@@ -94,15 +94,19 @@ const AddOrEditTemplateBase = () => {
 
   // useSafeUUIDParam in AddOrEditTemplateContext already validates the UUID
   // If in edit mode and UUID is invalid, it will be an empty string
-  if (isEdit && !editUUID) throw new Error('UUID is invalid');
+  if ((isEdit || isCopy) && !editUUID) throw new Error('UUID is invalid');
 
   const tabParam = urlSearchParams.get('tab');
   const initialIndex =
-    tabParam && stepIdToIndex[tabParam] ? stepIdToIndex[tabParam] : DEFAULT_STEP_INDEX;
+    tabParam && stepIdToIndex[tabParam]
+      ? stepIdToIndex[tabParam]
+      : isCopy
+        ? stepIdToIndex['detail']
+        : DEFAULT_STEP_INDEX;
 
   useEffect(() => {
     if (!urlSearchParams.get('tab')) {
-      setUrlSearchParams({ tab: DEFAULT_STEP_ID }, { replace: true });
+      setUrlSearchParams({ tab: isCopy ? 'detail' : DEFAULT_STEP_ID }, { replace: true });
     }
   }, []);
 
@@ -111,7 +115,7 @@ const AddOrEditTemplateBase = () => {
   const onCancel = () => {
     if (fromRef.current === 'table') {
       navigate(`${rootPath}/${TEMPLATES_ROUTE}`);
-    } else if (isEdit && editUUID) {
+    } else if ((isEdit || isCopy) && editUUID) {
       navigate(`${rootPath}/${TEMPLATES_ROUTE}/${editUUID}`);
     } else {
       navigate(`${rootPath}/${TEMPLATES_ROUTE}`);
@@ -145,7 +149,7 @@ const AddOrEditTemplateBase = () => {
       onClose={isEdit && isEmpty(templateRequest) ? onCancel : undefined}
       disableFocusTrap
     >
-      {isEdit && isEmpty(templateRequest) ? (
+      {(isEdit || isCopy) && isEmpty(templateRequest) ? (
         <Bullseye className={classes.minHeightForSpinner}>
           <Spinner size='xl' />
         </Bullseye>
@@ -182,7 +186,7 @@ const AddOrEditTemplateBase = () => {
                 key='os-and-architecture-key'
                 footer={{ ...sharedFooterProps, isNextDisabled: hasInvalidSteps(1) }}
               >
-                {(isEdit) && !isSourceTemplateReady ? (
+                {(isEdit || isCopy) && !isSourceTemplateReady ? (
                   <Bullseye>
                     <Spinner size='xl' />
                   </Bullseye>
@@ -226,7 +230,13 @@ const AddOrEditTemplateBase = () => {
             id='detail'
             status={isSourceTemplateReady && isNameTaken ? 'error' : 'default'}
           >
-            <DetailStep />
+            {(isEdit || isCopy) && !isSourceTemplateReady ? (
+              <Bullseye>
+                <Spinner size='xl' />
+              </Bullseye>
+            ) : (
+              <DetailStep />
+            )}
           </WizardStep>
           <WizardStep
             isDisabled={hasInvalidSteps(5)}

--- a/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/steps/DetailStep.test.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/steps/DetailStep.test.tsx
@@ -1,17 +1,22 @@
 import { render } from '@testing-library/react';
 import { useAddOrEditTemplateContext } from '../AddOrEditTemplateContext';
 import { defaultTemplateItem } from 'testingHelpers';
+import { TEMPLATE_NAME_TAKEN_MESSAGE } from '../../../helpers';
 import DetailStep from './DetailStep';
 
 jest.mock('../AddOrEditTemplateContext', () => ({
   useAddOrEditTemplateContext: jest.fn(),
 }));
 
+const defaultContext = {
+  templateRequest: defaultTemplateItem,
+  setTemplateRequest: () => undefined,
+  isNameTaken: false,
+  isNameCheckPending: false,
+};
+
 it('expect DetailStep to render correctly', () => {
-  (useAddOrEditTemplateContext as jest.Mock).mockImplementation(() => ({
-    templateRequest: defaultTemplateItem,
-    setTemplateRequest: () => undefined,
-  }));
+  (useAddOrEditTemplateContext as jest.Mock).mockImplementation(() => defaultContext);
 
   const { getByPlaceholderText } = render(<DetailStep />);
 
@@ -19,4 +24,15 @@ it('expect DetailStep to render correctly', () => {
   expect(getByPlaceholderText('Enter description')).toHaveTextContent(
     defaultTemplateItem.description,
   );
+});
+
+it('shows duplicate name error when name is taken', () => {
+  (useAddOrEditTemplateContext as jest.Mock).mockImplementation(() => ({
+    ...defaultContext,
+    isNameTaken: true,
+  }));
+
+  const { getByText } = render(<DetailStep />);
+
+  expect(getByText(TEMPLATE_NAME_TAKEN_MESSAGE)).toBeInTheDocument();
 });

--- a/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/steps/DetailStep.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/steps/DetailStep.tsx
@@ -10,12 +10,20 @@ import {
 } from '@patternfly/react-core';
 import { useAddOrEditTemplateContext } from '../AddOrEditTemplateContext';
 import { useState } from 'react';
-import { TemplateValidationSchema } from '../../../helpers';
+import { TemplateValidationSchema, TEMPLATE_NAME_TAKEN_MESSAGE } from '../../../helpers';
 import CustomHelperText from 'components/CustomHelperText/CustomHelperText';
 
 export default function DetailStep() {
-  const { templateRequest, setTemplateRequest } = useAddOrEditTemplateContext();
+  const { templateRequest, setTemplateRequest, isNameTaken } = useAddOrEditTemplateContext();
   const [errors, setErrors] = useState({ name: '', description: '' });
+
+  const trimmedName = templateRequest.name?.trim() ?? '';
+  const nameCheckEnabled = trimmedName.length > 0 && trimmedName.length <= 255;
+
+  const isDuplicate = isNameTaken && !errors.name && nameCheckEnabled;
+  const duplicateNameError = isDuplicate ? TEMPLATE_NAME_TAKEN_MESSAGE : '';
+
+  const nameError = errors.name || duplicateNameError;
 
   const setFieldValues = (value: string, field: 'name' | 'description') => {
     setTemplateRequest((prev) => ({ ...prev, [field]: value }));
@@ -46,7 +54,7 @@ export default function DetailStep() {
             label='Name'
             ouiaId='input_name'
             type='text'
-            validated={errors.name ? 'error' : 'default'}
+            validated={nameError ? 'error' : 'default'}
             onChange={(_event, value) => setFieldValues(value, 'name')}
             value={templateRequest?.name || ''}
             placeholder='Enter name'
@@ -56,7 +64,7 @@ export default function DetailStep() {
               }
             }}
           />
-          <CustomHelperText hide={!errors.name} textValue={errors.name} />
+          <CustomHelperText hide={!nameError} textValue={nameError} />
         </FormGroup>
         <FormGroup label='Description'>
           <TextArea

--- a/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/steps/RedHatRepositoriesStep.tsx
+++ b/src/Pages/Templates/TemplatesTable/components/AddOrEditTemplateModal/steps/RedHatRepositoriesStep.tsx
@@ -206,7 +206,7 @@ export default function RedHatRepositoriesStep() {
           </Hide>
         </Flex>
       </Hide>
-      {countIsZero ? (
+      {countIsZero && !isLoading ? (
         <Bullseye data-ouia-component-id='redhat_repositories_table'>
           <EmptyTableState
             notFiltered={searchQuery === ''}

--- a/src/Pages/Templates/TemplatesTable/helpers.ts
+++ b/src/Pages/Templates/TemplatesTable/helpers.ts
@@ -91,6 +91,8 @@ export const TemplateValidationSchema = Yup.object().shape({
   description: Yup.string().max(255, 'Too Long!'),
 });
 
+export const TEMPLATE_NAME_TAKEN_MESSAGE = 'A template with this name already exists.';
+
 const dateToMonthYear = (date: string | number | Date): string =>
   new Date(date).toLocaleDateString('en-US', {
     month: 'long',

--- a/src/Routes/constants.ts
+++ b/src/Routes/constants.ts
@@ -2,6 +2,7 @@ export const REPOSITORIES_ROUTE = 'repositories';
 export const ADMIN_TASKS_ROUTE = 'admin-tasks';
 export const TEMPLATES_ROUTE = 'templates';
 export const CONTENT_ROUTE = 'content';
+export const COPY_ROUTE = 'copy';
 export const SNAPSHOTS_ROUTE = 'snapshots';
 export const SYSTEMS_ROUTE = 'systems';
 export const DETAILS_ROUTE = 'details';

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -9,6 +9,7 @@ import {
   ADMIN_TASKS_ROUTE,
   ADVISORIES_ROUTE,
   CONTENT_ROUTE,
+  COPY_ROUTE,
   DELETE_ROUTE,
   EDIT_ROUTE,
   PACKAGES_ROUTE,
@@ -146,6 +147,9 @@ export default function RepositoriesRoutes() {
           {rbac?.templateWrite && subscriptions?.red_hat_enterprise_linux ? (
             <Route path={`${EDIT_ROUTE}`} element={<AddOrEditTemplateModal />} />
           ) : null}
+          {rbac?.templateWrite && subscriptions?.red_hat_enterprise_linux ? (
+            <Route path={`${COPY_ROUTE}`} element={<AddOrEditTemplateModal />} />
+          ) : null}
           {rbac?.templateWrite ? (
             <Route path={`${DELETE_ROUTE}`} element={<DeleteTemplateModal />} />
           ) : null}
@@ -163,6 +167,11 @@ export default function RepositoriesRoutes() {
                 key='3'
                 path={`${DELETE_ROUTE}/:templateUUID`}
                 element={<DeleteTemplateModal />}
+              />
+              <Route
+                key='4'
+                path={`${COPY_ROUTE}/:templateUUID`}
+                element={<AddOrEditTemplateModal />}
               />
             </>
           ) : null}

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -156,12 +156,12 @@ export default function RepositoriesRoutes() {
               <Route key='1' path={ADD_ROUTE} element={<AddOrEditTemplateModal />} />
               <Route
                 key='2'
-                path={`:templateUUID/${EDIT_ROUTE}`}
+                path={`${EDIT_ROUTE}/:templateUUID`}
                 element={<AddOrEditTemplateModal />}
               />
               <Route
                 key='3'
-                path={`:templateUUID/${DELETE_ROUTE}`}
+                path={`${DELETE_ROUTE}/:templateUUID`}
                 element={<DeleteTemplateModal />}
               />
             </>

--- a/src/services/Templates/TemplateApi.ts
+++ b/src/services/Templates/TemplateApi.ts
@@ -219,3 +219,14 @@ export const createTemplate: (request: TemplateRequest) => Promise<TemplateItem>
   const { data } = await axios.post('/api/content-sources/v1.0/templates/', request);
   return data;
 };
+
+export const isTemplateNameTaken = async (name: string, excludeUuid?: string): Promise<boolean> => {
+  const { data } = await axios.get<TemplateCollectionResponse>(
+    `/api/content-sources/v1/templates/?${objectToUrlParams({
+      offset: '0',
+      limit: '2',
+      name,
+    })}`,
+  );
+  return data.data.some((t) => t.uuid !== excludeUuid);
+};

--- a/src/services/Templates/TemplateQueries.ts
+++ b/src/services/Templates/TemplateQueries.ts
@@ -15,6 +15,7 @@ import {
   getTemplateErrata,
   getTemplateSnapshots,
   getTemplatesForSnapshots,
+  isTemplateNameTaken,
 } from './TemplateApi';
 import useNotification from 'Hooks/useNotification';
 import { AlertVariant } from '@patternfly/react-core';
@@ -25,6 +26,7 @@ export const GET_TEMPLATE_PACKAGES_KEY = 'GET_TEMPLATE_PACKAGES_KEY';
 export const TEMPLATE_ERRATA_KEY = 'TEMPLATE_ERRATA_KEY';
 export const TEMPLATE_SNAPSHOTS_KEY = 'TEMPLATE_SNAPSHOTS_KEY';
 export const TEMPLATES_FOR_SNAPSHOTS = 'TEMPLATES_BY_SNAPSHOTS_KEY';
+export const TEMPLATE_NAME_AVAILABILITY_KEY = 'TEMPLATE_NAME_AVAILABILITY_KEY';
 
 const TEMPLATE_LIST_POLLING_TIME = 15000; // 15 seconds
 const TEMPLATE_FETCH_POLLING_TIME = 5000; // 5 seconds
@@ -161,6 +163,24 @@ export const useTemplateList = (
     placeholderData: keepPreviousData,
     staleTime: 20000,
   });
+
+export const useTemplateNameAvailability = (name: string, excludeUuid?: string) => {
+  const trimmedName = name.trim();
+  const enabled = trimmedName.length > 0 && trimmedName.length <= 255;
+
+  const {
+    data: isNameTaken = false,
+    isFetching,
+    isFetched,
+  } = useQuery({
+    queryKey: [TEMPLATE_NAME_AVAILABILITY_KEY, trimmedName, excludeUuid],
+    queryFn: () => isTemplateNameTaken(trimmedName, excludeUuid),
+    enabled,
+    staleTime: 5_000,
+  });
+
+  return { isNameTaken, isFetching, isFetched };
+};
 
 export const useCreateTemplateQuery = (queryClient: QueryClient, request: TemplateRequest) => {
   const errorNotifier = useErrorNotification();


### PR DESCRIPTION
## Summary
This adds the ability to "copy" a template. On copying a template the
create template wizard is opened pre-filled with the data of the to be
copied template. 🧙🏼 
The wizard opens on the detail step so only a name
needs to be changed, but other steps are also allowed to be edited. ©️ 

To make this a good experience, the routing had to be fixed along with 
the loading states of the template wizard. ♻️ 
Proper name taken validation also had to added. 👮🏼‍♂️ 

🎥 😄 
<img width="1000" height="617" alt="output" src="https://github.com/user-attachments/assets/493ae574-ae9e-45b6-83fd-e2ca8c4c2f54" />

## Testing steps
Create a template, verify that on copy the wizard is pre-filled correctly.
Check that template action modals don't open over the detail page when
opened from the templates table.