### PR TITLE
Build: Add agent rules for github actions

### DIFF
--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -1,0 +1,1 @@
+../../docs/rules/github-actions.md

--- a/.cursor/rules/github-actions.md
+++ b/.cursor/rules/github-actions.md
@@ -1,0 +1,1 @@
+../../docs/rules/github-actions.md

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -5,6 +5,7 @@ Topic-specific rules for AI coding assistants. Files here are automatically pick
 ## Current Rules
 
 - **[testing.md](testing.md)**: Playwright testing conventions and best practices
+- **[github-actions.md](github-actions.md)**: GitHub Actions, secrets, and forked pull requests
 
 ## Adding New Rules
 

--- a/docs/rules/github-actions.md
+++ b/docs/rules/github-actions.md
@@ -1,0 +1,32 @@
+# GitHub Actions, secrets, and forked pull requests
+
+## Secrets made available as environment variables
+
+Secrets used in GitHub Actions workflows are stored in a shared secret store and not visible to agents. They are made available in CI as environment variables. Contact someone in the content-sources team for guidance.
+
+
+## Secrets and variables on fork PRs
+
+These repositories are **public**, but GitHub still **does not** pass GitHub repository **secrets** or **variables** to workflows that run for a pull request **opened from a fork**. That is a platform security rule, not something this repo can override.
+
+When CI runs for a fork PR:
+
+- `${{ secrets.* }}` is empty
+- `${{ vars.* }}` is empty
+- Any step that needs those values (for example optional uploads or integrations) will fail or no-op
+
+### Workaround when you need to test secrets in CI
+
+Push your branch to the **upstream** remote (original organization repo) and open the PR **from a branch on that repo**, not from your fork:
+
+```bash
+git remote add upstream https://github.com/content-services/content-sources-frontend.git
+# if upstream already exists, fetch and push your branch
+git push upstream your-branch-name
+```
+
+Then open the pull request from your branch into the default branch.
+
+### Examples of secret-dependent behavior
+
+Anything wired to `${{ secrets.* }}` or `${{ vars.* }}` in `.github/workflows/` is affected. For example, coverage or reporting keys if those are stored as secrets.


### PR DESCRIPTION
## Summary

Add agent rules for github actions

Working with forks presents extra challenges in using keys and tokens in Github actions.
This doc should help AI agents assist users write Github actions.

## Testing steps
tests pass.