### PR TITLE
HMS-10939: add repo list page

### DIFF
--- a/src/LightwellApp.tsx
+++ b/src/LightwellApp.tsx
@@ -1,9 +1,11 @@
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useEffect } from 'react';
+import { Route, Routes } from 'react-router-dom';
 
 import { ErrorPage } from 'components/Error/ErrorPage';
 import usePageSafe from 'Hooks/usePageSafe';
+import PackagesList from 'Pages/Lightwell/Packages/PackagesList';
 import RepositoriesTable from 'Pages/Lightwell/Repositories/RepositoriesTable';
 import { useAppContext } from './middleware/AppContext';
 
@@ -28,7 +30,10 @@ export default function LightwellApp() {
   return (
     <ErrorPage>
       <div data-ouia-safe={pageSafe} />
-      <RepositoriesTable />
+      <Routes>
+        <Route index element={<RepositoriesTable />} />
+        <Route path=':repoUUID' element={<PackagesList />} />
+      </Routes>
     </ErrorPage>
   );
 }

--- a/src/Pages/Lightwell/Packages/PackagesList.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesList.tsx
@@ -1,0 +1,104 @@
+import { Breadcrumb, BreadcrumbItem, Grid, Stack, StackItem, Title } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { useQuery } from '@tanstack/react-query';
+import { createUseStyles } from 'react-jss';
+import { useNavigate } from 'react-router-dom';
+
+import EmptyTableState from 'components/EmptyTableState/EmptyTableState';
+import Loader from 'components/Loader';
+import useSafeUUIDParam from 'Hooks/useSafeUUIDParam';
+import { useContentListQuery } from 'services/Content/ContentQueries';
+
+import { getMockLightwellRepository } from '../mockRepositories';
+import { LIGHTWELL_FEATURE_NAME } from '../constants';
+import { useState } from 'react';
+import { FilterData } from 'services/Content/ContentApi';
+
+const useStyles = createUseStyles({
+  topContainer: {
+    padding: '16px 24px',
+  },
+  titleWrapper: {
+    padding: '24px 0 0',
+  },
+});
+
+const PackagesList = () => {
+  const classes = useStyles();
+  const repoUUID = useSafeUUIDParam('repoUUID');
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const useMock = false;
+  const [filters, setFilters] = useState<FilterData>({
+    feature_name: LIGHTWELL_FEATURE_NAME,
+  });
+
+  const mockQuery = useQuery({
+    queryKey: ['lightwell-repository-mock', repoUUID],
+    queryFn: () => {
+      const repository = getMockLightwellRepository(repoUUID);
+      if (!repository) {
+        throw new Error('Lightwell repository not found');
+      }
+      return repository;
+    },
+    staleTime: 20000,
+    enabled: useMock && !!repoUUID,
+  });
+
+  // const apiQuery = useFetchContent(repoUUID, !!repoUUID && !useMock);
+
+  const apiQuery = useContentListQuery(page, 1, filters, '', [], !useMock);
+
+  const {
+    isLoading,
+    isError,
+    error,
+    data = { data: [], meta: { count: 0, limit: 1, offset: 0 } },
+  } = useMock ? mockQuery : apiQuery;
+
+  const clearFilters = () => {
+    setFilters({ search: '', feature_name: LIGHTWELL_FEATURE_NAME });
+    setPage(1);
+  };
+
+  // const { data: repository, isLoading, isError, error } = useMock ? mockQuery : apiQuery;
+
+  if (isError) throw error;
+
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  return (
+    <>
+      <Grid className={classes.topContainer}>
+        <Stack>
+          <StackItem>
+            <Breadcrumb ouiaId='lightwell-packages-breadcrumb'>
+              <BreadcrumbItem component='button' onClick={() => navigate('..')}>
+                Repositories
+              </BreadcrumbItem>
+              <BreadcrumbItem disabled>Packages</BreadcrumbItem>
+            </Breadcrumb>
+          </StackItem>
+          <StackItem className={classes.titleWrapper}>
+            <Title headingLevel='h1' ouiaId='lightwell-packages-header'>
+              {data[0]?.name}
+            </Title>
+          </StackItem>
+        </Stack>
+      </Grid>
+      <Grid className={`${spacing.pxLg} ${spacing.ptMd}`}>
+        <EmptyTableState
+          notFiltered
+          itemName='packages'
+          notFilteredBody='No packages are available in this repository yet.'
+          clearFilters={clearFilters}
+        />
+      </Grid>
+    </>
+  );
+};
+
+export default PackagesList;

