### PR TITLE
HMS-10192: Update zero state to include templates

### DIFF
--- a/_playwright-tests/Integration/NoSubsUserTest.spec.ts
+++ b/_playwright-tests/Integration/NoSubsUserTest.spec.ts
@@ -1,8 +1,11 @@
-import { test, expect } from 'test-utils';
-import { navigateToTemplates } from '../UI/helpers/navHelpers';
-import { closeGenericPopupsIfExist } from '../UI/helpers/helpers';
+import { test, expect, cleanupRepositories, randomName } from 'test-utils';
+import { closeGenericPopupsIfExist, waitForValidStatus } from '../UI/helpers/helpers';
+import { getZeroStateTitleLocator } from '../UI/helpers/navHelpers';
+import { PAGE_NAVIGATION_TIMEOUT_MS, PAGE_READY_TIMEOUT_MS } from '../testConstants';
 
-test.describe('Template use requires a RHEL subscription', () => {
+const repoNamePrefix = 'ZeroStateTest';
+
+test.describe('No-subs user content management', () => {
   test.skip(
     !process.env.INTEGRATION || !process.env.RBAC,
     `Skipping as the INTEGRATION and RBAC environment variables aren't both set to true.`,
@@ -11,22 +14,240 @@ test.describe('Template use requires a RHEL subscription', () => {
     storageState: '.auth/NO_SUBS_TOKEN.json',
     extraHTTPHeaders: process.env.NO_SUBS_TOKEN ? { Authorization: process.env.NO_SUBS_TOKEN } : {},
   });
+  test.describe.configure({ mode: 'serial' });
 
-  test('Navigate to Templates, ensure the "Create template" button is disabled for no-subs user', async ({
-    page,
-  }) => {
-    await navigateToTemplates(page);
+  test.beforeEach(async ({ page, client, cleanup }) => {
+    await cleanup.runAndAdd(() => cleanupRepositories(client, repoNamePrefix));
     await closeGenericPopupsIfExist(page);
+  });
 
-    const AddButton = page.getByRole('button', { name: 'Create template', exact: true }).first();
-    await expect(AddButton).toBeVisible();
-    await expect(AddButton).toBeDisabled({ timeout: 1000 });
-    // eslint-disable-next-line playwright/no-force-option
-    await AddButton.hover({ force: true });
-    const tooltip = page.getByRole('tooltip');
-    await expect(tooltip).toBeVisible();
-    await expect(tooltip).toHaveText(
-      'You do not have the required subscription (RHEL) to perform this action.',
-    );
+  test.describe('Zero state', () => {
+    test('Zero state is shown on repositories and templates routes', async ({ page }) => {
+      await test.step('Repositories route shows zero state', async () => {
+        await page.goto('/insights/content/repositories', {
+          timeout: PAGE_NAVIGATION_TIMEOUT_MS,
+        });
+
+        await expect(getZeroStateTitleLocator(page)).toBeVisible({
+          timeout: PAGE_READY_TIMEOUT_MS,
+        });
+        await expect(page.getByRole('heading', { name: 'About content templates' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'About repositories' })).toBeVisible();
+        await expect(
+          page.getByText('View all repositories within your organization.'),
+        ).toBeHidden();
+      });
+
+      await test.step('Templates route shows zero state', async () => {
+        await page.goto('/insights/content/templates', { timeout: PAGE_NAVIGATION_TIMEOUT_MS });
+
+        await expect(getZeroStateTitleLocator(page)).toBeVisible({
+          timeout: PAGE_READY_TIMEOUT_MS,
+        });
+        await expect(page.getByRole('heading', { name: 'About content templates' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'About repositories' })).toBeVisible();
+        await expect(
+          page.getByText('View all content templates within your organization.'),
+        ).toBeHidden();
+      });
+    });
+
+    test('Zero state documentation link opens Red Hat docs', async ({ page, context }) => {
+      await page.goto('/insights/content/templates', { timeout: PAGE_NAVIGATION_TIMEOUT_MS });
+
+      await expect(getZeroStateTitleLocator(page)).toBeVisible({
+        timeout: PAGE_READY_TIMEOUT_MS,
+      });
+
+      const pagePromise = context.waitForEvent('page');
+
+      await page
+        .getByRole('link', {
+          name: 'Learn more about managing system content and patch updates',
+        })
+        .click();
+
+      const docsPage = await pagePromise;
+      await expect(docsPage).toHaveURL(
+        /^https:\/\/docs\.redhat\.com\/en\/documentation\/red_hat_lightspeed\/.*managing_system_content_and_patch_updates_on_rhel_systems.*$/,
+      );
+      await expect(
+        docsPage.getByText(/Managing system content and patch updates/i).first(),
+      ).toBeVisible();
+    });
+
+    test('Zero state call to action (CTA) buttons navigate to list pages', async ({ page }) => {
+      await test.step('Add repositories CTA shows repositories list', async () => {
+        await page.goto('/insights/content/repositories', {
+          timeout: PAGE_NAVIGATION_TIMEOUT_MS,
+        });
+
+        await expect(getZeroStateTitleLocator(page)).toBeVisible({
+          timeout: PAGE_READY_TIMEOUT_MS,
+        });
+
+        await page
+          .getByRole('button', { name: 'Add repositories', exact: true })
+          .click({ noWaitAfter: true });
+
+        await expect(getZeroStateTitleLocator(page)).toBeHidden();
+        await expect(page.getByText('View all repositories within your organization.')).toBeVisible(
+          {
+            timeout: PAGE_READY_TIMEOUT_MS,
+          },
+        );
+      });
+
+      await test.step('Create template CTA shows templates list', async () => {
+        await page.goto('/insights/content/templates', { timeout: PAGE_NAVIGATION_TIMEOUT_MS });
+
+        await expect(getZeroStateTitleLocator(page)).toBeVisible({
+          timeout: PAGE_READY_TIMEOUT_MS,
+        });
+
+        await page
+          .getByRole('button', { name: 'Create template', exact: true })
+          .click({ noWaitAfter: true });
+
+        await expect(getZeroStateTitleLocator(page)).toBeHidden();
+        await expect(
+          page.getByText('View all content templates within your organization.'),
+        ).toBeVisible({ timeout: PAGE_READY_TIMEOUT_MS });
+      });
+    });
+  });
+
+  test('Empty templates table documentation link opens Red Hat docs', async ({
+    page,
+    context,
+    unusedRepoUrl,
+  }) => {
+    const repoName = `${repoNamePrefix}-${randomName()}`;
+    const url = await unusedRepoUrl();
+
+    await test.step('Add a custom repository to exit zero state', async () => {
+      await page.goto('/insights/content/repositories', {
+        timeout: PAGE_NAVIGATION_TIMEOUT_MS,
+      });
+
+      await page
+        .getByRole('button', { name: 'Add repositories', exact: true })
+        .click({ noWaitAfter: true });
+      await expect(page.getByText('View all repositories within your organization.')).toBeVisible({
+        timeout: PAGE_READY_TIMEOUT_MS,
+      });
+
+      await page
+        .getByRole('button', { name: 'Add repositories', exact: true })
+        .click({ noWaitAfter: true });
+      await expect(page.getByRole('dialog', { name: 'Add custom repositories' })).toBeVisible();
+
+      await page.getByRole('textbox', { name: 'Name', exact: true }).fill(repoName);
+      await page.getByLabel('Introspect only').click();
+      await page.getByRole('textbox', { name: 'URL', exact: true }).fill(`${url}`);
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+      await waitForValidStatus(page, repoName);
+    });
+
+    await test.step('Templates list shows the empty table state', async () => {
+      await page.goto('/insights/content/templates', { timeout: PAGE_NAVIGATION_TIMEOUT_MS });
+
+      await expect(getZeroStateTitleLocator(page)).toBeHidden();
+      await expect(
+        page.getByText('View all content templates within your organization.'),
+      ).toBeVisible({ timeout: PAGE_READY_TIMEOUT_MS });
+      await expect(
+        page.getByRole('link', { name: 'Learn more about content templates' }),
+      ).toBeVisible();
+    });
+
+    await test.step(`Click the 'Learn more about content templates' link and verify the destination`, async () => {
+      const pagePromise = context.waitForEvent('page');
+
+      await page.getByRole('link', { name: 'Learn more about content templates' }).click();
+      const docsPage = await pagePromise;
+      await expect(docsPage).toHaveURL(
+        /^https:\/\/docs\.redhat\.com\/en\/documentation\/red_hat_lightspeed\/.*using-content-templates-to-apply-system-patches.*$/,
+      );
+      await expect(docsPage.getByText(/^.*Using content templates.*$/).first()).toBeVisible();
+      await expect(
+        docsPage.getByText('A content template is a set of repository snapshots').first(),
+      ).toBeVisible();
+    });
+  });
+
+  test('Zero state is exited after adding a repository and requires a subscription to create templates', async ({
+    page,
+    unusedRepoUrl,
+  }) => {
+    const repoName = `${repoNamePrefix}-${randomName()}`;
+    const url = await unusedRepoUrl();
+
+    await test.step('Zero state is shown before any custom repositories exist', async () => {
+      await page.goto('/insights/content/repositories', {
+        timeout: PAGE_NAVIGATION_TIMEOUT_MS,
+      });
+
+      await expect(getZeroStateTitleLocator(page)).toBeVisible({
+        timeout: PAGE_READY_TIMEOUT_MS,
+      });
+    });
+
+    await test.step('Create a custom repository', async () => {
+      await page
+        .getByRole('button', { name: 'Add repositories', exact: true })
+        .click({ noWaitAfter: true });
+      await expect(page.getByText('View all repositories within your organization.')).toBeVisible({
+        timeout: PAGE_READY_TIMEOUT_MS,
+      });
+
+      await page
+        .getByRole('button', { name: 'Add repositories', exact: true })
+        .click({ noWaitAfter: true });
+      await expect(page.getByRole('dialog', { name: 'Add custom repositories' })).toBeVisible();
+
+      await page.getByRole('textbox', { name: 'Name', exact: true }).fill(repoName);
+      await page.getByLabel('Introspect only').click();
+      await page.getByRole('textbox', { name: 'URL', exact: true }).fill(`${url}`);
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+      await waitForValidStatus(page, repoName);
+    });
+
+    await test.step('Zero state is no longer shown after a custom repository exists', async () => {
+      await page.goto('/insights/content/repositories', {
+        timeout: PAGE_NAVIGATION_TIMEOUT_MS,
+      });
+
+      await expect(getZeroStateTitleLocator(page)).toBeHidden();
+      await expect(page.getByText('View all repositories within your organization.')).toBeVisible({
+        timeout: PAGE_READY_TIMEOUT_MS,
+      });
+
+      await page.goto('/insights/content/templates', { timeout: PAGE_NAVIGATION_TIMEOUT_MS });
+
+      await expect(getZeroStateTitleLocator(page)).toBeHidden();
+      await expect(
+        page.getByText('View all content templates within your organization.'),
+      ).toBeVisible({ timeout: PAGE_READY_TIMEOUT_MS });
+    });
+
+    await test.step('Create template toolbar button is disabled without a RHEL subscription', async () => {
+      const createTemplateButton = page
+        .getByRole('button', { name: 'Create template', exact: true })
+        .first();
+
+      await expect(createTemplateButton).toBeVisible();
+      await expect(createTemplateButton).toBeDisabled({ timeout: 1000 });
+      // eslint-disable-next-line playwright/no-force-option
+      await createTemplateButton.hover({ force: true });
+
+      const tooltip = page.getByRole('tooltip');
+      await expect(tooltip).toBeVisible();
+      await expect(tooltip).toHaveText(
+        'You do not have the required subscription (RHEL) to perform this action.',
+      );
+    });
   });
 });

--- a/_playwright-tests/UI/Templates.spec.ts
+++ b/_playwright-tests/UI/Templates.spec.ts
@@ -14,9 +14,9 @@ test.describe('Templates', () => {
     await navigateToTemplates(page);
     await closeGenericPopupsIfExist(page);
 
-    const AddButton = page.locator('[data-ouia-component-id="create_content_template"]');
-
-    await expect(AddButton.first()).toBeEnabled({ timeout: 10000 });
+    await expect(page.getByRole('button', { name: 'Create template' })).toBeEnabled({
+      timeout: 10000,
+    });
   });
 
   test('Copying templates', async ({ page, client, cleanup, unusedRepoUrl }) => {

--- a/_playwright-tests/UI/Templates.spec.ts
+++ b/_playwright-tests/UI/Templates.spec.ts
@@ -19,43 +19,6 @@ test.describe('Templates', () => {
     await expect(AddButton.first()).toBeEnabled({ timeout: 10000 });
   });
 
-  test('Validate documentation link in empty state', async ({ page, context }) => {
-    await test.step('Mock template list API to get to empty state', async () => {
-      await page.route('**/api/content-sources/*/templates/**', async (route) => {
-        const response = await route.fetch();
-        const json = {
-          data: [],
-          links: {
-            first: '/api/content-sources/v1.0/templates/?limit=20&offset=0',
-            last: '/api/content-sources/v1.0/templates/?limit=20&offset=0',
-          },
-          meta: { count: 0, limit: 20, offset: 0 },
-        };
-        await route.fulfill({ response, json });
-      });
-    });
-
-    await test.step('Navigate to the templates page', async () => {
-      await navigateToTemplates(page);
-      await closeGenericPopupsIfExist(page);
-    });
-
-    await test.step(`Click the 'Learn more about content templates' link and verify the destination`, async () => {
-      // Start waiting for the docs page before clicking
-      const pagePromise = context.waitForEvent('page');
-
-      await page.getByRole('link', { name: 'Learn more about content templates' }).click();
-      const docsPage = await pagePromise;
-      await expect(docsPage).toHaveURL(
-        /^https:\/\/docs\.redhat\.com\/en\/documentation\/red_hat_lightspeed\/.*using-content-templates-to-apply-system-patches.*$/,
-      );
-      await expect(docsPage.getByText(/^.*Using content templates.*$/).first()).toBeVisible();
-      await expect(
-        docsPage.getByText('A content template is a set of repository snapshots').first(),
-      ).toBeVisible();
-    });
-  });
-
   test('Copying templates', async ({ page, client, cleanup, unusedRepoUrl }) => {
     const smallRHRepo = 'Red Hat CodeReady Linux Builder for RHEL 9 ARM 64 (RPMs)';
 

--- a/_playwright-tests/UI/helpers/navHelpers.ts
+++ b/_playwright-tests/UI/helpers/navHelpers.ts
@@ -7,27 +7,38 @@ import {
 } from '../../testConstants';
 import { retry } from './helpers';
 
-const navigateToRepositoriesFunc = async (page: Page) => {
-  await page.goto('/insights/content/repositories', { timeout: PAGE_NAVIGATION_TIMEOUT_MS });
+/** Locator for content zero state title (custom UI or dashboard default). */
+export const getZeroStateTitleLocator = (page: Page) =>
+  page.getByText(new RegExp(`Start using (content templates|Content management) now`));
 
-  const zeroState = page.getByText('Start using content templates now');
-
-  const repositoriesListPage = page.getByText('View all repositories within your organization.');
-
-  // Wait for either list page or zerostate
+const waitForListPageOrZeroState = async (
+  page: Page,
+  listPageLocator: Locator,
+  zeroStateLocator: Locator,
+  pageDescription: string,
+) => {
   try {
     await Promise.race([
-      repositoriesListPage.waitFor({ state: 'visible', timeout: PAGE_READY_TIMEOUT_MS }),
-      zeroState.waitFor({ state: 'visible', timeout: PAGE_READY_TIMEOUT_MS }),
+      listPageLocator.waitFor({ state: 'visible', timeout: PAGE_READY_TIMEOUT_MS }),
+      zeroStateLocator.waitFor({ state: 'visible', timeout: PAGE_READY_TIMEOUT_MS }),
     ]);
   } catch (error) {
     throw new Error(
-      `Neither repositories list nor zero state appeared: ${(error as Error)?.message}`,
+      `Neither ${pageDescription} nor zero state appeared: ${(error as Error)?.message}`,
     );
   }
+};
 
-  if (await isZeroStateVisible(page)) {
-    await page.getByRole('button', { name: /Add repositories/i }).click();
+const navigateToRepositoriesFunc = async (page: Page) => {
+  await page.goto('/insights/content/repositories', { timeout: PAGE_NAVIGATION_TIMEOUT_MS });
+
+  const zeroState = getZeroStateTitleLocator(page);
+  const repositoriesListPage = page.getByText('View all repositories within your organization.');
+
+  await waitForListPageOrZeroState(page, repositoriesListPage, zeroState, 'repositories list');
+
+  if (await zeroState.isVisible()) {
+    await page.getByRole('button', { name: /Add repositories/i }).click({ noWaitAfter: true });
     await repositoriesListPage.waitFor({ state: 'visible', timeout: PAGE_READY_TIMEOUT_MS });
   }
 };
@@ -54,12 +65,16 @@ export const navigateToRepositories = async (page: Page) => {
 const navigateToTemplatesFunc = async (page: Page) => {
   await page.goto('/insights/content/templates', { timeout: PAGE_NAVIGATION_QUICK_TIMEOUT_MS });
 
+  const zeroState = getZeroStateTitleLocator(page);
   const templateText = page.getByText('View all content templates within your organization.');
 
-  await waitForListPageOrZeroState(page, templateText, 'templates list');
+  await waitForListPageOrZeroState(page, templateText, zeroState, 'templates list');
 
-  if (await isZeroStateVisible(page)) {
-    await page.getByRole('button', { name: /Create template/i }).click();
+  // On main, /templates always rendered the list. This branch shows zero state on that route too.
+  if (await zeroState.isVisible()) {
+    await page
+      .getByRole('button', { name: 'Create template', exact: true })
+      .click({ noWaitAfter: true });
     await templateText.waitFor({ state: 'visible', timeout: PAGE_READY_TIMEOUT_MS });
   }
 };

--- a/_playwright-tests/UI/helpers/navHelpers.ts
+++ b/_playwright-tests/UI/helpers/navHelpers.ts
@@ -10,7 +10,7 @@ import { retry } from './helpers';
 const navigateToRepositoriesFunc = async (page: Page) => {
   await page.goto('/insights/content/repositories', { timeout: PAGE_NAVIGATION_TIMEOUT_MS });
 
-  const zeroState = page.getByText('Start using Content management now');
+  const zeroState = page.getByText('Start using content templates now');
 
   const repositoriesListPage = page.getByText('View all repositories within your organization.');
 
@@ -26,8 +26,9 @@ const navigateToRepositoriesFunc = async (page: Page) => {
     );
   }
 
-  if (await zeroState.isVisible()) {
-    await page.getByRole('button', { name: 'Add repositories now' }).click();
+  if (await isZeroStateVisible(page)) {
+    await page.getByRole('button', { name: /Add repositories/i }).click();
+    await repositoriesListPage.waitFor({ state: 'visible', timeout: PAGE_READY_TIMEOUT_MS });
   }
 };
 
@@ -55,8 +56,12 @@ const navigateToTemplatesFunc = async (page: Page) => {
 
   const templateText = page.getByText('View all content templates within your organization.');
 
-  // Wait for either list page or zerostate
-  await templateText.waitFor({ state: 'visible', timeout: PAGE_READY_TIMEOUT_MS });
+  await waitForListPageOrZeroState(page, templateText, 'templates list');
+
+  if (await isZeroStateVisible(page)) {
+    await page.getByRole('button', { name: /Create template/i }).click();
+    await templateText.waitFor({ state: 'visible', timeout: PAGE_READY_TIMEOUT_MS });
+  }
 };
 
 export const navigateToTemplates = async (page: Page) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,8 +12,10 @@ import { useAppContext } from './middleware/AppContext';
 import { ContentOrigin, FilterData } from './services/Content/ContentApi';
 import { useContentListQuery } from './services/Content/ContentQueries';
 import { perPageKey } from './Pages/Repositories/ContentListTable/ContentListTable';
-import { CONTENT_ROUTE, REPOSITORIES_ROUTE } from './Routes/constants';
+import { CONTENT_ROUTE, REPOSITORIES_ROUTE, TEMPLATES_ROUTE } from './Routes/constants';
 import usePageSafe from 'Hooks/usePageSafe';
+import { TemplateFilterData } from './services/Templates/TemplateApi';
+import { useTemplateList } from './services/Templates/TemplateQueries';
 
 export default function App() {
   const { rbac, isFetchingPermissions, zeroState, setZeroState } = useAppContext();
@@ -23,7 +25,10 @@ export default function App() {
   const { hideGlobalFilter } = useChrome();
 
   const isDefaultRoute = useMemo(
-    () => [REPOSITORIES_ROUTE, '', CONTENT_ROUTE].includes(last(pathname.split('/')) || ''),
+    () =>
+      [REPOSITORIES_ROUTE, '', CONTENT_ROUTE, TEMPLATES_ROUTE].includes(
+        last(pathname.split('/')) || '',
+      ),
     [pathname],
   );
 
@@ -34,6 +39,19 @@ export default function App() {
     statuses: [],
   });
 
+  const [templateFilterData] = useState<TemplateFilterData>({
+    search: '',
+    arch: '',
+    version: [],
+    extended_release_version: [],
+    restrict_to_major: false,
+    repository_uuids: '',
+    snapshot_uuids: '',
+    extended_release: [],
+  });
+
+  const enableZeroStateCheck = isDefaultRoute && zeroState;
+
   const { data = { data: [], meta: { count: 0, limit: 20, offset: 0 } }, isLoading } =
     useContentListQuery(
       1,
@@ -41,23 +59,27 @@ export default function App() {
       filterData,
       '',
       [ContentOrigin.EXTERNAL, ContentOrigin.UPLOAD],
-      isDefaultRoute && zeroState, // We only check if the route is correct and zerostate is true (defaults to true)
+      enableZeroStateCheck,
     );
+
+  const {
+    data: templateData = { data: [], meta: { count: 0, limit: 20, offset: 0 } },
+    isLoading: isLoadingTemplates,
+  } = useTemplateList(1, 1, '', templateFilterData, false, enableZeroStateCheck);
 
   // Hide Insights' global filter bar
   useEffect(() => {
     hideGlobalFilter(true);
   }, [hideGlobalFilter]);
 
-  // Check for user's custom repositories to determine whether we need to show zero state
+  // Check for user's custom repositories and templates to determine whether we need to show zero state
   useEffect(() => {
-    // Zero state may be true AND a user may have repositories if they have signed in via a different machine for the first time
-    if ((zeroState && data.data.length > 0) || (zeroState && !isDefaultRoute)) {
+    if (zeroState && (data.data.length > 0 || templateData.meta.count > 0 || !isDefaultRoute)) {
       setZeroState(false);
     }
-  }, [data.data.length, zeroState]);
+  }, [data.data.length, templateData.meta.count, zeroState, isDefaultRoute, setZeroState]);
 
-  if (!rbac || isFetchingPermissions || isLoading) {
+  if (!rbac || isFetchingPermissions || isLoading || isLoadingTemplates) {
     return (
       <Bullseye>
         <div data-ouia-safe={false} />

--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -51,7 +51,14 @@ export default function RepositoriesRoutes() {
   return (
     <ErrorPage>
       <Routes key={key}>
-        {zeroState ? <Route index path={REPOSITORIES_ROUTE} element={<ZeroState />} /> : <></>}
+        {zeroState ? (
+          <>
+            <Route index path={REPOSITORIES_ROUTE} element={<ZeroState />} />
+            <Route path={TEMPLATES_ROUTE} element={<ZeroState />} />
+          </>
+        ) : (
+          <></>
+        )}
         <Route path={REPOSITORIES_ROUTE} element={<RepositoryLayout />}>
           <Route path='' element={<ContentListTable />}>
             {rbac?.repoWrite ? (

--- a/src/components/ZeroState/ZeroState.test.tsx
+++ b/src/components/ZeroState/ZeroState.test.tsx
@@ -2,32 +2,36 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ZeroState } from './ZeroState';
 import { useAppContext } from 'middleware/AppContext';
-import { useHref, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { ReactNode } from 'react';
 
 jest.mock('middleware/AppContext', () => ({
   useAppContext: jest.fn(),
 }));
 
+jest.mock('Hooks/useRootPath', () => () => '/insights/content');
+
 const navigateMock = jest.fn();
 
 jest.mock('react-router-dom', () => ({
   useNavigate: jest.fn(),
-  useHref: jest.fn(),
 }));
 
 jest.mock('@redhat-cloud-services/frontend-components/AsyncComponent', () => {
   function MockAsyncComponent({
+    customTitle,
     customText,
     customSection,
     customButton,
   }: {
+    customTitle: ReactNode;
     customText: ReactNode;
     customSection: ReactNode;
     customButton: ReactNode;
   }) {
     return (
       <div>
+        <div>{customTitle}</div>
         <div>{customText}</div>
         <div>{customSection}</div>
         <div>{customButton}</div>
@@ -37,42 +41,74 @@ jest.mock('@redhat-cloud-services/frontend-components/AsyncComponent', () => {
   return MockAsyncComponent;
 });
 
+const defaultContext = {
+  setZeroState: jest.fn(),
+};
+
 describe('ZeroState', () => {
   beforeEach(() => {
     (useNavigate as jest.Mock).mockReturnValue(navigateMock);
-    (useHref as jest.Mock).mockReturnValue('/insights/content/repositories');
     navigateMock.mockReset();
+    (useAppContext as jest.Mock).mockReturnValue(defaultContext);
   });
 
-  it('shows the Red Hat repository card and navigates from buttons', async () => {
-    const setZeroState = jest.fn();
+  it('shows both cards with correct content', () => {
+    render(<ZeroState />);
+
+    expect(screen.getByText('Start using content templates now')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Get started by creating a content template to manage updates for your RHEL systems or adding external repositories.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('About content templates')).toBeInTheDocument();
+    expect(screen.getByText('About repositories')).toBeInTheDocument();
+    expect(screen.getByText(/Content templates use repository snapshots/i)).toBeInTheDocument();
+    expect(screen.getByText(/Standard Operating Environment \(SOE\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/Repositories provide the content sources/i)).toBeInTheDocument();
+  });
+
+  it('navigates to browse repositories from the repositories card', async () => {
     const user = userEvent.setup();
-    (useAppContext as jest.Mock).mockReturnValue({
-      setZeroState,
-      isLightspeedEnabled: false,
-    });
 
     render(<ZeroState />);
 
-    expect(screen.getByText(/Get started with Insights/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Browse Red Hat repositories' })).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: 'Browse Red Hat repositories' }));
-    await user.click(screen.getByRole('button', { name: 'Add repositories now' }));
-
-    expect(setZeroState).toHaveBeenCalledWith(false);
+    await user.click(screen.getByRole('button', { name: 'Browse available repositories' }));
+    expect(defaultContext.setZeroState).toHaveBeenCalledWith(false);
     expect(navigateMock).toHaveBeenCalledWith('/insights/content/repositories?origin=red_hat');
   });
 
-  it('uses lightspeed copy when enabled', () => {
-    const setZeroState = jest.fn();
-    (useAppContext as jest.Mock).mockReturnValue({
-      setZeroState,
-      isLightspeedEnabled: true,
-    });
+  it('navigates to templates list from CTA button', async () => {
+    const user = userEvent.setup();
 
     render(<ZeroState />);
 
-    expect(screen.getByText(/Get started with Red Hat Lightspeed/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Browse Red Hat repositories' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Create template' }));
+    expect(defaultContext.setZeroState).toHaveBeenCalledWith(false);
+    expect(navigateMock).toHaveBeenCalledWith('/insights/content/templates');
+  });
+
+  it('navigates to repositories list from CTA button', async () => {
+    const user = userEvent.setup();
+
+    render(<ZeroState />);
+
+    await user.click(screen.getByRole('button', { name: 'Add repositories' }));
+    expect(defaultContext.setZeroState).toHaveBeenCalledWith(false);
+    expect(navigateMock).toHaveBeenCalledWith('/insights/content/repositories');
+  });
+
+  it('renders learn more links', () => {
+    render(<ZeroState />);
+
+    const learnMoreLinks = screen.getAllByRole('link');
+    expect(learnMoreLinks).toHaveLength(2);
+    expect(
+      screen.getByText('Learn more about managing system content and patch updates'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Learn more about repositories' })).toHaveAttribute(
+      'href',
+      'https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html/deploying_and_managing_rhel_systems_in_hybrid_clouds/assembly_managing-repositories-in-red-hat-hybrid-cloud-console_host-management-services',
+    );
   });
 });

--- a/src/components/ZeroState/ZeroState.tsx
+++ b/src/components/ZeroState/ZeroState.tsx
@@ -13,22 +13,27 @@ import {
   Content,
   Title,
 } from '@patternfly/react-core';
+import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
 import { createUseStyles } from 'react-jss';
 
+import useRootPath from 'Hooks/useRootPath';
 import { useAppContext } from 'middleware/AppContext';
-import { useHref, useNavigate } from 'react-router-dom';
-import { REPOSITORIES_ROUTE } from 'Routes/constants';
+import { useNavigate } from 'react-router-dom';
+import { REPOSITORIES_ROUTE, TEMPLATES_ROUTE } from 'Routes/constants';
+
+const CONTENT_DOCS_URL =
+  'https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html/managing_system_content_and_patch_updates_on_rhel_systems/index';
+
+const REPOSITORIES_DOCS_URL =
+  'https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html/deploying_and_managing_rhel_systems_in_hybrid_clouds/assembly_managing-repositories-in-red-hat-hybrid-cloud-console_host-management-services';
 
 const useStyles = createUseStyles({
   contentZerostate: {
     minHeight: '100%',
     '& .bannerBefore': { maxHeight: '320px!important' },
     '& .bannerRight': { justifyContent: 'space-evenly!important' },
-  },
-  textContent: {
-    minHeight: '40px',
   },
   removeBottomPadding: {
     paddingBottom: '0',
@@ -38,24 +43,18 @@ const useStyles = createUseStyles({
 export const ZeroState = () => {
   const classes = useStyles();
   const navigate = useNavigate();
-  const { setZeroState, isLightspeedEnabled } = useAppContext();
-  const path = useHref('content');
-  const pathname = path.split('content')[0] + 'content';
+  const rootPath = useRootPath();
+  const { setZeroState } = useAppContext();
 
-  const handleMainButtonClick = () => {
+  const openTemplatesList = () => {
     setZeroState(false);
+    navigate(`${rootPath}/${TEMPLATES_ROUTE}`);
   };
 
-  const repoList = [
-    {
-      title: 'Red Hat repositories',
-      description: 'Browse available Red Hat repositories to create RHEL images.',
-      onClick: () => {
-        setZeroState(false);
-        navigate(`${pathname}/${REPOSITORIES_ROUTE}?origin=red_hat`);
-      },
-    },
-  ];
+  const openRepositoriesList = () => {
+    setZeroState(false);
+    navigate(`${rootPath}/${REPOSITORIES_ROUTE}`);
+  };
 
   return (
     <>
@@ -75,38 +74,146 @@ export const ZeroState = () => {
             ErrorComponent={<ErrorState />}
             app='Content_management'
             ouiaId='get_started_from_zerostate_description'
-            customText={`Get started with ${isLightspeedEnabled ? 'Red Hat Lightspeed' : 'Insights'} by adding repositories`}
+            customTitle='Start using content templates now'
+            customText='Get started by creating a content template to manage updates for your RHEL systems or adding external repositories.'
             customSection={
               <PageSection hasBodyWrapper={false} className={classes.removeBottomPadding}>
-                <Flex direction={{ default: 'row' }} gap={{ default: 'gap' }}>
-                  {repoList.map(({ title, description, onClick }) => (
-                    <FlexItem flex={{ default: 'flex_1' }} key={title}>
-                      <Card>
-                        <CardTitle>
-                          <Title headingLevel='h3'>{title}</Title>
-                        </CardTitle>
-                        <CardBody>
-                          <Content className={classes.textContent}>
-                            <Content component='p'>{description}</Content>
-                          </Content>
-                          <Button onClick={onClick} variant='secondary' size='lg'>
-                            Browse {title}
-                          </Button>
-                        </CardBody>
-                      </Card>
-                    </FlexItem>
-                  ))}
+                <Flex
+                  direction={{ default: 'row' }}
+                  gap={{ default: 'gapLg' }}
+                  alignItems={{ default: 'alignItemsStretch' }}
+                >
+                  <FlexItem flex={{ default: 'flex_1' }}>
+                    <Card isFullHeight>
+                      <CardTitle>
+                        <Title headingLevel='h3'>About content templates</Title>
+                      </CardTitle>
+                      <CardBody>
+                        <Flex
+                          direction={{ default: 'column' }}
+                          gap={{ default: 'gapMd' }}
+                          style={{ height: '100%' }}
+                        >
+                          <FlexItem flex={{ default: 'flex_1' }}>
+                            <Content>
+                              <Content component='p'>
+                                Content templates use repository snapshots to control which
+                                advisories and package versions are applied when patching your RHEL
+                                systems.
+                              </Content>
+                              <Content component='p'>
+                                Use templates to define a Standard Operating Environment (SOE) by
+                                pinning repositories to a specific point in time. This ensures a
+                                consistent baseline of tested packages and advisories across your
+                                systems.
+                              </Content>
+                            </Content>
+                          </FlexItem>
+                          <FlexItem>
+                            <Flex
+                              direction={{ default: 'column' }}
+                              alignItems={{ default: 'alignItemsFlexStart' }}
+                              gap={{ default: 'gapMd' }}
+                            >
+                              <Button
+                                variant='link'
+                                isInline
+                                component='a'
+                                href={CONTENT_DOCS_URL}
+                                target='_blank'
+                                rel='noopener noreferrer'
+                                icon={<ExternalLinkSquareAltIcon />}
+                                iconPosition='end'
+                              >
+                                Learn more about managing system content and patch updates
+                              </Button>
+                            </Flex>
+                          </FlexItem>
+                        </Flex>
+                      </CardBody>
+                    </Card>
+                  </FlexItem>
+                  <FlexItem flex={{ default: 'flex_1' }}>
+                    <Card isFullHeight>
+                      <CardTitle>
+                        <Title headingLevel='h3'>About repositories</Title>
+                      </CardTitle>
+                      <CardBody>
+                        <Flex
+                          direction={{ default: 'column' }}
+                          gap={{ default: 'gapMd' }}
+                          style={{ height: '100%' }}
+                        >
+                          <FlexItem flex={{ default: 'flex_1' }}>
+                            <Content>
+                              <Content component='p'>
+                                Repositories provide the content sources that templates use to
+                                define what packages and advisories are available to your systems.
+                              </Content>
+                              <Content component='p'>
+                                You can use official Red Hat content, add external sources, or
+                                upload custom RPMs.
+                              </Content>
+                            </Content>
+                          </FlexItem>
+                          <FlexItem>
+                            <Flex
+                              direction={{ default: 'column' }}
+                              alignItems={{ default: 'alignItemsFlexStart' }}
+                              gap={{ default: 'gapMd' }}
+                            >
+                              <Button
+                                onClick={() => {
+                                  setZeroState(false);
+                                  navigate(`${rootPath}/${REPOSITORIES_ROUTE}?origin=red_hat`);
+                                }}
+                                variant='secondary'
+                              >
+                                Browse available repositories
+                              </Button>
+                              <Button
+                                variant='link'
+                                isInline
+                                component='a'
+                                href={REPOSITORIES_DOCS_URL}
+                                target='_blank'
+                                rel='noopener noreferrer'
+                                icon={<ExternalLinkSquareAltIcon />}
+                                iconPosition='end'
+                              >
+                                Learn more about repositories
+                              </Button>
+                            </Flex>
+                          </FlexItem>
+                        </Flex>
+                      </CardBody>
+                    </Card>
+                  </FlexItem>
                 </Flex>
               </PageSection>
             }
             customButton={
-              <Button
-                id='get-started-repositories-button'
-                ouiaId='get_started_repositories_button'
-                onClick={() => handleMainButtonClick()}
+              <Flex
+                direction={{ default: 'column' }}
+                alignItems={{ default: 'alignItemsCenter' }}
+                gap={{ default: 'gapSm' }}
               >
-                Add repositories now
-              </Button>
+                <Button
+                  id='create-template-button'
+                  ouiaId='create_template_button'
+                  onClick={openTemplatesList}
+                >
+                  Create template
+                </Button>
+                <Button
+                  id='add-repositories-button'
+                  ouiaId='add_repositories_button'
+                  variant='link'
+                  onClick={openRepositoriesList}
+                >
+                  Add repositories
+                </Button>
+              </Flex>
             }
           />
         </Grid>

--- a/src/services/Templates/TemplateQueries.ts
+++ b/src/services/Templates/TemplateQueries.ts
@@ -150,6 +150,7 @@ export const useTemplateList = (
   sortBy: string,
   filterData: TemplateFilterData,
   polling: boolean = false,
+  enabled: boolean = true,
 ) =>
   useQuery({
     // Below MUST match the "templateListKeyArray" seen below (once written) in the useDeleteTemplate.
@@ -162,6 +163,7 @@ export const useTemplateList = (
     refetchInterval: polling ? TEMPLATE_LIST_POLLING_TIME : undefined,
     placeholderData: keepPreviousData,
     staleTime: 20000,
+    enabled,
   });
 
 export const useTemplateNameAvailability = (name: string, excludeUuid?: string) => {


### PR DESCRIPTION
## Summary

Zero State banner now applied on Templates page too. Text updated as per UI team's mock.
HMS-10192 [UI] update zero state to include templates

## Testing steps
This needs to merge first: [HMS-10192: update Content Management zero state copy](https://github.com/RedHatInsights/insights-dashboard/pull/819)