### PR TITLE
HMS-10953: update empty state for lightwell repos

### DIFF
--- a/src/Pages/Lightwell/Repositories/RepositoriesTable.test.tsx
+++ b/src/Pages/Lightwell/Repositories/RepositoriesTable.test.tsx
@@ -24,9 +24,7 @@ it('shows empty state when there are no repositories', async () => {
 
   renderRepositoriesTable();
 
-  expect(
-    await screen.findByText('No Lightwell repositories are available yet.'),
-  ).toBeInTheDocument();
+  expect(await screen.findByText('Lightwell members only')).toBeInTheDocument();
 });
 
 it('renders with a single row', async () => {

--- a/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
+++ b/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
@@ -20,7 +20,7 @@ import { useNavigate } from 'react-router-dom';
 import { createUseStyles } from 'react-jss';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
-import EmptyTableState from 'components/EmptyTableState/EmptyTableState';
+import EmptyTableState from './components/EmptyTableState';
 import Header from 'components/Header/Header';
 import Hide from 'components/Hide/Hide';
 import { FilterData } from 'services/Content/ContentApi';
@@ -281,12 +281,7 @@ const RepositoriesTable = () => {
           </Hide>
           <Hide hide={!countIsZero || isLoading}>
             <Stack>
-              <EmptyTableState
-                notFiltered={true}
-                clearFilters={() => {}}
-                itemName='repositories'
-                notFilteredBody='No Lightwell repositories are available yet.'
-              />
+              <EmptyTableState />
             </Stack>
           </Hide>
         </Grid>

--- a/src/Pages/Lightwell/Repositories/components/EmptyTableState.test.tsx
+++ b/src/Pages/Lightwell/Repositories/components/EmptyTableState.test.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react';
+import EmptyTableState from './EmptyTableState';
+
+it('Empty Lightwell state shows expected content', () => {
+  const { queryByText } = render(<EmptyTableState />);
+
+  expect(queryByText('Lightwell members only')).toBeInTheDocument();
+  expect(queryByText('Contact sales for access')).toBeInTheDocument();
+});

--- a/src/Pages/Lightwell/Repositories/components/EmptyTableState.tsx
+++ b/src/Pages/Lightwell/Repositories/components/EmptyTableState.tsx
@@ -1,0 +1,45 @@
+import { EmptyStateBody, EmptyState, EmptyStateVariant, Button } from '@patternfly/react-core';
+import { ExternalLinkAltIcon, LockIcon } from '@patternfly/react-icons';
+import { LIGHTWELL_PROJECT_URL } from 'Pages/Lightwell/constants';
+import { createUseStyles } from 'react-jss';
+
+const useStyles = createUseStyles({
+  emptyStateContainer: {
+    display: 'flex',
+    flexGrow: 1,
+  },
+  emptyStateBody: {
+    marginBottom: '16px',
+    textWrap: 'wrap',
+    maxWidth: '500px',
+  },
+});
+
+const EmptyTableState = () => {
+  const classes = useStyles();
+  return (
+    <EmptyState
+      headingLevel='h2'
+      icon={LockIcon}
+      titleText='Lightwell members only'
+      variant={EmptyStateVariant.full}
+      className={classes.emptyStateContainer}
+    >
+      <EmptyStateBody className={classes.emptyStateBody}>
+        <Button
+          variant='link'
+          component='a'
+          href={LIGHTWELL_PROJECT_URL}
+          icon={<ExternalLinkAltIcon />}
+          iconPosition='end'
+          target='_blank'
+          rel='noopener noreferrer'
+        >
+          Contact sales for access
+        </Button>
+      </EmptyStateBody>
+    </EmptyState>
+  );
+};
+
+export default EmptyTableState;

--- a/src/Pages/Lightwell/constants.ts
+++ b/src/Pages/Lightwell/constants.ts
@@ -12,3 +12,5 @@ export const REPOSITORY_DESCRIPTIONS: Record<string, string> = {
     'Maven artifacts with Red Hat backported fixes for known vulnerabilities in pinned versions.',
   pypi: 'Python wheels with Red Hat backported fixes for known vulnerabilities in pinned versions.',
 };
+
+export const LIGHTWELL_PROJECT_URL = 'https://www.redhat.com/en/lightwell#follow-our-progress';


### PR DESCRIPTION
## Summary

Updates empty state for the /lightwell route

## Testing steps

1. Log in with a user that doesn't have access to Lightwell and go to the /lightwell route
2. Should see "Lightwell members only" and a link routing to the Lightwell project page to request access

<img width="2388" height="828" alt="Screenshot From 2026-07-03 09-53-00" src="https://github.com/user-attachments/assets/c4b0e987-9210-46b0-a20d-06472a0141b4" />