--- a/src/Pages/Lightwell/Repositories/RepositoriesTable.test.tsx
+++ b/src/Pages/Lightwell/Repositories/RepositoriesTable.test.tsx
@@ -1,18 +1,53 @@
 import { render, screen } from '@testing-library/react';
 
 import RepositoriesTable from './RepositoriesTable';
+import { useContentListQuery } from 'services/Content/ContentQueries';
+import { defaultLightwellContentItem, ReactQueryTestWrapper } from 'testingHelpers';
 
-jest.mock('components/Header/Header', () => {
-  function MockHeader({ title }: { title: string }) {
-    return <div>{title}</div>;
-  }
-  return MockHeader;
+jest.mock('services/Content/ContentQueries', () => ({
+  useContentListQuery: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+}));
+
+const renderRepositoriesTable = () =>
+  render(
+    <ReactQueryTestWrapper>
+      <RepositoriesTable />
+    </ReactQueryTestWrapper>,
+  );
+
+it('shows empty state when there are no repositories', async () => {
+  (useContentListQuery as jest.Mock).mockImplementation(() => ({ isLoading: false }));
+
+  renderRepositoriesTable();
+
+  expect(
+    await screen.findByText('No Lightwell repositories are available yet.'),
+  ).toBeInTheDocument();
 });
 
-it('renders the Lightwell repositories empty state', () => {
-  render(<RepositoriesTable />);
+it('renders with a single row', async () => {
+  (useContentListQuery as jest.Mock).mockImplementation(() => ({
+    isLoading: false,
+    data: {
+      data: [defaultLightwellContentItem],
+      meta: { count: 1, limit: 20, offset: 0 },
+    },
+  }));
 
-  expect(screen.getByText('Lightwell - Repositories')).toBeInTheDocument();
-  expect(screen.getByText('No repositories')).toBeInTheDocument();
-  expect(screen.getByText('No Lightwell repositories are available yet.')).toBeInTheDocument();
+  renderRepositoriesTable();
+
+  expect(await screen.findByText('Java Validated')).toBeInTheDocument();
+  expect(
+    await screen.findByText(
+      'Maven artifacts with Red Hat backported fixes for known vulnerabilities in pinned versions.',
+    ),
+  ).toBeInTheDocument();
+  expect(await screen.findByText('Java (Maven)')).toBeInTheDocument();
+  expect(
+    await screen.findByText(defaultLightwellContentItem.package_count.toLocaleString()),
+  ).toBeInTheDocument();
 });

--- a/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
+++ b/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
@@ -1,25 +1,298 @@
-import { Grid } from '@patternfly/react-core';
+import {
+  Button,
+  Card,
+  Content,
+  Flex,
+  FlexItem,
+  Grid,
+  Label,
+  PageSection,
+  Pagination,
+  PaginationVariant,
+  Stack,
+} from '@patternfly/react-core';
+import { CodeIcon, JavaIcon, PythonIcon } from '@patternfly/react-icons';
+import { SkeletonTable } from '@patternfly/react-component-groups';
+import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { createUseStyles } from 'react-jss';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 import EmptyTableState from 'components/EmptyTableState/EmptyTableState';
 import Header from 'components/Header/Header';
+import Hide from 'components/Hide/Hide';
+import { FilterData } from 'services/Content/ContentApi';
+import { useContentListQuery } from 'services/Content/ContentQueries';
 
-const RepositoriesTable = () => (
-  <>
-    <Header
-      title='Lightwell - Repositories'
-      ouiaId='lightwell_header'
-      paragraph='Open source libraries rebuilt securely with backported fixes for known vulnerabilities.'
-    />
-    <Grid className={`${spacing.pxLg} ${spacing.ptMd}`}>
-      <EmptyTableState
-        notFiltered
-        itemName='repositories'
-        notFilteredBody='No Lightwell repositories are available yet.'
-        clearFilters={() => {}}
+import { LIGHTWELL_FEATURE_NAME, lightwellPerPageKey } from '../constants';
+import { getMockLightwellRepositoryList } from '../mockRepositories';
+import {
+  getEcosystemFromContentType,
+  formatEcosystemDisplay,
+  getRepositoryDescription,
+} from '../helpers';
+import ConnectRepositoryPopover from './components/ConnectRepositoryPopover';
+import { capitalize } from 'lodash';
+
+const useStyles = createUseStyles({
+  topContainer: {
+    justifyContent: 'space-between',
+    padding: '16px 24px',
+    height: 'fit-content',
+  },
+  bottomContainer: {
+    justifyContent: 'space-between',
+  },
+});
+
+const columns = [
+  { name: 'Repository', sortAttribute: 'name' },
+  { name: 'Ecosystem', sortAttribute: 'content_type' },
+  { name: 'Security level', sortAttribute: 'security_level' },
+  { name: 'Packages', sortAttribute: null },
+  { name: 'Builds', sortAttribute: null },
+] as const;
+
+const displayValue = (value?: string) => (value?.trim() ? value : '—');
+
+const formatRepositoryName = (
+  ecosystem?: string,
+  securityLevel?: string,
+  fallbackName?: string,
+) => {
+  const ecosystemLabel = ecosystem?.trim();
+  const securityLabel = securityLevel?.trim();
+
+  if (ecosystemLabel && securityLabel) {
+    return `${capitalize(ecosystemLabel)} ${capitalize(securityLabel)}`;
+  }
+
+  return fallbackName?.trim() || '—';
+};
+
+const RepositoriesTable = () => {
+  const classes = useStyles();
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const storedPerPage = Number(localStorage.getItem(lightwellPerPageKey)) || 20;
+  const [perPage, setPerPage] = useState(storedPerPage);
+  const filters: FilterData = {
+    feature_name: LIGHTWELL_FEATURE_NAME,
+  };
+
+  const useMock = false;
+
+  const mockQuery = useQuery({
+    queryKey: ['lightwell-repositories-mock', page, perPage, filters],
+    queryFn: () => getMockLightwellRepositoryList(page, perPage, filters),
+    placeholderData: keepPreviousData,
+    staleTime: 20000,
+    enabled: useMock,
+  });
+
+  const apiQuery = useContentListQuery(page, perPage, filters, '', [], !useMock);
+
+  const {
+    isLoading,
+    isError,
+    error,
+    data = { data: [], meta: { count: 0, limit: 20, offset: 0 } },
+  } = useMock ? mockQuery : apiQuery;
+
+  const {
+    data: repositories = [],
+    meta: { count = 0 },
+  } = data;
+
+  if (isError) throw error;
+
+  const onSetPage = (_, newPage: number) => setPage(newPage);
+
+  const onPerPageSelect = (_, newPerPage: number, newPage: number) => {
+    localStorage.setItem(lightwellPerPageKey, newPerPage.toString());
+    setPerPage(newPerPage);
+    setPage(newPage);
+  };
+
+  const paginationProps = {
+    isDisabled: isLoading,
+    itemCount: count,
+    perPage,
+    page,
+    onSetPage,
+    onPerPageSelect,
+  };
+
+  const countIsZero = count === 0;
+
+  return (
+    <>
+      <Header
+        title='Repositories'
+        ouiaId='lightwell-header'
+        paragraph='Browse Lightwell repositories by ecosystem and security level.'
+        showOpenSourceBadge={false}
       />
-    </Grid>
-  </>
-);
+      <PageSection hasBodyWrapper={false} className={spacing.pb_2xl}>
+        <Grid data-ouia-component-id='lightwell-repositories-page'>
+          <Hide hide={countIsZero || count < 10}>
+            <Flex
+              className={classes.topContainer}
+              data-ouia-component-id='lightwell-repositories-toolbar'
+            >
+              <FlexItem></FlexItem>
+              <FlexItem>
+                <Pagination
+                  id='lightwell-top-pagination'
+                  widgetId='lightwellTopPaginationWidgetId'
+                  isCompact
+                  {...paginationProps}
+                />
+              </FlexItem>
+            </Flex>
+          </Hide>
+          <Hide hide={!isLoading}>
+            <Stack>
+              <SkeletonTable
+                rows={perPage}
+                columnsCount={columns.length}
+                variant={TableVariant.compact}
+              />
+            </Stack>
+          </Hide>
+          <Hide hide={countIsZero || isLoading}>
+            <Stack>
+              <Card className={`${spacing.ptLg} ${spacing.pbXl} ${spacing.pxLg}`}>
+                <Stack>
+                  <Table
+                    aria-label='Lightwell repositories table'
+                    ouiaId='lightwell-repositories-table'
+                    variant={TableVariant.compact}
+                  >
+                    <Thead>
+                      <Tr>
+                        {columns.map((column) => (
+                          <Th key={column.name}>{column.name}</Th>
+                        ))}
+                      </Tr>
+                    </Thead>
+                    <Tbody>
+                      {repositories.map((repo) => {
+                        const {
+                          uuid,
+                          name,
+                          content_type,
+                          published_distribution_url,
+                          security_level,
+                          package_count,
+                          builds,
+                        } = repo;
+                        const ecosystem = getEcosystemFromContentType(content_type);
+
+                        return (
+                          <Tr key={uuid}>
+                            <Td dataLabel={columns[0].name} className={spacing.pMd}>
+                              <Flex direction={{ default: 'column' }} gap={{ default: 'gapSm' }}>
+                                <FlexItem>
+                                  {content_type === 'maven' ? (
+                                    <JavaIcon className={spacing.mrSm} />
+                                  ) : (
+                                    <PythonIcon className={spacing.mrSm} />
+                                  )}
+                                  <Button
+                                    variant='link'
+                                    isInline
+                                    ouiaId={`lightwell-repo-${uuid}`}
+                                    onClick={() => navigate(uuid)}
+                                  >
+                                    {formatRepositoryName(ecosystem, security_level, name)}
+                                  </Button>
+                                </FlexItem>
+                                <FlexItem>
+                                  <Content component='small'>
+                                    {displayValue(getRepositoryDescription(content_type))}
+                                  </Content>
+                                </FlexItem>
+                                <FlexItem>
+                                  <ConnectRepositoryPopover
+                                    repository={{
+                                      uuid,
+                                      name,
+                                      published_distribution_url,
+                                      content_type,
+                                    }}
+                                  >
+                                    <Label
+                                      isCompact
+                                      icon={<CodeIcon />}
+                                      variant='outline'
+                                      color='blue'
+                                      tabIndex={0}
+                                    >
+                                      Connect to this repository
+                                    </Label>
+                                  </ConnectRepositoryPopover>
+                                </FlexItem>
+                              </Flex>
+                            </Td>
+                            <Td className={spacing.pMd} dataLabel={columns[1].name}>
+                              {displayValue(formatEcosystemDisplay(content_type))}
+                            </Td>
+                            <Td className={spacing.pMd} dataLabel={columns[2].name}>
+                              {security_level?.trim() === 'validated' ? (
+                                <Label variant='outline' color='purple'>
+                                  {capitalize(security_level)}
+                                </Label>
+                              ) : security_level?.trim() === 'remediated' ? (
+                                <Label color='purple'>{capitalize(security_level)}</Label>
+                              ) : (
+                                '—'
+                              )}
+                            </Td>
+                            <Td className={spacing.pMd} dataLabel={columns[3].name}>
+                              {package_count.toLocaleString()}
+                            </Td>
+                            <Td className={spacing.pMd} dataLabel={columns[4].name}>
+                              {builds ? builds.toLocaleString() : 0}
+                            </Td>
+                          </Tr>
+                        );
+                      })}
+                    </Tbody>
+                  </Table>
+                  <Hide hide={countIsZero || count < 10}>
+                    <Flex className={classes.bottomContainer}>
+                      <FlexItem />
+                      <FlexItem>
+                        <Pagination
+                          id='lightwell-bottom-pagination'
+                          widgetId='lightwellBottomPaginationWidgetId'
+                          variant={PaginationVariant.bottom}
+                          {...paginationProps}
+                        />
+                      </FlexItem>
+                    </Flex>
+                  </Hide>
+                </Stack>
+              </Card>
+            </Stack>
+          </Hide>
+          <Hide hide={!countIsZero || isLoading}>
+            <Stack>
+              <EmptyTableState
+                notFiltered={true}
+                clearFilters={() => {}}
+                itemName='repositories'
+                notFilteredBody='No Lightwell repositories are available yet.'
+              />
+            </Stack>
+          </Hide>
+        </Grid>
+      </PageSection>
+    </>
+  );
+};
 
 export default RepositoriesTable;

--- a/src/Pages/Lightwell/Repositories/components/ConnectRepositoryPopover.tsx
+++ b/src/Pages/Lightwell/Repositories/components/ConnectRepositoryPopover.tsx
@@ -1,0 +1,118 @@
+import {
+  ClipboardCopy,
+  ClipboardCopyVariant,
+  Content,
+  Popover,
+  Stack,
+  StackItem,
+  Tab,
+  TabContent,
+  Tabs,
+  TabTitleText,
+} from '@patternfly/react-core';
+import { createRef, ReactElement, useMemo, useState } from 'react';
+import { createUseStyles } from 'react-jss';
+
+import { ContentItem } from 'services/Content/ContentApi';
+
+import { ConnectSnippetTab, getConnectSnippetTabs } from './connectSnippets';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+
+const useStyles = createUseStyles({
+  popoverBody: {
+    minWidth: '32rem',
+    maxWidth: '40rem',
+  },
+});
+
+type ConnectRepositoryPopoverProps = {
+  repository: Pick<ContentItem, 'name' | 'published_distribution_url' | 'content_type' | 'uuid'>;
+  children: ReactElement;
+};
+
+const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPopoverProps) => {
+  const classes = useStyles();
+  const tabs = useMemo(() => getConnectSnippetTabs(repository), [repository]);
+  const [activeTabKey, setActiveTabKey] = useState(tabs[0]?.eventKey ?? '');
+
+  const tabRefs = useMemo(
+    () =>
+      tabs.reduce(
+        (refs, tab) => {
+          refs[tab.eventKey] = createRef<HTMLElement>();
+          return refs;
+        },
+        {} as Record<string, React.RefObject<HTMLElement>>,
+      ),
+    [tabs],
+  );
+
+  const renderTabPanel = (tab: ConnectSnippetTab) => (
+    <Stack hasGutter>
+      {tab.snippets.map((snippet) => (
+        <StackItem key={snippet.label}>
+          <Content component='small' className={spacing.mMd}>
+            {snippet.label}
+          </Content>
+          <ClipboardCopy
+            isReadOnly
+            hoverTip='Copy'
+            clickTip='Copied'
+            variant={snippet.urlOnly ? ClipboardCopyVariant.inline : ClipboardCopyVariant.expansion}
+          >
+            {snippet.code}
+          </ClipboardCopy>
+        </StackItem>
+      ))}
+    </Stack>
+  );
+
+  const bodyContent = (
+    <div className={classes.popoverBody}>
+      <Tabs
+        activeKey={activeTabKey}
+        onSelect={(_, eventKey) => setActiveTabKey(eventKey as string)}
+        aria-label='Connect repository snippets'
+        ouiaId='lightwell-connect-snippets-tabs'
+      >
+        {tabs.map((tab) => (
+          <Tab
+            key={tab.eventKey}
+            eventKey={tab.eventKey}
+            title={<TabTitleText>{tab.title}</TabTitleText>}
+            tabContentRef={tabRefs[tab.eventKey]}
+            ouiaId={`lightwell-connect-tab-${tab.eventKey}`}
+          />
+        ))}
+      </Tabs>
+      {tabs.map((tab, index) => (
+        <TabContent
+          key={tab.eventKey}
+          eventKey={tab.eventKey}
+          id={`lightwell-connect-panel-${tab.eventKey}`}
+          aria-label={tab.title}
+          ref={tabRefs[tab.eventKey]}
+          hidden={index > 0}
+        >
+          {renderTabPanel(tab)}
+        </TabContent>
+      ))}
+    </div>
+  );
+
+  return (
+    <Popover
+      aria-label='Connect to this repository'
+      headerContent='Connect to this repository'
+      bodyContent={bodyContent}
+      position='right'
+      showClose={false}
+      minWidth='32rem'
+      maxWidth='40rem'
+    >
+      {children}
+    </Popover>
+  );
+};
+
+export default ConnectRepositoryPopover;

--- a/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
+++ b/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
@@ -1,0 +1,97 @@
+import { ContentItem } from 'services/Content/ContentApi';
+
+export interface ConnectCodeSnippet {
+  label: string;
+  code: string;
+  urlOnly?: boolean;
+}
+
+export interface ConnectSnippetTab {
+  eventKey: string;
+  title: string;
+  snippets: ConnectCodeSnippet[];
+}
+
+type RepositoryContext = Pick<ContentItem, 'name' | 'published_distribution_url' | 'content_type'>;
+
+const getMavenSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[] => {
+  const { name, published_distribution_url } = repository;
+
+  return [
+    {
+      eventKey: 'maven',
+      title: 'Maven',
+      snippets: [
+        {
+          label: 'Add to your settings.xml or pom.xml:',
+          code: `<repository>
+  <id>${name}</id>
+  <url>${published_distribution_url}</url>
+</repository>`,
+        },
+      ],
+    },
+    {
+      eventKey: 'gradle',
+      title: 'Gradle',
+      snippets: [
+        {
+          label: 'Add to your build gradle:',
+          code: `repositories {
+    maven {
+        url "${published_distribution_url}"
+    }
+}`,
+        },
+      ],
+    },
+  ];
+};
+
+const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[] => {
+  const { published_distribution_url } = repository;
+
+  return [
+    {
+      eventKey: 'pip',
+      title: 'pip',
+      snippets: [
+        {
+          label: 'pip install',
+          code: `pip install --index-url ${published_distribution_url} <package>`,
+        },
+      ],
+    },
+    {
+      eventKey: 'pip.conf',
+      title: 'pip.conf',
+      snippets: [
+        {
+          label: 'pip.conf',
+          code: `[global] index-url = ${published_distribution_url}`,
+        },
+      ],
+    },
+    {
+      eventKey: 'artifactory',
+      title: 'Artifactory',
+      snippets: [
+        {
+          label: 'Configure as a remote repository in Artifactory:',
+          code: published_distribution_url ? published_distribution_url : '',
+          urlOnly: true,
+        },
+      ],
+    },
+  ];
+};
+
+export const getConnectSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[] => {
+  const contentType = repository.content_type?.trim().toLowerCase();
+
+  if (contentType === 'maven') {
+    return getMavenSnippetTabs(repository);
+  }
+
+  return getPythonSnippetTabs(repository);
+};

--- a/src/Pages/Lightwell/constants.ts
+++ b/src/Pages/Lightwell/constants.ts
@@ -1,0 +1,14 @@
+export const LIGHTWELL_FEATURE_NAME = 'lightwell-network';
+
+export const lightwellPerPageKey = 'lightwellRepositoriesPerPage';
+
+export const CONTENT_TYPE_PARAMETERS: Record<string, { ecosystem: string; label: string }> = {
+  maven: { ecosystem: 'Java', label: 'Maven' },
+  pypi: { ecosystem: 'Python', label: 'PyPI' },
+};
+
+export const REPOSITORY_DESCRIPTIONS: Record<string, string> = {
+  maven:
+    'Maven artifacts with Red Hat backported fixes for known vulnerabilities in pinned versions.',
+  pypi: 'Python wheels with Red Hat backported fixes for known vulnerabilities in pinned versions.',
+};

--- a/src/Pages/Lightwell/helpers.ts
+++ b/src/Pages/Lightwell/helpers.ts
@@ -1,0 +1,22 @@
+import { CONTENT_TYPE_PARAMETERS, REPOSITORY_DESCRIPTIONS } from './constants';
+
+const getContentTypeParameters = (contentType?: string) => {
+  const normalized = contentType?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  return CONTENT_TYPE_PARAMETERS[normalized];
+};
+
+export const getEcosystemFromContentType = (contentType?: string): string | undefined =>
+  getContentTypeParameters(contentType)?.ecosystem;
+
+export const formatEcosystemDisplay = (contentType?: string): string | undefined => {
+  const config = getContentTypeParameters(contentType);
+  if (!config) return undefined;
+  return `${config.ecosystem} (${config.label})`;
+};
+
+export const getRepositoryDescription = (contentType?: string): string | undefined => {
+  const normalized = contentType?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  return REPOSITORY_DESCRIPTIONS[normalized];
+};

--- a/src/Pages/Lightwell/mockRepositories.ts
+++ b/src/Pages/Lightwell/mockRepositories.ts
@@ -1,0 +1,84 @@
+import { ContentItem, ContentListResponse, FilterData } from 'services/Content/ContentApi';
+
+const mockRepositories = [
+  {
+    uuid: '11111111-1111-4111-8111-111111111111',
+    name: 'lightwell/java/validated',
+    url: 'https://example.com/lightwell/java/validated',
+    description:
+      'Maven artifacts with Red Hat backported fixes for known vulnerabilities in pinned versions.',
+    security_level: 'Validated',
+    content_type: 'maven',
+    package_count: 1284,
+    last_introspection_status: 'Valid',
+    builds: 12,
+  },
+  {
+    uuid: '22222222-2222-4222-8222-222222222222',
+    name: 'lightwell/java/remediated',
+    url: 'https://example.com/lightwell/java/remediated',
+    description:
+      'Maven artifacts with Red Hat backported fixes for known vulnerabilities in pinned versions.',
+    security_level: 'Remediated',
+    content_type: 'maven',
+    package_count: 892,
+    last_introspection_status: 'Valid',
+    builds: 122,
+  },
+  {
+    uuid: '33333333-3333-4333-8333-333333333333',
+    name: 'lightwell/python/remediated',
+    url: 'https://example.com/lightwell/python/remediated',
+    description:
+      'Python wheels with Red Hat backported fixes for known vulnerabilities in pinned versions.',
+    security_level: 'Remediated',
+    content_type: 'pypi',
+    package_count: 456,
+    last_introspection_status: 'Valid',
+    builds: 59,
+  },
+  {
+    uuid: '44444444-4444-4444-8444-444444444444',
+    name: 'lightwell/python/validated',
+    url: 'https://example.com/lightwell/python/validated',
+    description:
+      'Python wheels with Red Hat backported fixes for known vulnerabilities in pinned versions.',
+    security_level: 'Validated',
+    content_type: 'pypi',
+    package_count: 1045,
+    last_introspection_status: 'Valid',
+    builds: 234,
+  },
+] as ContentItem[];
+
+export const getMockLightwellRepository = (uuid: string): ContentItem | undefined => {
+  const normalizedUuid = decodeURIComponent(uuid);
+  return mockRepositories.find((repo) => repo.uuid === normalizedUuid);
+};
+
+export const getMockLightwellRepositoryList = (
+  page: number,
+  perPage: number,
+  filters: FilterData,
+): ContentListResponse => {
+  const search = (filters.search ?? '').trim().toLowerCase();
+
+  let filtered = mockRepositories;
+
+  if (search) {
+    filtered = filtered.filter((repo) => repo.name.toLowerCase().includes(search));
+  }
+
+  const offset = (page - 1) * perPage;
+  const data = filtered.slice(offset, offset + perPage);
+
+  return {
+    data,
+    links: { first: '', last: '' },
+    meta: {
+      count: filtered.length,
+      limit: perPage,
+      offset,
+    },
+  };
+};

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -22,9 +22,16 @@ interface HeaderProps {
   ouiaId: string;
   paragraph: string;
   aboutData?: Omit<HelpPopoverProps, 'children'>;
+  showOpenSourceBadge?: boolean;
 }
 
-export default function Header({ title, ouiaId, paragraph, aboutData }: HeaderProps) {
+export default function Header({
+  title,
+  ouiaId,
+  paragraph,
+  aboutData,
+  showOpenSourceBadge,
+}: HeaderProps) {
   return (
     <PageHeader>
       <Flex className={`${spacing.mXs} ${spacing.pbSm}`} direction={{ default: 'column' }}>
@@ -43,9 +50,11 @@ export default function Header({ title, ouiaId, paragraph, aboutData }: HeaderPr
                   />
                 </HelpPopover>
               ) : null}
-              <span style={{ verticalAlign: '2px' }}>
-                <OpenSourceBadge repositoriesURL='https://github.com/content-services/content-sources-frontend' />
-              </span>
+              {showOpenSourceBadge !== false ? (
+                <span style={{ verticalAlign: '2px' }}>
+                  <OpenSourceBadge repositoriesURL='https://github.com/content-services/content-sources-frontend' />
+                </span>
+              ) : null}
             </>
           }
         />

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -28,6 +28,12 @@ export interface ContentItem {
   origin?: ContentOrigin;
   last_snapshot_task?: AdminTask;
   last_introspection_status: string;
+  content_type?: string;
+  description?: string;
+  ecosystem?: string;
+  security_level?: string;
+  builds?: number;
+  published_distribution_url?: string;
 }
 
 export interface PopularRepository {
@@ -156,6 +162,7 @@ export type FilterData = Partial<{
   urls: Array<string>;
   availableForArch: string;
   availableForVersion: string;
+  feature_name: string;
 }>;
 
 export type ValidateItem = {
@@ -381,6 +388,7 @@ export const getContentList: (
       available_for_version: filterData.availableForVersion,
       extended_release: extendedReleaseParam,
       extended_release_version: filterData.extended_release_version,
+      feature_name: filterData.feature_name,
     })}`,
   );
   return data;

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -85,7 +85,7 @@ const buildContentListKey = (
     '',
   )}${filterData?.versions?.join('')}${filterData?.urls?.join('')}${filterData?.uuids?.join(
     '',
-  )}${filterData?.statuses?.join('')}${filterData?.availableForArch}${filterData?.availableForVersion}${filterData?.search}${filterData?.extended_release}${filterData?.extended_release_version}`;
+  )}${filterData?.statuses?.join('')}${filterData?.availableForArch}${filterData?.availableForVersion}${filterData?.search}${filterData?.extended_release}${filterData?.extended_release_version}${filterData?.feature_name}`;
 
 export const useFetchContent = (uuid: string, enabled = true) =>
   useQuery({

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -389,6 +389,30 @@ export const defaultContentItemWithSnapshot: ContentItem = {
   last_introspection_status: '',
 };
 
+export const defaultLightwellContentItem: ContentItem = {
+  account_id: 'undefined',
+  distribution_arch: 'any',
+  distribution_versions: ['any'],
+  name: 'lightwell/java/validated',
+  org_id: '-3',
+  url: 'https://example.com/lightwell/java/validated',
+  uuid: '3875c35b-a67a-4ac2-a989-21139433c177',
+  package_count: 1000,
+  origin: ContentOrigin.CUSTOM,
+  status: '',
+  last_introspection_error: '',
+  last_introspection_time: '',
+  failed_introspections_count: 0,
+  gpg_key: '',
+  metadata_verification: false,
+  snapshot: false,
+  module_hotfixes: false,
+  last_introspection_status: '',
+  security_level: 'Validated',
+  content_type: 'maven',
+  builds: 13,
+};
+
 export const defaultTemplateItem: TemplateItem = {
   uuid: '50412eda-7df5-4fac-8556-278f45e2ef9b',
   name: 'Standard Template',


### PR DESCRIPTION
## Summary

Adds UI for listing Lightwell repos

## Testing steps

1. Check out this [PR](https://github.com/content-services/content-sources-backend/pull/1559)
2. Go to stage.foo.redhat.com/lightwell
3. Two maven repositories should be listed
4. The "Connect to this repository" popover snippets should be able to be viewed and copied
5. Clicking the repository name should route to the packages list (empty state)
