### PR TITLE
HMS-10844: refactor useNavigateTo where appropriate

### DIFF
--- a/src/Hooks/navigation/navigationPaths.ts
+++ b/src/Hooks/navigation/navigationPaths.ts
@@ -1,8 +1,21 @@
 import { ContentOrigin } from 'services/Content/ContentApi';
 
-import { PACKAGES_ROUTE, REPOSITORIES_ROUTE } from 'Routes/constants';
+import {
+  ADMIN_TASKS_ROUTE,
+  PACKAGES_ROUTE,
+  REPOSITORIES_ROUTE,
+  SYSTEMS_ROUTE,
+  TEMPLATES_ROUTE,
+} from 'Routes/constants';
 
-export type DestinationKey = 'repositories' | 'packagesLatest' | 'root';
+export type DestinationKey =
+  | 'repositories'
+  | 'templates'
+  | 'packagesLatest'
+  | 'root'
+  | 'adminTasks'
+  | 'repositorySnapshots'
+  | 'systems';
 
 type NavigationPaths = Record<DestinationKey, BuildDestinationPath>;
 type BuildDestinationPath = (params: DestinationParams) => string;
@@ -10,6 +23,7 @@ type DestinationParams = {
   contentOrigin: ContentOrigin[];
   rootPath: string;
   repoUUID: string;
+  templateUUID: string;
 };
 
 /**
@@ -27,11 +41,17 @@ export const navigationPaths: NavigationPaths = {
     (contentOrigin.length === 1 && contentOrigin[0] === ContentOrigin.REDHAT
       ? `?origin=${contentOrigin}`
       : ''),
-  packagesLatest: ({ rootPath, repoUUID }) =>
-    `${rootPath}/${REPOSITORIES_ROUTE}/${repoUUID}/${PACKAGES_ROUTE}`,
   repositories: ({ rootPath, contentOrigin }) =>
     `${rootPath}/${REPOSITORIES_ROUTE}` +
     (contentOrigin.length === 1 && contentOrigin[0] === ContentOrigin.REDHAT
       ? `?origin=${contentOrigin}`
       : ''),
+  packagesLatest: ({ rootPath, repoUUID }) =>
+    `${rootPath}/${REPOSITORIES_ROUTE}/${repoUUID}/${PACKAGES_ROUTE}`,
+  adminTasks: ({ rootPath }) => `${rootPath}/${REPOSITORIES_ROUTE}/${ADMIN_TASKS_ROUTE}`,
+  repositorySnapshots: ({ rootPath, repoUUID }) =>
+    `${rootPath}/${REPOSITORIES_ROUTE}/${repoUUID}/snapshots`,
+  templates: ({ rootPath }) => `${rootPath}/${TEMPLATES_ROUTE}`,
+  systems: ({ rootPath, templateUUID }) =>
+    `${rootPath}/${TEMPLATES_ROUTE}/${templateUUID}/${SYSTEMS_ROUTE}`,
 };

--- a/src/Hooks/navigation/useNavigateTo.test.ts
+++ b/src/Hooks/navigation/useNavigateTo.test.ts
@@ -1,0 +1,116 @@
+import { renderHook, act } from '@testing-library/react';
+import { useNavigateTo } from './useNavigateTo';
+import { ContentOrigin } from 'services/Content/ContentApi';
+
+const mockNavigate = jest.fn();
+
+const REPO_UUID = '12345678-1234-4234-8234-123456789012';
+const TEMPLATE_UUID = '87654321-4321-4321-8321-210987654321';
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ repoUUID: REPO_UUID, templateUUID: TEMPLATE_UUID }),
+}));
+
+jest.mock('Hooks/useRootPath', () => () => '/app');
+
+jest.mock('middleware/AppContext', () => ({
+  useAppContext: jest.fn(),
+}));
+
+import { useAppContext } from 'middleware/AppContext';
+
+describe('useNavigateTo', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    (useAppContext as jest.Mock).mockReturnValue({ contentOrigin: [] });
+  });
+
+  describe('repositories', () => {
+    it('navigates to /app/repositories without origin query by default', () => {
+      const { result } = renderHook(() => useNavigateTo('repositories'));
+
+      act(() => {
+        result.current();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith('/app/repositories');
+    });
+
+    it('appends origin query when only Red Hat is selected', () => {
+      (useAppContext as jest.Mock).mockReturnValue({
+        contentOrigin: [ContentOrigin.REDHAT],
+      });
+
+      const { result } = renderHook(() => useNavigateTo('repositories'));
+
+      act(() => {
+        result.current();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith('/app/repositories?origin=red_hat');
+    });
+  });
+
+  describe('repositorySnapshots', () => {
+    it('navigates to /app/repositories/<repoUUID>/snapshots', () => {
+      const { result } = renderHook(() => useNavigateTo('repositorySnapshots'));
+
+      act(() => {
+        result.current();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(`/app/repositories/${REPO_UUID}/snapshots`);
+    });
+  });
+
+  describe('root', () => {
+    it('navigates to /app without origin query by default', () => {
+      const { result } = renderHook(() => useNavigateTo('root'));
+
+      act(() => {
+        result.current();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith('/app');
+    });
+
+    it('appends origin query when only Red Hat is selected', () => {
+      (useAppContext as jest.Mock).mockReturnValue({
+        contentOrigin: [ContentOrigin.REDHAT],
+      });
+
+      const { result } = renderHook(() => useNavigateTo('root'));
+
+      act(() => {
+        result.current();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith('/app?origin=red_hat');
+    });
+  });
+
+  describe('templates', () => {
+    it('navigates to /app/templates', () => {
+      const { result } = renderHook(() => useNavigateTo('templates'));
+
+      act(() => {
+        result.current();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith('/app/templates');
+    });
+  });
+
+  describe('adminTasks', () => {
+    it('navigates to /app/repositories/admin-tasks', () => {
+      const { result } = renderHook(() => useNavigateTo('adminTasks'));
+
+      act(() => {
+        result.current();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith('/app/repositories/admin-tasks');
+    });
+  });
+});

--- a/src/Hooks/navigation/useNavigateTo.ts
+++ b/src/Hooks/navigation/useNavigateTo.ts
@@ -19,9 +19,10 @@ export const useNavigateTo = (destinationKey: DestinationKey) => {
   const navigate = useNavigate();
   const rootPath = useRootPath();
   const repoUUID = useSafeUUIDParam('repoUUID');
+  const templateUUID = useSafeUUIDParam('templateUUID');
 
   return useCallback(() => {
     const path = navigationPaths[destinationKey];
-    return navigate(path({ rootPath, repoUUID, contentOrigin }));
-  }, [contentOrigin, rootPath, repoUUID]);
+    return navigate(path({ rootPath, repoUUID, templateUUID, contentOrigin }));
+  }, [contentOrigin, rootPath, repoUUID, templateUUID]);
 };

--- a/src/Pages/Repositories/AdminFeaturesTable/AdminFeaturesTable.test.tsx
+++ b/src/Pages/Repositories/AdminFeaturesTable/AdminFeaturesTable.test.tsx
@@ -38,7 +38,7 @@ jest.mock('react-router-dom', () => ({
   Outlet: () => <></>,
 }));
 
-jest.mock('Hooks/useRootPath', () => () => 'BasePath');
+jest.mock('Hooks/navigation/useNavigateTo', () => ({ useNavigateTo: jest.fn() }));
 jest.mock('Hooks/useDebounce', () => (val) => val);
 
 it('AdminFeaturesTable to render, select item, and copy', async () => {

--- a/src/Pages/Repositories/AdminFeaturesTable/AdminFeaturesTable.tsx
+++ b/src/Pages/Repositories/AdminFeaturesTable/AdminFeaturesTable.tsx
@@ -15,15 +15,13 @@ import { useEffect, useMemo, useState } from 'react';
 import { SkeletonTable } from '@patternfly/react-component-groups';
 import Hide from 'components/Hide/Hide';
 import EmptyTableState from 'components/EmptyTableState/EmptyTableState';
-import { useNavigate } from 'react-router-dom';
 import useDebounce from 'Hooks/useDebounce';
-import useRootPath from 'Hooks/useRootPath';
-import { ADMIN_TASKS_ROUTE, REPOSITORIES_ROUTE } from 'Routes/constants';
 import { useAdminFeatureListQuery, useFetchAdminFeatureQuery } from 'services/Admin/AdminQueries';
 import type { AdminFeature } from 'services/Admin/AdminApi';
 import { createUseStyles } from 'react-jss';
 import { CopyIcon } from '@patternfly/react-icons';
 import JsonView from 'react18-json-view';
+import { useNavigateTo } from 'Hooks/navigation/useNavigateTo';
 
 const useStyles = createUseStyles({
   '@keyframes flashAnimation': {
@@ -65,8 +63,7 @@ const useStyles = createUseStyles({
 
 const AdminFeaturesTable = () => {
   const classes = useStyles();
-  const navigate = useNavigate();
-  const rootPath = useRootPath();
+  const onClose = useNavigateTo('adminTasks');
   const [isFeatureOpen, setIsFeatureOpen] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const storedFeature = sessionStorage.getItem('feature');
@@ -83,8 +80,6 @@ const AdminFeaturesTable = () => {
     checkedFeatures.clear();
     setCheckedFeatures(new Set(checkedFeatures));
   }, [feature]);
-
-  const onClose = () => navigate(`${rootPath}/${REPOSITORIES_ROUTE}/${ADMIN_TASKS_ROUTE}`);
 
   const { isLoading, isFetching, data, isError } = useAdminFeatureListQuery();
 

--- a/src/Pages/Repositories/AdminTaskTable/components/ViewPayloadModal/ViewPayloadModal.tsx
+++ b/src/Pages/Repositories/AdminTaskTable/components/ViewPayloadModal/ViewPayloadModal.tsx
@@ -17,9 +17,8 @@ import AdminTaskInfo from './components/AdminTaskInfo';
 import ReactJson from 'react18-json-view';
 import Hide from 'components/Hide/Hide';
 import { useFetchAdminTaskQuery } from 'services/Admin/AdminTaskQueries';
-import { useNavigate, useParams } from 'react-router-dom';
-import useRootPath from 'Hooks/useRootPath';
-import { ADMIN_TASKS_ROUTE, REPOSITORIES_ROUTE } from 'Routes/constants';
+import { useParams } from 'react-router-dom';
+import { useNavigateTo } from 'Hooks/navigation/useNavigateTo';
 
 const useStyles = createUseStyles({
   jsonView: {
@@ -36,10 +35,8 @@ export interface TabData {
 const ViewPayloadModal = () => {
   const { taskUUID: uuid } = useParams();
   const classes = useStyles();
-  const navigate = useNavigate();
-  const rootPath = useRootPath();
 
-  const onClose = () => navigate(`${rootPath}/${REPOSITORIES_ROUTE}/${ADMIN_TASKS_ROUTE}`);
+  const onClose = useNavigateTo('adminTasks');
 
   const [activeTabKey, setActiveTabKey] = useState<string | number>(0);
   const detailRef = createRef<HTMLElement>();

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.test.tsx
@@ -1,10 +1,9 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SnapshotDetailsModal, { SnapshotDetailTab } from './SnapshotDetailsModal';
-import { useAppContext } from 'middleware/AppContext';
-import { ContentOrigin } from 'services/Content/ContentApi';
+import { useNavigateTo } from 'Hooks/navigation/useNavigateTo';
 
-const mockNavigate = jest.fn();
+const mockUseNavigateTo = useNavigateTo as jest.Mock;
 const mockSetSearchParams = jest.fn();
 
 jest.mock('./Tabs/SnapshotPackagesTab', () => ({
@@ -19,15 +18,12 @@ jest.mock('./SnapshotSelector', () => ({
   SnapshotSelector: () => <div>Snapshot selector</div>,
 }));
 
-jest.mock('middleware/AppContext', () => ({
-  useAppContext: jest.fn(),
+jest.mock('Hooks/navigation/useNavigateTo', () => ({
+  useNavigateTo: jest.fn(),
 }));
 
-jest.mock('Hooks/useRootPath', () => () => '/app');
-
 jest.mock('react-router-dom', () => ({
-  useNavigate: () => mockNavigate,
-  useParams: () => ({ repoUUID: 'repo-uuid', snapshotUUID: 'snap-uuid' }),
+  useParams: () => ({ snapshotUUID: 'snap-uuid' }),
   useSearchParams: () => {
     const params = new URLSearchParams(window.location.search);
     return [params, mockSetSearchParams];
@@ -36,51 +32,15 @@ jest.mock('react-router-dom', () => ({
 
 describe('SnapshotDetailsModal', () => {
   beforeEach(() => {
-    mockNavigate.mockClear();
     mockSetSearchParams.mockClear();
     window.history.replaceState({}, '', '/');
-    (useAppContext as jest.Mock).mockReturnValue({
-      contentOrigin: [],
-    });
   });
 
-  const clickModalHeaderClose = async (user: ReturnType<typeof userEvent.setup>) => {
-    const dialog = screen.getByRole('dialog');
-    // Footer uses aria-label "Close snapshot detail"; PatternFly header close stays "Close".
-    await user.click(within(dialog).getByRole('button', { name: 'Close' }));
-  };
-
-  it('navigates back to repositories on close without origin query by default', async () => {
-    const user = userEvent.setup();
-
+  it('navigation hooks are called with the correct keys', async () => {
     render(<SnapshotDetailsModal />);
 
-    await clickModalHeaderClose(user);
-
-    expect(mockNavigate).toHaveBeenCalledWith('/app/repositories');
-  });
-
-  it('appends origin query when only Red Hat is selected', async () => {
-    const user = userEvent.setup();
-    (useAppContext as jest.Mock).mockReturnValue({
-      contentOrigin: [ContentOrigin.REDHAT],
-    });
-
-    render(<SnapshotDetailsModal />);
-
-    await clickModalHeaderClose(user);
-
-    expect(mockNavigate).toHaveBeenCalledWith('/app/repositories?origin=red_hat');
-  });
-
-  it('navigates to snapshots list when View all snapshots is clicked', async () => {
-    const user = userEvent.setup();
-
-    render(<SnapshotDetailsModal />);
-
-    await user.click(screen.getByRole('button', { name: 'View all snapshots' }));
-
-    expect(mockNavigate).toHaveBeenCalledWith('/app/repositories/repo-uuid/snapshots');
+    expect(mockUseNavigateTo).toHaveBeenCalledWith('repositories');
+    expect(mockUseNavigateTo).toHaveBeenCalledWith('repositorySnapshots');
   });
 
   it('syncs errata tab from search params on mount', async () => {

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/SnapshotDetailsModal.tsx
@@ -11,17 +11,14 @@ import {
   TabTitleText,
 } from '@patternfly/react-core';
 import { InnerScrollContainer } from '@patternfly/react-table';
-import { ContentOrigin } from 'services/Content/ContentApi';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import useRootPath from 'Hooks/useRootPath';
-import { useAppContext } from 'middleware/AppContext';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { SnapshotPackagesTab } from './Tabs/SnapshotPackagesTab';
 import { createUseStyles } from 'react-jss';
 import { SnapshotSelector } from './SnapshotSelector';
-import { REPOSITORIES_ROUTE } from 'Routes/constants';
 import { SnapshotErrataTab } from './Tabs/SnapshotErrataTab';
 import { modalTableSurfaceStyles } from 'helpers';
+import { useNavigateTo } from 'Hooks/navigation/useNavigateTo';
 
 const useStyles = createUseStyles({
   modalTableScope: modalTableSurfaceStyles,
@@ -42,12 +39,9 @@ export enum SnapshotDetailTab {
 }
 
 export default function SnapshotDetailsModal() {
-  const { contentOrigin } = useAppContext();
   const classes = useStyles();
-  const { repoUUID, snapshotUUID } = useParams();
+  const { snapshotUUID } = useParams();
   const [urlSearchParams, setUrlSearchParams] = useSearchParams();
-  const rootPath = useRootPath();
-  const navigate = useNavigate();
   const [activeTabKey, setActiveTabKey] = useState<string | number>(0);
 
   useEffect(() => {
@@ -64,15 +58,8 @@ export default function SnapshotDetailsModal() {
     setActiveTabKey(tabIndex);
   };
 
-  const onClose = () =>
-    navigate(
-      `${rootPath}/${REPOSITORIES_ROUTE}` +
-        (contentOrigin.length === 1 && contentOrigin[0] === ContentOrigin.REDHAT
-          ? `?origin=${contentOrigin}`
-          : ''),
-    );
-
-  const onBackClick = () => navigate(rootPath + `/${REPOSITORIES_ROUTE}/${repoUUID}/snapshots`);
+  const onClose = useNavigateTo('repositories');
+  const onBackClick = useNavigateTo('repositorySnapshots');
 
   return (
     <Modal

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataTab.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotDetailsModal/Tabs/SnapshotErrataTab.tsx
@@ -7,16 +7,14 @@ import {
   PaginationVariant,
 } from '@patternfly/react-core';
 import Hide from 'components/Hide/Hide';
-import { ContentOrigin } from 'services/Content/ContentApi';
 import { createUseStyles } from 'react-jss';
 import { useEffect, useMemo, useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import useRootPath from 'Hooks/useRootPath';
-import { useAppContext } from 'middleware/AppContext';
+import { useParams } from 'react-router-dom';
 import { useGetSnapshotErrataQuery } from 'services/Content/ContentQueries';
 import AdvisoriesTable from 'components/SharedTables/AdvisoriesTable';
 import SnapshotErrataFilters from './SnapshotErrataFilters';
 import { ThProps } from '@patternfly/react-table';
+import { useNavigateTo } from 'Hooks/navigation/useNavigateTo';
 
 const useStyles = createUseStyles({
   mainContainer: {
@@ -44,11 +42,9 @@ const defaultFilterState = { search: '', type: [] as string[], severity: [] as s
 
 export function SnapshotErrataTab() {
   const classes = useStyles();
-  const { contentOrigin } = useAppContext();
 
   const { snapshotUUID = '' } = useParams();
-  const rootPath = useRootPath();
-  const navigate = useNavigate();
+  const onClose = useNavigateTo('root');
   const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(storedPerPage);
@@ -103,14 +99,6 @@ export function SnapshotErrataTab() {
     setPage(newPage);
     localStorage.setItem(perPageKey, newPerPage.toString());
   };
-
-  const onClose = () =>
-    navigate(
-      rootPath +
-        (contentOrigin.length === 1 && contentOrigin[0] === ContentOrigin.REDHAT
-          ? `?origin=${contentOrigin}`
-          : ''),
-    );
 
   const {
     data: errataList = [],

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/DeleteSnapshotsModal/DeleteSnapshotsModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/DeleteSnapshotsModal/DeleteSnapshotsModal.tsx
@@ -33,6 +33,7 @@ import { useFetchTemplatesForSnapshots } from 'services/Templates/TemplateQuerie
 import { formatDateDDMMMYYYY, modalTableSurfaceStyles } from 'helpers';
 import ChangedArrows from '../components/ChangedArrows';
 import { SnapshotDetailTab } from '../../SnapshotDetailsModal/SnapshotDetailsModal';
+import { useNavigateTo } from 'Hooks/navigation/useNavigateTo';
 
 const useStyles = createUseStyles({
   modalTableScope: modalTableSurfaceStyles,
@@ -57,6 +58,7 @@ const useStyles = createUseStyles({
 export default function DeleteSnapshotsModal() {
   const classes = useStyles();
   const navigate = useNavigate();
+  const onClose = useNavigateTo('repositorySnapshots');
   const queryClient = useQueryClient();
   const rootPath = useRootPath();
   const path = useHref('content');
@@ -84,8 +86,6 @@ export default function DeleteSnapshotsModal() {
 
   const { mutateAsync: deleteSnapshots, isPending: isDeletingSnapshots } =
     useBulkDeleteSnapshotsMutate(queryClient, uuid, snapshotsToDelete);
-
-  const onClose = () => navigate(`${rootPath}/${REPOSITORIES_ROUTE}/${uuid}/snapshots`);
 
   const onSave = async () => {
     deleteSnapshots(snapshotsToDelete).then(() => {

--- a/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/SnapshotListModal/SnapshotListModal.tsx
@@ -39,6 +39,7 @@ import { SnapshotDetailTab } from '../SnapshotDetailsModal/SnapshotDetailsModal'
 import { formatDateDDMMMYYYY, modalTableSurfaceStyles } from 'helpers';
 import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip';
 import LatestRepoConfig from './components/LatestRepoConfig';
+import { useNavigateTo } from 'Hooks/navigation/useNavigateTo';
 
 const useStyles = createUseStyles({
   modalTableScope: modalTableSurfaceStyles,
@@ -66,8 +67,9 @@ const SnapshotListModal = () => {
   const classes = useStyles();
   const rootPath = useRootPath();
   const { repoUUID: uuid = '' } = useParams();
-  const { contentOrigin, rbac } = useAppContext();
+  const { rbac } = useAppContext();
   const navigate = useNavigate();
+  const onClose = useNavigateTo('repositories');
   const storedPerPage = Number(localStorage.getItem(perPageKey)) || 20;
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(storedPerPage);
@@ -127,14 +129,6 @@ const SnapshotListModal = () => {
       columnIndex,
     };
   };
-
-  const onClose = () =>
-    navigate(
-      `${rootPath}/${REPOSITORIES_ROUTE}` +
-        (contentOrigin.length === 1 && contentOrigin[0] === ContentOrigin.REDHAT
-          ? `?origin=${contentOrigin}`
-          : ''),
-    );
 
   const onSelectSnapshot = (uuid: string, value: boolean) => {
     const newSet = new Set<string>(checkedSnapshots);

--- a/src/Pages/Templates/TemplateDetails/TemplateDetails.tsx
+++ b/src/Pages/Templates/TemplateDetails/TemplateDetails.tsx
@@ -13,10 +13,8 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { Outlet, useNavigate, useParams } from 'react-router-dom';
+import { Outlet, useParams } from 'react-router-dom';
 import { createUseStyles } from 'react-jss';
-import { TEMPLATES_ROUTE } from 'Routes/constants';
-import useRootPath from 'Hooks/useRootPath';
 import { useFetchTemplate } from 'services/Templates/TemplateQueries';
 import useDistributionDetails from '../../../Hooks/useDistributionDetails';
 import DetailItem from './components/DetaiItem';
@@ -26,6 +24,7 @@ import Loader from 'components/Loader';
 import TemplateActionDropdown from './components/TemplateActionDropdown';
 import TemplateDetailsTabs from './components/TemplateDetailsTabs';
 import { abbreviateStreamName } from '../TemplatesTable/helpers';
+import { useNavigateTo } from 'Hooks/navigation/useNavigateTo';
 
 const useStyles = createUseStyles({
   fullHeight: {
@@ -63,8 +62,7 @@ export default function TemplateDetails() {
   const classes = useStyles();
   const { templateUUID } = useParams();
 
-  const rootPath = useRootPath();
-  const navigate = useNavigate();
+  const navigateToTemplateList = useNavigateTo('templates');
 
   const { data: template, isError, error, isLoading } = useFetchTemplate(templateUUID as string);
 
@@ -81,8 +79,6 @@ export default function TemplateDetails() {
   // Error is caught in the wrapper component
   if (isError) throw error;
   if (repositoryParamsIsError) throw repositoryParamsError;
-
-  const navigateToTemplateList = () => navigate(rootPath + `/${TEMPLATES_ROUTE}`);
 
   if (isLoading || archVersionLoading) {
     return <Loader />;

--- a/src/Pages/Templates/TemplateDetails/components/AssignTemplateModal/AddSystemModal.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/AssignTemplateModal/AddSystemModal.tsx
@@ -40,13 +40,14 @@ import { useQueryClient } from '@tanstack/react-query';
 import type { TemplateItem } from 'services/Templates/TemplateApi';
 import { FETCH_TEMPLATE_KEY, useFetchTemplate } from 'services/Templates/TemplateQueries';
 import Loader from 'components/Loader';
-import { PATCH_SYSTEMS_ROUTE, SYSTEMS_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
+import { PATCH_SYSTEMS_ROUTE } from 'Routes/constants';
 import SystemListTable from './SystemListTable';
 import ConditionalTooltip from 'components/ConditionalTooltip/ConditionalTooltip';
 import useNotification from 'Hooks/useNotification';
 import TagsFilter from 'components/TagsFilter/TagsFilter';
 import { isVersionLockedSystem } from '../../../TemplatesTable/helpers';
 import { modalTableSurfaceStyles } from 'helpers';
+import { useNavigateTo } from 'Hooks/navigation/useNavigateTo';
 
 const useStyles = createUseStyles({
   modalTableScope: modalTableSurfaceStyles,
@@ -230,7 +231,7 @@ export default function AddSystemModal() {
     localStorage.setItem(perPageKey, newPerPage.toString());
   };
 
-  const onClose = () => navigate(`${rootPath}/${TEMPLATES_ROUTE}/${uuid}/${SYSTEMS_ROUTE}`);
+  const onClose = useNavigateTo('systems');
 
   const handleSelectItem = (id: string) => {
     if (selectedList.has(id)) {

--- a/src/Pages/Templates/TemplateDetails/components/AssignTemplateModal/AssignTemplateModal.tsx
+++ b/src/Pages/Templates/TemplateDetails/components/AssignTemplateModal/AssignTemplateModal.tsx
@@ -1,6 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
-import useRootPath from '../../../../../Hooks/useRootPath';
+import { useParams, useSearchParams } from 'react-router-dom';
 import React, { useState, useMemo, useEffect } from 'react';
 import useNotification from '../../../../../Hooks/useNotification';
 import { useFetchTemplate } from '../../../../../services/Templates/TemplateQueries';
@@ -16,7 +15,6 @@ import {
   ModalFooter,
   ModalBody,
 } from '@patternfly/react-core';
-import { TEMPLATES_ROUTE, SYSTEMS_ROUTE } from '../../../../../Routes/constants';
 import ConditionalTooltip from '../../../../../components/ConditionalTooltip/ConditionalTooltip';
 import HelpPopover from '../../../../../components/HelpPopover';
 import text from '@patternfly/react-styles/css/utilities/Text/text';
@@ -36,6 +34,7 @@ import {
 } from 'Pages/Templates/TemplatesTable/constants';
 import { modalTableSurfaceStyles } from 'helpers';
 import { createUseStyles } from 'react-jss';
+import { useNavigateTo } from 'Hooks/navigation/useNavigateTo';
 
 const useStyles = createUseStyles({
   modalTableScope: modalTableSurfaceStyles,
@@ -46,8 +45,6 @@ const AssignTemplateModal = () => {
   const queryClient = useQueryClient();
   const { notify } = useNotification();
 
-  const rootPath = useRootPath();
-  const navigate = useNavigate();
   const { templateUUID: uuid = '' } = useParams();
 
   const [searchParams, setSearchParams] = useSearchParams();
@@ -131,7 +128,7 @@ const AssignTemplateModal = () => {
     }
   }, [last_update_task]);
 
-  const onClose = () => navigate(`${rootPath}/${TEMPLATES_ROUTE}/${uuid}/${SYSTEMS_ROUTE}`);
+  const onClose = useNavigateTo('systems');
 
   const isSystemListMethod = assignmentMethod === AssignmentMethods.SystemList;
 


### PR DESCRIPTION
## Summary
- makes use of useNavigateTo hook for frequently used navigation paths - such as `repositories` or `repositorySnapshots`
- gathering the paths in one place for easy change
- cleaning up code a bit
- adding unit tests for useNavigateTo hook to make sure it returns the right paths

## Testing steps
- testing manually: all the navigation from the components where the changes happened should work as it previously did
- all tests pass