### PR TITLE
HMS-10575: keep filter bar visible when search yields no results

### DIFF
--- a/_playwright-tests/Integration/AssignTemplateToSystemUI.spec.ts
+++ b/_playwright-tests/Integration/AssignTemplateToSystemUI.spec.ts
@@ -129,6 +129,17 @@ test.describe('Assign Standard Template to System via UI', () => {
       await expect(page.getByRole('heading', { level: 1 })).toHaveText(templateName);
     });
 
+    await test.step('Verify filter bar remains visible when search yields no matching systems', async () => {
+      const searchInput = page.getByPlaceholder('Filter by name');
+      await searchInput.fill('nonexistent-system-xyz');
+
+      await expect(page.getByText('No associated systems match the filter criteria')).toBeVisible();
+      await expect(searchInput).toBeVisible();
+
+      await page.getByRole('button', { name: 'Clear all filters' }).click();
+      await expect(page.getByText(hostname)).toBeVisible();
+    });
+
     await test.step('Wait for package URLs to be served from template', async () => {
       // Refresh the subscription manager so the system picks up the new template entitlements
       await refreshSubscriptionManager(regClient);

--- a/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/Tabs/TemplateSystemsTab.tsx
@@ -226,7 +226,7 @@ export default function TemplateSystemsTab() {
 
   return (
     <Grid className={classes.mainContainer}>
-      <Hide hide={!total_items}>
+      <Hide hide={!total_items && !debouncedSearchQuery}>
         <InputGroup className={classes.topContainer}>
           <Flex gap={{ default: 'gapMd' }}>
             <InputGroupItem>


### PR DESCRIPTION
Previously the filter bar was hidden whenever total_items was 0, including when an active search query simply matched no systems. This made it impossible to clear the filter or adjust the search. Now the filter bar stays visible as long as there is an active search query, showing the filtered empty state with a "Clear all filters" button.


Co-Authored-By: drellabot

This is test of Drella. See some references:
Triggered by: https://github.com/drellabot/tasks/issues/84
Details of the run: https://drella.osbuild.org/#task/tasks-84-filter_is_hidden_when_system_is_not_found (VPN needed)
PR it opened: https://github.com/drellabot/content-sources-frontend/pull/1

On purpose it does not open PR directly here - it could but for testing purposes we keep it separated. So I just picked the commit and pushing it here.