### PR TITLE
Lightwell: Hide submenu items that can get you away from Lightwell

### DIFF
--- a/src/LightwellApp.tsx
+++ b/src/LightwellApp.tsx
@@ -1,3 +1,4 @@
+import '../styles/lightwell-chrome-overrides.scss';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useEffect } from 'react';

--- a/styles/lightwell-chrome-overrides.scss
+++ b/styles/lightwell-chrome-overrides.scss
@@ -1,0 +1,12 @@
+// Hide 'My Profile', 'My User Access' and 'User Preferences' as they get you away from Lightwell and you cannot get back
+li.pf-v6-c-menu__list-item:has(> a[href*="/wapps/ugc/protected/personalInfo.html"]),
+li.pf-v6-c-menu__list-item:has(> a[href="/iam/my-user-access"]),
+li.pf-v6-c-menu__list-item:has(> a[href="/settings/notifications/user-preferences"]) {
+    display: none !important;
+}
+
+// Hide everything in the Settings menu except for Color scheme
+.chr-c-menu-settings .pf-v6-c-menu__group:not(:has([data-ouia-component-id="settings-menu-color-system"])),
+.chr-c-menu-settings .pf-v6-c-divider {
+    display: none !important;
+}


### PR DESCRIPTION
We want to make sure that customer cannot jump away from Lightwell if there is no way how to navigate back. Also we want to keep it as simple as possible not to distract customers with options that are not relevant for Lightwell.
