### PR TITLE
HMS-10952: add python to lightwell list

### DIFF
--- a/src/Pages/Lightwell/Repositories/components/ConnectRepositoryPopover.tsx
+++ b/src/Pages/Lightwell/Repositories/components/ConnectRepositoryPopover.tsx
@@ -22,6 +22,10 @@ const useStyles = createUseStyles({
   popoverBody: {
     minWidth: '32rem',
     maxWidth: '40rem',
+    '& .pf-v6-c-clipboard-copy__expandable-content': {
+      '--pf-v6-c-clipboard-copy__expandable-content--BorderColor':
+        'var(--pf-t--global--border--color--control--default)',
+    },
   },
 });
 
@@ -51,17 +55,23 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
     <Stack hasGutter>
       {tab.snippets.map((snippet) => (
         <StackItem key={snippet.label}>
-          <Content component='small' className={spacing.mMd}>
+          <Content component='small' style={{ textAlign: 'left' }}>
             {snippet.label}
           </Content>
           <ClipboardCopy
             isReadOnly
+            isCode
             hoverTip='Copy'
             clickTip='Copied'
             variant={snippet.urlOnly ? ClipboardCopyVariant.inline : ClipboardCopyVariant.expansion}
           >
             {snippet.code}
           </ClipboardCopy>
+          {snippet.description && (
+            <Content component='small' className={spacing.mtSm} style={{ textAlign: 'left' }}>
+              {snippet.description}
+            </Content>
+          )}
         </StackItem>
       ))}
     </Stack>
@@ -93,6 +103,7 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
           aria-label={tab.title}
           ref={tabRefs[tab.eventKey]}
           hidden={index > 0}
+          className={spacing.ptMd}
         >
           {renderTabPanel(tab)}
         </TabContent>

--- a/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
+++ b/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
@@ -4,6 +4,7 @@ export interface ConnectCodeSnippet {
   label: string;
   code: string;
   urlOnly?: boolean;
+  description?: string;
 }
 
 export interface ConnectSnippetTab {
@@ -57,7 +58,7 @@ const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[
       title: 'pip',
       snippets: [
         {
-          label: 'pip install',
+          label: 'Install directly:',
           code: `pip install --index-url ${published_distribution_url} <package>`,
         },
       ],
@@ -67,7 +68,7 @@ const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[
       title: 'pip.conf',
       snippets: [
         {
-          label: 'pip.conf',
+          label: 'Add to your pip.conf for permanent use:',
           code: `[global] index-url = ${published_distribution_url}`,
         },
       ],
@@ -80,6 +81,8 @@ const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[
           label: 'Configure as a remote repository in Artifactory:',
           code: published_distribution_url ? published_distribution_url : '',
           urlOnly: true,
+          description:
+            'Set the remote URL to this endpoint. Artifactory will proxy and cache packages automatically.',
         },
       ],
     },

--- a/src/Pages/Lightwell/constants.ts
+++ b/src/Pages/Lightwell/constants.ts
@@ -4,11 +4,12 @@ export const lightwellPerPageKey = 'lightwellRepositoriesPerPage';
 
 export const CONTENT_TYPE_PARAMETERS: Record<string, { ecosystem: string; label: string }> = {
   maven: { ecosystem: 'Java', label: 'Maven' },
-  pypi: { ecosystem: 'Python', label: 'PyPI' },
+  python: { ecosystem: 'Python', label: 'PyPI' },
 };
 
 export const REPOSITORY_DESCRIPTIONS: Record<string, string> = {
   maven:
     'Maven artifacts with Red Hat backported fixes for known vulnerabilities in pinned versions.',
-  pypi: 'Python wheels with Red Hat backported fixes for known vulnerabilities in pinned versions.',
+  python:
+    'Python wheels with Red Hat backported fixes for known vulnerabilities in pinned versions.',
 };


### PR DESCRIPTION
## Summary

This was implemented well previously and being handled generically :) just had to change the content type label 

## Testing steps
1. Use this PR: https://github.com/content-services/content-sources-backend/pull/1562
2. Navigate to the Lightwell page, see Python repository info
