### PR TITLE
HMS-10389: Fix GPG Key validity check is erratic

### DIFF
--- a/_playwright-tests/UI/GPG_keys.spec.ts
+++ b/_playwright-tests/UI/GPG_keys.spec.ts
@@ -46,6 +46,10 @@ test.describe('Test GPG keys', () => {
       ).toBeVisible();
       await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeDisabled();
       await page.getByPlaceholder('Paste GPG key or URL here').fill(packages_key);
+      await expect(page.getByRole('textbox', { name: 'gpgkey_file_to_upload' })).toContainText(
+        '-----BEGIN PGP PUBLIC KEY BLOCK-----',
+      );
+      await expect(page.getByRole('button', { name: 'Save', exact: true })).toBeEnabled();
       await page.getByRole('button', { name: 'Save', exact: true }).click();
     });
 

--- a/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/AddContent.tsx
@@ -27,13 +27,14 @@ import {
 } from '@patternfly/react-core';
 
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { createUseStyles } from 'react-jss';
 import Hide from 'components/Hide/Hide';
 import {
   failedFileUpload,
   type FileRejection,
   getDefaultValues,
+  isPendingUrlFetch,
   isValidURL,
   mapContentItemToDefaultFormikValues,
   mapFormikToAPIValues,
@@ -216,28 +217,51 @@ const AddContent = ({ isEdit = false }: Props) => {
     isPending: isValidating,
   } = useValidateContentList();
 
+  const gpgKeyUrlBeingFetchedRef = useRef<string | null>(null);
+  const [gpgKeyUrlFetchSettled, setGpgKeyUrlFetchSettled] = useState(0);
+
   useEffect(() => {
-    (async () => {
-      if (isValidURL(debouncedValues.gpgKey)) {
-        const result = await fetchGpgKey(debouncedValues.gpgKey);
-        // If successful
-        if (result !== debouncedValues.gpgKey) {
-          updateVariable({
-            gpgKey: result,
-            ...(values.gpgKey === '' && !!result
-              ? {
-                  metadataVerification: !!validationList?.url?.metadata_signature_present,
-                }
-              : {}),
-          });
-          return;
-        }
+    const gpgKey = debouncedValues.gpgKey;
+    if (!gpgKey || !isValidURL(gpgKey)) {
+      gpgKeyUrlBeingFetchedRef.current = null;
+      return;
+    }
+
+    const requestedUrl = gpgKey;
+    gpgKeyUrlBeingFetchedRef.current = requestedUrl;
+    let cancelled = false;
+
+    void (async () => {
+      const result = await fetchGpgKey(requestedUrl);
+      if (cancelled) return;
+
+      if (gpgKeyUrlBeingFetchedRef.current === requestedUrl) {
+        gpgKeyUrlBeingFetchedRef.current = null;
+      }
+      if (result !== requestedUrl) {
+        updateVariable({
+          gpgKey: result,
+          ...(values.gpgKey === '' && !!result
+            ? {
+                metadataVerification: !!validationList?.url?.metadata_signature_present,
+              }
+            : {}),
+        });
+      } else {
+        setGpgKeyUrlFetchSettled((version) => version + 1);
       }
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [debouncedValues.gpgKey]);
 
   useDeepCompareEffect(() => {
     if (isFetchingGpgKey || isLoadingInitialContent || isEmpty(debouncedValues)) return;
+    if (isPendingUrlFetch(debouncedValues.gpgKey, gpgKeyUrlBeingFetchedRef.current)) {
+      return;
+    }
     (async () => {
       // We wait for the gpg_key to finish returning before validating
       const { uuid, name, url, gpgKey, metadataVerification } = debouncedValues;
@@ -269,7 +293,7 @@ const AddContent = ({ isEdit = false }: Props) => {
       setErrors(mappedErrorData);
       setChangeVerified(true);
     })();
-  }, [debouncedValues]);
+  }, [debouncedValues, gpgKeyUrlFetchSettled]);
 
   const updateGpgKey = async (value: string) => {
     // It's not a valid url, so we allow the user to continue

--- a/src/Pages/Repositories/ContentListTable/components/AddContent/helpers.test.ts
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   FormikValues,
   REGEX_URL,
   failedFileUpload,
+  isPendingUrlFetch,
   isValidURL,
   mapFormikToAPIValues,
   mapValidationData,
@@ -21,6 +22,14 @@ it('isValidURL', () => {
   expect(isValidURL('https://www.google.com')).toBeTruthy();
   expect(isValidURL('BANANA!')).toBeFalsy();
   expect(isValidURL('http://e.ca')).toBeTruthy();
+});
+
+it('isPendingUrlFetch', () => {
+  const gpgUrl = 'http://example.com/RPM-GPG-KEY';
+  expect(isPendingUrlFetch(gpgUrl, gpgUrl)).toBe(true);
+  expect(isPendingUrlFetch(gpgUrl, null)).toBe(false);
+  expect(isPendingUrlFetch('-----BEGIN PGP PUBLIC KEY BLOCK-----', gpgUrl)).toBe(false);
+  expect(isPendingUrlFetch('', gpgUrl)).toBe(false);
 });
 
 it('mapFormikToAPIValues', () => {

--- a/src/Pages/Repositories/ContentListTable/components/AddContent/helpers.ts
+++ b/src/Pages/Repositories/ContentListTable/components/AddContent/helpers.ts
@@ -90,6 +90,10 @@ export const isValidURL = (val: string) => {
   return val.match(regex);
 };
 
+/** True when value is a URL whose content is still being fetched. */
+export const isPendingUrlFetch = (value: string, urlBeingFetched: string | null): boolean =>
+  !!value && !!isValidURL(value) && value === urlBeingFetched;
+
 export const mapFormikToAPIValues = ({
   uuid,
   name,


### PR DESCRIPTION
## Summary


  Fix flaky GPGKey test
    Make test wait for GPGKey text to be displayed.

   Add isPendingUrlFetch helper

## Testing steps

UI/GPG_keys.spec.ts  passes