### PR TITLE
docs: Make sure step 3 is considered mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Alternatively, add these lines to your /etc/hosts file:
 2. To ensure you have the correct node version installed do: `nvm use`.
    Yarn WILL prevent you from progressing if you have not updated your node version to match the one in the .nvmrc file.
 
-3. To run Playwright tests, you need to set up the `_playwright-tests/test-utils` submodule. If you haven't already cloned the repo with all its submodules, you can do this by running `./test-utils.sh setup`. This is a one-time setup, but if the submodule folder ever becomes empty, you'll need to run this command again. Additionally, for any existing setups, be sure to update your packages with `yarn install` to ensure everything is up to date.
+3. Next, run `./test-utils.sh setup` to set up the `_playwright-tests/test-utils` submodule. This is a one-time setup, but if the submodule folder ever becomes empty, you'll need to run this command again. This step is mandatory and enables you to run Playwright tests.
 
 4. `yarn install`
 


### PR DESCRIPTION
## Summary

I ran into this problem myself when trying to setup the repo for local development.

The previous wording suggested that following this step is only required if one wants to run Playwright tests, when in fact, `yarn install` fails on a fresh checkout of this repo. When reading "To run Playwright tests" I skipped over the entire paragraph.
The wording is now trimmed down now to only mention what seems useful in a first "getting started" setup guide. Arguably it could be trimmed even further to just instruct the user to call the script.

## Testing steps

Do a fresh `git clone` of the repo and follow the steps, skipping step 3. `yarn install` will fail.