### PR TITLE
Build: Ignore Babel major updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,9 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@eslint/js'
         update-types: ['version-update:semver-major']
+      # Babel 8 ships ESM-only helpers that break Jest 29 until we migrate
+      - dependency-name: '@babel/*'
+        update-types: ['version-update:semver-major']
       # Compromised versions from https://www.stepsecurity.io/blog/multiple-redhat-cloud-services-npm-packages-compromised
       - dependency-name: '@redhat-cloud-services/types'
         versions: ['3.6.1', '3.6.2', '3.6.4']


### PR DESCRIPTION
## Summary
- Add `@babel/*` to Dependabot's semver-major ignore list
- Prevents grouped npm PRs (e.g. #1050) from bumping Babel 7 to Babel 8, which breaks Jest 29 with ESM parse errors in `@babel/helper-validator-identifier`

## Test plan
- [ ] Merge this PR
- [ ] Comment `@dependabot rebase` on #1050 so it drops the Babel 8 bumps and keeps the other safe updates


Made with [Cursor](https://cursor.com)