### PR TITLE
HMS-10959,HMS-10961: add filtering, misc fixes

### DIFF
--- a/src/Hooks/useLightwellNavigate.ts
+++ b/src/Hooks/useLightwellNavigate.ts
@@ -1,0 +1,25 @@
+import { useNavigate } from 'react-router-dom';
+
+import { useLightwellRootPath } from './useLightwellRootPath';
+
+// Build Lightwell paths under the /lightwell mount point
+const buildLightwellNavigationPaths = (rootPath: string) => ({
+  repositories: () => rootPath,
+  repositoryPackages: (repoUUID: string) => `${rootPath}/${repoUUID}`,
+  packageDetails: (repoUUID: string, packageName: string) =>
+    `${rootPath}/${repoUUID}/${encodeURIComponent(packageName)}`,
+});
+
+export const useLightwellNavigate = () => {
+  const navigate = useNavigate();
+  const rootPath = useLightwellRootPath();
+  const paths = buildLightwellNavigationPaths(rootPath);
+
+  return {
+    paths,
+    goToRepositories: () => navigate(paths.repositories()),
+    goToRepositoryPackages: (repoUUID: string) => navigate(paths.repositoryPackages(repoUUID)),
+    goToPackageDetails: (repoUUID: string, packageName: string) =>
+      navigate(paths.packageDetails(repoUUID, packageName)),
+  };
+};

--- a/src/Hooks/useLightwellRootPath.ts
+++ b/src/Hooks/useLightwellRootPath.ts
@@ -1,0 +1,10 @@
+import { useMemo } from 'react';
+import { useHref } from 'react-router-dom';
+
+import { LIGHTWELL_ROUTE } from '../Pages/Lightwell/constants';
+
+// Resolves the Lightwell root path from the current route context
+export function useLightwellRootPath(): string {
+  const path = useHref(LIGHTWELL_ROUTE);
+  return useMemo(() => path.replace(/\/$/, '') || LIGHTWELL_ROUTE, [path]);
+}

--- a/src/LightwellApp.tsx
+++ b/src/LightwellApp.tsx
@@ -1,4 +1,3 @@
-import '../styles/lightwell-chrome-overrides.scss';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useEffect } from 'react';
@@ -6,7 +5,8 @@ import { Route, Routes } from 'react-router-dom';
 
 import { ErrorPage } from 'components/Error/ErrorPage';
 import usePageSafe from 'Hooks/usePageSafe';
-import PackagesList from 'Pages/Lightwell/Packages/PackagesList';
+import PackagesTable from 'Pages/Lightwell/Packages/PackagesTable';
+import PackageDetails from 'Pages/Lightwell/Packages/PackageDetails';
 import RepositoriesTable from 'Pages/Lightwell/Repositories/RepositoriesTable';
 import { useAppContext } from './middleware/AppContext';
 
@@ -33,7 +33,8 @@ export default function LightwellApp() {
       <div data-ouia-safe={pageSafe} />
       <Routes>
         <Route index element={<RepositoriesTable />} />
-        <Route path=':repoUUID' element={<PackagesList />} />
+        <Route path=':repoUUID' element={<PackagesTable />} />
+        <Route path=':repoUUID/:packageName' element={<PackageDetails />} />
       </Routes>
     </ErrorPage>
   );

--- a/src/Pages/Lightwell/Packages/PackageDetails.test.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+
+import PackageDetails from './PackageDetails';
+import {
+  useFetchContent,
+  useLightwellRepositoryPackagesQuery,
+} from 'services/Content/ContentQueries';
+import {
+  defaultLightwellContentItem,
+  defaultLightwellRepositoryPackageItem,
+  defaultLightwellRepositoryPackageResponse,
+  ReactQueryTestWrapper,
+} from 'testingHelpers';
+
+jest.mock('services/Content/ContentQueries', () => ({
+  useFetchContent: jest.fn(),
+  useLightwellRepositoryPackagesQuery: jest.fn(),
+}));
+
+const mockUseParams = jest.fn(() => ({
+  repoUUID: defaultLightwellContentItem.uuid,
+  packageName: 'missing-package',
+}));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+  useParams: () => mockUseParams(),
+}));
+
+jest.mock('../../../Hooks/useLightwellNavigate', () => ({
+  useLightwellNavigate: () => ({
+    goToRepositories: jest.fn(),
+    goToRepositoryPackages: jest.fn(),
+  }),
+}));
+
+const renderPackageDetails = () =>
+  render(
+    <ReactQueryTestWrapper>
+      <PackageDetails />
+    </ReactQueryTestWrapper>,
+  );
+
+beforeEach(() => {
+  mockUseParams.mockReturnValue({
+    repoUUID: defaultLightwellContentItem.uuid,
+    packageName: 'missing-package',
+  });
+});
+
+it('shows empty state', async () => {
+  mockUseParams.mockReturnValue({
+    repoUUID: defaultLightwellContentItem.uuid,
+    packageName: defaultLightwellRepositoryPackageItem.name,
+  });
+
+  (useFetchContent as jest.Mock).mockImplementation(() => ({
+    isLoading: false,
+    data: defaultLightwellContentItem,
+  }));
+  (useLightwellRepositoryPackagesQuery as jest.Mock).mockImplementation(() => ({
+    isLoading: false,
+    isFetching: false,
+    data: {
+      ...defaultLightwellRepositoryPackageResponse,
+      results: [{ ...defaultLightwellRepositoryPackageItem, versions: [], latest_releases: [] }],
+    },
+  }));
+
+  renderPackageDetails();
+
+  expect(await screen.findByText('No details available yet for this package.')).toBeInTheDocument();
+});

--- a/src/Pages/Lightwell/Packages/PackageDetails.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.tsx
@@ -1,0 +1,97 @@
+import { Breadcrumb, BreadcrumbItem, Grid, Stack, StackItem, Title } from '@patternfly/react-core';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { createUseStyles } from 'react-jss';
+import { useParams } from 'react-router-dom';
+
+import EmptyTableState from 'components/EmptyTableState/EmptyTableState';
+import Loader from 'components/Loader';
+import useSafeUUIDParam from 'Hooks/useSafeUUIDParam';
+import {
+  useFetchContent,
+  useLightwellRepositoryPackagesQuery,
+} from 'services/Content/ContentQueries';
+
+import { formatRepositoryName } from '../helpers';
+import { useLightwellNavigate } from '../../../Hooks/useLightwellNavigate';
+
+const useStyles = createUseStyles({
+  topContainer: {
+    padding: '16px 24px',
+  },
+  titleWrapper: {
+    padding: '24px 0 0',
+  },
+});
+
+const PackageDetails = () => {
+  const classes = useStyles();
+  const repoUUID = useSafeUUIDParam('repoUUID');
+  const { packageName: packageNameParam = '' } = useParams();
+  const { goToRepositories, goToRepositoryPackages } = useLightwellNavigate();
+  const packageName = packageNameParam ? decodeURIComponent(packageNameParam) : '';
+
+  const {
+    data: repository,
+    isLoading: isRepositoryLoading,
+    isError: isRepositoryError,
+    error: repositoryError,
+  } = useFetchContent(repoUUID, !!repoUUID);
+
+  const {
+    data: packages,
+    isLoading: isPackagesLoading,
+    isError: isPackagesError,
+    error: packagesError,
+  } = useLightwellRepositoryPackagesQuery(repoUUID, 1, 100, packageName, !!repoUUID);
+
+  if (isRepositoryLoading || !repository || isPackagesLoading || !packages) {
+    return <Loader />;
+  }
+
+  if (!repoUUID || isRepositoryError) throw repositoryError;
+  if (isPackagesError) throw packagesError;
+
+  const repositoryName = formatRepositoryName(
+    repository.content_type,
+    repository.security_level,
+    repository.name,
+  );
+
+  return (
+    <>
+      <Grid className={classes.topContainer}>
+        <Stack>
+          <StackItem>
+            <Breadcrumb ouiaId='lightwell-package-details-breadcrumb'>
+              <BreadcrumbItem component='button' onClick={goToRepositories}>
+                Lightwell
+              </BreadcrumbItem>
+              <BreadcrumbItem component='button' onClick={() => goToRepositoryPackages(repoUUID)}>
+                {repositoryName}
+              </BreadcrumbItem>
+              <BreadcrumbItem disabled>{packageName || '—'}</BreadcrumbItem>
+            </Breadcrumb>
+          </StackItem>
+          <StackItem className={classes.titleWrapper}>
+            <Title headingLevel='h1' ouiaId='lightwell-package-details-header'>
+              {packageName || 'Package details'}
+            </Title>
+          </StackItem>
+        </Stack>
+      </Grid>
+
+      <Grid className={spacing.pxLg}>
+        <Stack>
+          <EmptyTableState
+            notFiltered
+            clearFilters={() => undefined}
+            itemName='package details'
+            notFilteredBody='No details available yet for this package.'
+          />
+        </Stack>
+      </Grid>
+    </>
+  );
+};
+
+export default PackageDetails;

--- a/src/Pages/Lightwell/Packages/PackagesTable.test.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesTable.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+
+import PackagesTable from './PackagesTable';
+import {
+  useFetchContent,
+  useLightwellRepositoryPackagesQuery,
+} from 'services/Content/ContentQueries';
+import {
+  defaultLightwellContentItem,
+  defaultLightwellRepositoryPackageItem,
+  defaultLightwellRepositoryPackageResponse,
+  ReactQueryTestWrapper,
+} from 'testingHelpers';
+
+jest.mock('services/Content/ContentQueries', () => ({
+  useFetchContent: jest.fn(),
+  useLightwellRepositoryPackagesQuery: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+  useParams: () => ({
+    repoUUID: defaultLightwellContentItem.uuid,
+  }),
+  useMatch: () => ({ pathnameBase: '/lightwell' }),
+}));
+
+jest.mock('../../../Hooks/useLightwellNavigate', () => ({
+  useLightwellNavigate: () => ({
+    goToRepositories: jest.fn(),
+    goToPackageDetails: jest.fn(),
+  }),
+}));
+
+const renderPackagesTable = () =>
+  render(
+    <ReactQueryTestWrapper>
+      <PackagesTable />
+    </ReactQueryTestWrapper>,
+  );
+
+it('shows empty state when there are no packages', async () => {
+  (useFetchContent as jest.Mock).mockImplementation(() => ({
+    isLoading: false,
+    data: defaultLightwellContentItem,
+  }));
+  (useLightwellRepositoryPackagesQuery as jest.Mock).mockImplementation(() => ({
+    isLoading: false,
+    isFetching: false,
+    data: { ...defaultLightwellRepositoryPackageResponse, results: [], total: 0 },
+  }));
+
+  renderPackagesTable();
+
+  expect(
+    await screen.findByText('No packages available yet in this repository.'),
+  ).toBeInTheDocument();
+});
+
+it('renders with a single package', async () => {
+  (useFetchContent as jest.Mock).mockImplementation(() => ({
+    isLoading: false,
+    data: defaultLightwellContentItem,
+  }));
+  (useLightwellRepositoryPackagesQuery as jest.Mock).mockImplementation(() => ({
+    isLoading: false,
+    isFetching: false,
+    data: {
+      ...defaultLightwellRepositoryPackageResponse,
+      results: [defaultLightwellRepositoryPackageItem],
+      total: 1,
+    },
+  }));
+
+  renderPackagesTable();
+
+  expect(screen.queryAllByText('Java Validated')).toHaveLength(2);
+  expect(await screen.findByLabelText('Repository URL')).toHaveTextContent(
+    'https://example.com/lightwell/java/validated',
+  );
+  expect(await screen.findByText('org.json.test')).toBeInTheDocument();
+  expect(screen.queryByText('rhlw-3004-test')).not.toBeInTheDocument();
+  expect(await screen.findByLabelText('Copy 3.14.0')).toHaveTextContent('3.14.0');
+  expect(await screen.findByText('2026-07-01')).toBeInTheDocument();
+});

--- a/src/Pages/Lightwell/Packages/PackagesTable.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesTable.tsx
@@ -7,6 +7,7 @@ import {
   Flex,
   FlexItem,
   Grid,
+  Icon,
   Label,
   Pagination,
   PaginationVariant,
@@ -22,27 +23,35 @@ import { CopyIcon, CodeIcon, JavaIcon, PythonIcon } from '@patternfly/react-icon
 import { SkeletonTable } from '@patternfly/react-component-groups';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { createUseStyles } from 'react-jss';
-import { useMemo, useState, type ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Table, TableVariant, Tr, Td, Thead, Th, Tbody } from '@patternfly/react-table';
-
-import { useFetchContent, useRepositoryPackagesQuery } from 'services/Content/ContentQueries';
-import { RepositoryPackageItem } from 'services/Content/ContentApi';
-import { getMockLightwellPackages, LightwellPackage } from '../mockPackages';
+import { useState, type ReactNode } from 'react';
 import {
-  displayValue,
+  Table,
+  TableVariant,
+  Tr,
+  Td,
+  Thead,
+  Th,
+  Tbody,
+  type BaseCellProps,
+} from '@patternfly/react-table';
+
+import {
+  useLightwellRepositoryPackagesQuery,
+  useFetchContent,
+} from 'services/Content/ContentQueries';
+import { RepositoryPackageItem } from 'services/Content/ContentApi';
+import {
   formatRepositoryName,
-  getEcosystemFromContentType,
   getRepositoryDescription,
+  stripLightwellVersionSuffix,
 } from '../helpers';
 import Hide from 'components/Hide/Hide';
-import { LIGHTWELL_USE_MOCK, lightwellPkgsPerPageKey } from '../constants';
-import useSafeUUIDParam from 'Hooks/useSafeUUIDParam';
+import { lightwellPkgsPerPageKey } from '../constants';
 import EmptyTableState from 'components/EmptyTableState/EmptyTableState';
 import Loader from 'components/Loader';
-import { getMockLightwellRepository } from '../mockRepositories';
+import { useLightwellNavigate } from '../../../Hooks/useLightwellNavigate';
 import ConnectRepositoryPopover from '../Repositories/components/ConnectRepositoryPopover';
-import { useQuery } from '@tanstack/react-query';
+import useSafeUUIDParam from 'Hooks/useSafeUUIDParam';
 
 const useStyles = createUseStyles({
   topContainer: {
@@ -65,22 +74,15 @@ const useStyles = createUseStyles({
   },
 });
 
-type PackageColumn = {
-  id: 'package' | 'versions' | 'latestReleases' | 'namespace' | 'lastUpdated';
+type MappedPackage = {
+  group_id: string;
   name: string;
-  remediatedOnly?: boolean;
-  javaOnly?: boolean;
+  versions: string[];
+  latest_releases: string[];
+  last_updated: string;
 };
 
-const columns: PackageColumn[] = [
-  { id: 'package', name: 'Package' },
-  { id: 'versions', name: 'Versions' },
-  { id: 'latestReleases', name: 'Latest releases', remediatedOnly: true },
-  { id: 'namespace', name: 'Namespace', javaOnly: true },
-  { id: 'lastUpdated', name: 'Last updated' },
-];
-
-const mapRepositoryPackage = (pkg: RepositoryPackageItem): LightwellPackage => {
+const mapRepositoryPackage = (pkg: RepositoryPackageItem): MappedPackage => {
   const latestCreatedAt = pkg.latest_releases
     .map((release) => release.created_at)
     .sort()
@@ -89,7 +91,7 @@ const mapRepositoryPackage = (pkg: RepositoryPackageItem): LightwellPackage => {
   return {
     group_id: pkg.group,
     name: pkg.name,
-    versions: pkg.versions,
+    versions: pkg.versions.map(stripLightwellVersionSuffix),
     latest_releases: pkg.latest_releases.map((release) => release.release),
     last_updated: latestCreatedAt?.split('T')[0] ?? '—',
   };
@@ -142,16 +144,61 @@ const StackedItemsCell = ({
   );
 };
 
-const PackagesList = () => {
+const PackagesTable = () => {
   const classes = useStyles();
   const repoUUID = useSafeUUIDParam('repoUUID');
-  const navigate = useNavigate();
-  const useMock = LIGHTWELL_USE_MOCK;
+  const { goToRepositories, goToPackageDetails } = useLightwellNavigate();
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
   const storedPerPage = Number(localStorage.getItem(lightwellPkgsPerPageKey)) || 20;
   const [perPage, setPerPage] = useState(storedPerPage);
   const [expandedPackages, setExpandedPackages] = useState<Set<string>>(new Set());
+
+  const {
+    data: repository,
+    isLoading: isRepositoryLoading,
+    isError: isRepositoryError,
+    error: repositoryError,
+  } = useFetchContent(repoUUID, !!repoUUID);
+
+  const {
+    data: packagesData,
+    isLoading: isLoadingPackages,
+    isFetching: isFetchingPackages,
+    isError: isPackagesError,
+    error: packagesError,
+  } = useLightwellRepositoryPackagesQuery(repoUUID, page, perPage, search, !!repoUUID);
+
+  const results = packagesData?.results ?? [];
+  const packages = results.map(mapRepositoryPackage);
+  const packageCount = packagesData?.total ?? 0;
+
+  const countIsZero = packageCount === 0;
+  const showPagination = packages.length > 0;
+
+  if (isRepositoryLoading || !repository) {
+    return <Loader />;
+  }
+
+  if (!repoUUID || isRepositoryError) throw repositoryError;
+  if (isPackagesError) throw packagesError;
+
+  const onSetPage = (_, newPage: number) => setPage(newPage);
+
+  const onPerPageSelect = (_, newPerPage: number, newPage: number) => {
+    localStorage.setItem(lightwellPkgsPerPageKey, newPerPage.toString());
+    setPerPage(newPerPage);
+    setPage(newPage);
+  };
+
+  const paginationProps = {
+    isDisabled: isLoadingPackages || isFetchingPackages,
+    itemCount: packageCount,
+    perPage,
+    page,
+    onSetPage,
+    onPerPageSelect,
+  };
 
   const togglePackageExpanded = (packageKey: string) => {
     setExpandedPackages((prev) => {
@@ -165,86 +212,23 @@ const PackagesList = () => {
     });
   };
 
-  const mockRepositoryQuery = useQuery({
-    queryKey: ['lightwell-repository-mock', repoUUID],
-    queryFn: () => {
-      const mockRepository = getMockLightwellRepository(repoUUID);
-      if (!mockRepository) {
-        throw new Error('Lightwell repository not found');
-      }
-      return mockRepository;
-    },
-    staleTime: 20000,
-    enabled: useMock && !!repoUUID,
-  });
-
-  const apiRepositoryQuery = useFetchContent(repoUUID, !!repoUUID && !useMock);
-  const packagesQuery = useRepositoryPackagesQuery(repoUUID, page, perPage, !useMock && !!repoUUID);
-
-  const {
-    data: repository,
-    isLoading: isRepositoryLoading,
-    isError,
-    error,
-  } = useMock ? mockRepositoryQuery : apiRepositoryQuery;
-
-  const { packages, packageCount } = useMemo(() => {
-    if (useMock) {
-      const mockPackages = getMockLightwellPackages(repoUUID, search);
-      const offset = (page - 1) * perPage;
-      return {
-        packages: mockPackages.slice(offset, offset + perPage),
-        packageCount: mockPackages.length,
-      };
-    }
-
-    const results = packagesQuery.data?.results ?? [];
-    return {
-      packages: results.map(mapRepositoryPackage),
-      packageCount: packagesQuery.data?.total ?? 0,
-    };
-  }, [useMock, repoUUID, search, page, perPage, packagesQuery.data]);
-
-  const isLoadingPackages = useMock ? false : packagesQuery.isLoading || packagesQuery.isFetching;
-  const countIsZero = packageCount === 0;
-
-  if (isError) throw error;
-  if (!useMock && packagesQuery.isError) throw packagesQuery.error;
-
-  if (isRepositoryLoading || !repository) {
-    return <Loader />;
-  }
-
-  const onSetPage = (_, newPage: number) => setPage(newPage);
-
-  const onPerPageSelect = (_, newPerPage: number, newPage: number) => {
-    localStorage.setItem(lightwellPkgsPerPageKey, newPerPage.toString());
-    setPerPage(newPerPage);
-    setPage(newPage);
-  };
-
-  const paginationProps = {
-    isDisabled: isLoadingPackages,
-    itemCount: packageCount,
-    perPage,
-    page,
-    onSetPage,
-    onPerPageSelect,
-  };
-
-  const ecosystem = getEcosystemFromContentType(repository.content_type);
-  const repositoryName = formatRepositoryName(ecosystem, repository.security_level);
+  const repositoryName = formatRepositoryName(
+    repository.content_type,
+    repository.security_level,
+    repository.name,
+  );
   const isRemediatedRepository = repository.security_level === 'remediated';
   const isJavaRepository = repository.content_type === 'maven';
-  const visibleColumns = columns.filter((column) => {
-    if (column.remediatedOnly && !isRemediatedRepository) {
-      return false;
-    }
-    if (column.javaOnly && !isJavaRepository) {
-      return false;
-    }
-    return true;
-  });
+
+  const columnHeaders: { title: string; width?: BaseCellProps['width'] }[] = [
+    { title: 'Package', width: 25 },
+    { title: 'Version', width: 15 },
+    ...(isRemediatedRepository
+      ? [{ title: 'Latest release', width: 20 as BaseCellProps['width'] }]
+      : []),
+    ...(isJavaRepository ? [{ title: 'Namespace', width: 20 as BaseCellProps['width'] }] : []),
+    { title: 'Last updated', width: 15 },
+  ];
 
   return (
     <>
@@ -252,7 +236,7 @@ const PackagesList = () => {
         <Stack>
           <StackItem>
             <Breadcrumb ouiaId='lightwell-packages-breadcrumb'>
-              <BreadcrumbItem component='button' onClick={() => navigate('..')}>
+              <BreadcrumbItem component='button' onClick={goToRepositories}>
                 Lightwell
               </BreadcrumbItem>
               <BreadcrumbItem disabled>{repositoryName}</BreadcrumbItem>
@@ -266,7 +250,9 @@ const PackagesList = () => {
             >
               <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
                 <FlexItem>
-                  {repository?.content_type === 'maven' ? <JavaIcon /> : <PythonIcon />}
+                  <Icon size='xl'>
+                    {repository?.content_type === 'maven' ? <JavaIcon /> : <PythonIcon />}
+                  </Icon>
                 </FlexItem>
                 <FlexItem>
                   <Title headingLevel='h1' ouiaId='lightwell-packages-header'>
@@ -279,10 +265,10 @@ const PackagesList = () => {
                     icon={<CopyIcon />}
                     isCompact
                     onClick={() =>
-                      navigator.clipboard.writeText(repository?.published_distribution_url || '')
+                      navigator.clipboard.writeText(repository.published_distribution_url || '')
                     }
                   >
-                    {repository?.published_distribution_url}
+                    {repository.published_distribution_url}
                   </Label>
                 </FlexItem>
               </Flex>
@@ -295,20 +281,20 @@ const PackagesList = () => {
                     content_type: repository.content_type,
                   }}
                 >
-                  <Button variant='secondary' icon={<CodeIcon />}>
+                  <Button size='sm' variant='secondary' icon={<CodeIcon />}>
                     Connect
                   </Button>
                 </ConnectRepositoryPopover>
               </FlexItem>
             </Flex>
-            <Content className={`${spacing.pySm}`}>
-              {displayValue(getRepositoryDescription(repository?.content_type))}
+            <Content className={spacing.pySm}>
+              {getRepositoryDescription(repository.content_type)}
             </Content>
           </StackItem>
         </Stack>
       </Grid>
 
-      <Grid className={`${spacing.pxLg}`}>
+      <Grid className={spacing.pxLg}>
         <Toolbar ouiaId='lightwell-packages-toolbar'>
           <ToolbarContent>
             <ToolbarItem className={classes.filterToolbarItem}>
@@ -317,12 +303,18 @@ const PackagesList = () => {
                 aria-label='Filter by name or namespace'
                 placeholder='Filter by name or namespace'
                 value={search}
-                onChange={(_event, value) => setSearch(value)}
-                onClear={() => setSearch('')}
+                onChange={(_event, value) => {
+                  setSearch(value);
+                  setPage(1);
+                }}
+                onClear={() => {
+                  setSearch('');
+                  setPage(1);
+                }}
               />
             </ToolbarItem>
             <ToolbarItem variant='pagination' align={{ default: 'alignEnd' }}>
-              <Hide hide={countIsZero || packageCount < 10}>
+              <Hide hide={!showPagination}>
                 <Pagination
                   id='lightwell-top-pagination'
                   widgetId='lightwellTopPaginationWidgetId'
@@ -337,7 +329,7 @@ const PackagesList = () => {
         <Hide hide={!isLoadingPackages}>
           <SkeletonTable
             rows={perPage}
-            columnsCount={visibleColumns.length}
+            columnsCount={columnHeaders.length}
             variant={TableVariant.compact}
           />
         </Hide>
@@ -349,12 +341,14 @@ const PackagesList = () => {
                 <Table
                   aria-label='Lightwell packages table'
                   ouiaId='lightwell-packages-table'
-                  variant={TableVariant.compact}
+                  isStriped
                 >
                   <Thead>
                     <Tr>
-                      {visibleColumns.map((column) => (
-                        <Th key={column.id}>{column.name}</Th>
+                      {columnHeaders.map(({ title, width }) => (
+                        <Th key={title + 'column'} width={width} modifier='wrap'>
+                          {title}
+                        </Th>
                       ))}
                     </Tr>
                   </Thead>
@@ -364,11 +358,26 @@ const PackagesList = () => {
                       const packageKey = `${group_id}-${name}`;
                       const isCollapsed = !expandedPackages.has(packageKey);
 
+                      const renderVersionLabel = (version: string) => (
+                        <Label
+                          isCompact
+                          icon={<CopyIcon />}
+                          onClick={() =>
+                            navigator.clipboard.writeText(`${group_id}:${name}:${version}`)
+                          }
+                          aria-label={`Copy ${version}`}
+                        >
+                          {version}
+                        </Label>
+                      );
+
                       const renderReleaseLabel = (release: string) => (
                         <Label
                           isCompact
                           icon={<CopyIcon />}
-                          onClick={() => navigator.clipboard.writeText(release)}
+                          onClick={() =>
+                            navigator.clipboard.writeText(`${group_id}:${name}:${release}`)
+                          }
                           aria-label={`Copy ${release}`}
                         >
                           {release}
@@ -377,46 +386,49 @@ const PackagesList = () => {
 
                       return (
                         <Tr key={packageKey}>
-                          {visibleColumns.map((column) => (
-                            <Td key={column.id} dataLabel={column.name} className={spacing.pMd}>
-                              {column.id === 'package' && (
-                                <Button
-                                  variant='link'
-                                  isInline
-                                  ouiaId={`lightwell-package-${name}`}
-                                  onClick={() => navigate('#')}
-                                >
-                                  {name}
-                                </Button>
-                              )}
-                              {column.id === 'versions' && (
-                                <StackedItemsCell
-                                  items={versions}
-                                  packageKey={packageKey}
-                                  isCollapsed={isCollapsed}
-                                  onToggle={togglePackageExpanded}
-                                  showToggle
-                                />
-                              )}
-                              {column.id === 'latestReleases' && (
-                                <StackedItemsCell
-                                  items={latest_releases}
-                                  packageKey={packageKey}
-                                  isCollapsed={isCollapsed}
-                                  onToggle={togglePackageExpanded}
-                                  renderItem={renderReleaseLabel}
-                                />
-                              )}
-                              {column.id === 'namespace' && group_id}
-                              {column.id === 'lastUpdated' && last_updated}
+                          <Td>
+                            <Button
+                              variant='link'
+                              isInline
+                              ouiaId={`lightwell-package-${name}`}
+                              onClick={() => goToPackageDetails(repoUUID, name)}
+                            >
+                              {name}
+                            </Button>
+                          </Td>
+                          <Td>
+                            <StackedItemsCell
+                              items={versions}
+                              packageKey={packageKey}
+                              isCollapsed={isCollapsed}
+                              onToggle={togglePackageExpanded}
+                              showToggle
+                              renderItem={
+                                repository.security_level === 'validated'
+                                  ? renderVersionLabel
+                                  : undefined
+                              }
+                            />
+                          </Td>
+                          {isRemediatedRepository ? (
+                            <Td>
+                              <StackedItemsCell
+                                items={latest_releases}
+                                packageKey={packageKey}
+                                isCollapsed={isCollapsed}
+                                onToggle={togglePackageExpanded}
+                                renderItem={renderReleaseLabel}
+                              />
                             </Td>
-                          ))}
+                          ) : null}
+                          {isJavaRepository ? <Td>{group_id}</Td> : null}
+                          <Td>{last_updated}</Td>
                         </Tr>
                       );
                     })}
                   </Tbody>
                 </Table>
-                <Hide hide={countIsZero || packageCount < 10}>
+                <Hide hide={!showPagination}>
                   <Flex className={classes.bottomContainer}>
                     <FlexItem />
                     <FlexItem>
@@ -448,4 +460,4 @@ const PackagesList = () => {
   );
 };
 
-export default PackagesList;
+export default PackagesTable;

--- a/src/Pages/Lightwell/Repositories/RepositoriesTable.test.tsx
+++ b/src/Pages/Lightwell/Repositories/RepositoriesTable.test.tsx
@@ -10,6 +10,13 @@ jest.mock('services/Content/ContentQueries', () => ({
 
 jest.mock('react-router-dom', () => ({
   useNavigate: jest.fn(),
+  useMatch: () => ({ pathnameBase: '/lightwell' }),
+}));
+
+jest.mock('../../../Hooks/useLightwellNavigate', () => ({
+  useLightwellNavigate: () => ({
+    goToRepositoryPackages: jest.fn(),
+  }),
 }));
 
 const renderRepositoriesTable = () =>
@@ -27,7 +34,7 @@ it('shows empty state when there are no repositories', async () => {
   expect(await screen.findByText('Lightwell members only')).toBeInTheDocument();
 });
 
-it('renders with a single row', async () => {
+it('renders with a single repository', async () => {
   (useContentListQuery as jest.Mock).mockImplementation(() => ({
     isLoading: false,
     data: {
@@ -45,7 +52,6 @@ it('renders with a single row', async () => {
     ),
   ).toBeInTheDocument();
   expect(await screen.findByText('Java (Maven)')).toBeInTheDocument();
-  expect(
-    await screen.findByText(defaultLightwellContentItem.package_count.toLocaleString()),
-  ).toBeInTheDocument();
+  expect(await screen.findByText('1')).toBeInTheDocument();
+  expect(await screen.findByText('3')).toBeInTheDocument();
 });

--- a/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
+++ b/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
@@ -5,6 +5,7 @@ import {
   Flex,
   FlexItem,
   Grid,
+  Icon,
   Label,
   PageSection,
   Pagination,
@@ -13,10 +14,17 @@ import {
 } from '@patternfly/react-core';
 import { CodeIcon, JavaIcon, PythonIcon } from '@patternfly/react-icons';
 import { SkeletonTable } from '@patternfly/react-component-groups';
-import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import {
+  Table,
+  TableVariant,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  type BaseCellProps,
+} from '@patternfly/react-table';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { createUseStyles } from 'react-jss';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
@@ -26,15 +34,9 @@ import Hide from 'components/Hide/Hide';
 import { FilterData } from 'services/Content/ContentApi';
 import { useContentListQuery } from 'services/Content/ContentQueries';
 
-import { LIGHTWELL_FEATURE_NAME, LIGHTWELL_USE_MOCK, lightwellReposPerPageKey } from '../constants';
-import { getMockLightwellRepositoryList } from '../mockRepositories';
-import {
-  getEcosystemFromContentType,
-  formatEcosystemDisplay,
-  getRepositoryDescription,
-  formatRepositoryName,
-  displayValue,
-} from '../helpers';
+import { LIGHTWELL_FEATURE_NAME, lightwellReposPerPageKey } from '../constants';
+import { formatEcosystemDisplay, getRepositoryDescription, formatRepositoryName } from '../helpers';
+import { useLightwellNavigate } from '../../../Hooks/useLightwellNavigate';
 import ConnectRepositoryPopover from './components/ConnectRepositoryPopover';
 import { capitalize } from 'lodash';
 
@@ -49,17 +51,9 @@ const useStyles = createUseStyles({
   },
 });
 
-const columns = [
-  { name: 'Repository', sortAttribute: 'name' },
-  { name: 'Ecosystem', sortAttribute: 'content_type' },
-  { name: 'Security level', sortAttribute: 'security_level' },
-  { name: 'Packages', sortAttribute: null },
-  { name: 'Builds', sortAttribute: null },
-] as const;
-
 const RepositoriesTable = () => {
   const classes = useStyles();
-  const navigate = useNavigate();
+  const { goToRepositoryPackages } = useLightwellNavigate();
   const [page, setPage] = useState(1);
   const storedPerPage = Number(localStorage.getItem(lightwellReposPerPageKey)) || 20;
   const [perPage, setPerPage] = useState(storedPerPage);
@@ -67,24 +61,12 @@ const RepositoriesTable = () => {
     feature_name: LIGHTWELL_FEATURE_NAME,
   };
 
-  const useMock = LIGHTWELL_USE_MOCK;
-
-  const mockQuery = useQuery({
-    queryKey: ['lightwell-repositories-mock', page, perPage, filters],
-    queryFn: () => getMockLightwellRepositoryList(page, perPage, filters),
-    placeholderData: keepPreviousData,
-    staleTime: 20000,
-    enabled: useMock,
-  });
-
-  const apiQuery = useContentListQuery(page, perPage, filters, '', [], !useMock);
-
   const {
     isLoading,
     isError,
     error,
     data = { data: [], meta: { count: 0, limit: 20, offset: 0 } },
-  } = useMock ? mockQuery : apiQuery;
+  } = useContentListQuery(page, perPage, filters, '', []);
 
   const {
     data: repositories = [],
@@ -92,6 +74,14 @@ const RepositoriesTable = () => {
   } = data;
 
   if (isError) throw error;
+
+  const columnHeaders: { title: string; width?: BaseCellProps['width'] }[] = [
+    { title: 'Repository' },
+    { title: 'Ecosystem', width: 15 },
+    { title: 'Security level', width: 15 },
+    { title: 'Packages', width: 10 },
+    { title: 'Builds', width: 10 },
+  ];
 
   const onSetPage = (_, newPage: number) => setPage(newPage);
 
@@ -127,7 +117,6 @@ const RepositoriesTable = () => {
               className={classes.topContainer}
               data-ouia-component-id='lightwell-repositories-toolbar'
             >
-              <FlexItem></FlexItem>
               <FlexItem>
                 <Pagination
                   id='lightwell-top-pagination'
@@ -142,7 +131,7 @@ const RepositoriesTable = () => {
             <Stack>
               <SkeletonTable
                 rows={perPage}
-                columnsCount={columns.length}
+                columnsCount={columnHeaders.length}
                 variant={TableVariant.compact}
               />
             </Stack>
@@ -154,12 +143,14 @@ const RepositoriesTable = () => {
                   <Table
                     aria-label='Lightwell repositories table'
                     ouiaId='lightwell-repositories-table'
-                    variant={TableVariant.compact}
+                    isStriped
                   >
                     <Thead>
                       <Tr>
-                        {columns.map((column) => (
-                          <Th key={column.name}>{column.name}</Th>
+                        {columnHeaders.map(({ title, width }) => (
+                          <Th key={title + 'column'} width={width} modifier='wrap'>
+                            {title}
+                          </Th>
                         ))}
                       </Tr>
                     </Thead>
@@ -172,32 +163,32 @@ const RepositoriesTable = () => {
                           published_distribution_url,
                           security_level,
                           package_count,
-                          builds,
+                          build_count,
                         } = repo;
-                        const ecosystem = getEcosystemFromContentType(content_type);
 
                         return (
                           <Tr key={uuid}>
-                            <Td dataLabel={columns[0].name} className={spacing.pMd}>
-                              <Flex direction={{ default: 'column' }} gap={{ default: 'gapSm' }}>
-                                <FlexItem>
-                                  {content_type === 'maven' ? (
-                                    <JavaIcon className={spacing.mrSm} />
-                                  ) : (
-                                    <PythonIcon className={spacing.mrSm} />
-                                  )}
+                            <Td>
+                              <Flex direction={{ default: 'column' }} gap={{ default: 'gapXs' }}>
+                                <Flex
+                                  alignItems={{ default: 'alignItemsCenter' }}
+                                  gap={{ default: 'gapSm' }}
+                                >
+                                  <Icon size='xl'>
+                                    {content_type === 'maven' ? <JavaIcon /> : <PythonIcon />}
+                                  </Icon>
                                   <Button
                                     variant='link'
                                     isInline
                                     ouiaId={`lightwell-repo-${uuid}`}
-                                    onClick={() => navigate(uuid)}
+                                    onClick={() => goToRepositoryPackages(uuid)}
                                   >
-                                    {formatRepositoryName(ecosystem, security_level)}
+                                    {formatRepositoryName(content_type, security_level, name)}
                                   </Button>
-                                </FlexItem>
+                                </Flex>
                                 <FlexItem>
                                   <Content component='small'>
-                                    {displayValue(getRepositoryDescription(content_type))}
+                                    {getRepositoryDescription(content_type)}
                                   </Content>
                                 </FlexItem>
                                 <FlexItem>
@@ -222,10 +213,8 @@ const RepositoriesTable = () => {
                                 </FlexItem>
                               </Flex>
                             </Td>
-                            <Td className={spacing.pMd} dataLabel={columns[1].name}>
-                              {displayValue(formatEcosystemDisplay(content_type))}
-                            </Td>
-                            <Td className={spacing.pMd} dataLabel={columns[2].name}>
+                            <Td>{formatEcosystemDisplay(content_type)}</Td>
+                            <Td>
                               {security_level === 'validated' ? (
                                 <Label variant='outline' color='purple'>
                                   {capitalize(security_level)}
@@ -236,12 +225,8 @@ const RepositoriesTable = () => {
                                 '—'
                               )}
                             </Td>
-                            <Td className={spacing.pMd} dataLabel={columns[3].name}>
-                              {package_count.toLocaleString()}
-                            </Td>
-                            <Td className={spacing.pMd} dataLabel={columns[4].name}>
-                              {builds ? builds.toLocaleString() : 0}
-                            </Td>
+                            <Td>{package_count}</Td>
+                            <Td>{build_count ?? '0'}</Td>
                           </Tr>
                         );
                       })}

--- a/src/Pages/Lightwell/Repositories/components/ConnectRepositoryPopover.tsx
+++ b/src/Pages/Lightwell/Repositories/components/ConnectRepositoryPopover.tsx
@@ -38,6 +38,7 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
   const classes = useStyles();
   const tabs = useMemo(() => getConnectSnippetTabs(repository), [repository]);
   const [activeTabKey, setActiveTabKey] = useState(tabs[0]?.eventKey ?? '');
+  const firstTabKey = tabs[0]?.eventKey ?? '';
 
   const tabRefs = useMemo(
     () =>
@@ -118,9 +119,9 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
       headerContent='Connect to this repository'
       bodyContent={bodyContent}
       position='right'
-      showClose={false}
       minWidth='32rem'
       maxWidth='40rem'
+      onHide={() => setActiveTabKey(firstTabKey)}
     >
       {children}
     </Popover>

--- a/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
+++ b/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
@@ -103,7 +103,7 @@ const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[
 };
 
 export const getConnectSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[] => {
-  const contentType = repository.content_type?.trim().toLowerCase();
+  const contentType = repository.content_type;
 
   if (contentType === 'maven') {
     return getMavenSnippetTabs(repository);

--- a/src/Pages/Lightwell/constants.ts
+++ b/src/Pages/Lightwell/constants.ts
@@ -1,6 +1,6 @@
 export const LIGHTWELL_FEATURE_NAME = 'lightwell-network';
 
-export const LIGHTWELL_USE_MOCK = false;
+export const LIGHTWELL_ROUTE = '/lightwell';
 
 export const lightwellReposPerPageKey = 'lightwellRepositoriesPerPage';
 

--- a/src/Pages/Lightwell/helpers.ts
+++ b/src/Pages/Lightwell/helpers.ts
@@ -2,7 +2,7 @@ import { capitalize } from 'lodash';
 import { CONTENT_TYPE_PARAMETERS, REPOSITORY_DESCRIPTIONS } from './constants';
 
 const getContentTypeParameters = (contentType?: string) => {
-  const normalized = contentType?.trim().toLowerCase();
+  const normalized = contentType?.toLowerCase();
   if (!normalized) return undefined;
   return CONTENT_TYPE_PARAMETERS[normalized];
 };
@@ -17,24 +17,24 @@ export const formatEcosystemDisplay = (contentType?: string): string | undefined
 };
 
 export const getRepositoryDescription = (contentType?: string): string | undefined => {
-  const normalized = contentType?.trim().toLowerCase();
+  const normalized = contentType?.toLowerCase();
   if (!normalized) return undefined;
   return REPOSITORY_DESCRIPTIONS[normalized];
 };
 
 export const formatRepositoryName = (
-  ecosystem?: string,
+  contentType?: string,
   securityLevel?: string,
   fallbackName?: string,
 ) => {
-  const ecosystemLabel = ecosystem?.trim();
-  const securityLabel = securityLevel?.trim();
+  const ecosystem = getEcosystemFromContentType(contentType);
 
-  if (ecosystemLabel && securityLabel) {
-    return `${capitalize(ecosystemLabel)} ${capitalize(securityLabel)}`;
+  if (ecosystem && securityLevel) {
+    return `${capitalize(ecosystem)} ${capitalize(securityLevel)}`;
   }
 
-  return fallbackName?.trim() || '—';
+  return fallbackName || '—';
 };
 
-export const displayValue = (value?: string) => (value?.trim() ? value : '—');
+export const stripLightwellVersionSuffix = (version: string): string =>
+  version.replace(/\.rhlw-.*$/, '');

--- a/src/Pages/Lightwell/mockPackages.ts
+++ b/src/Pages/Lightwell/mockPackages.ts
@@ -1,84 +1,105 @@
-export type LightwellPackage = {
-  group_id: string;
-  name: string;
-  versions: string[];
-  latest_releases: string[];
-  last_updated: string;
-};
+import { RepositoryPackageItem } from 'services/Content/ContentApi';
 
-const mockPackagesByRepository: Record<string, LightwellPackage[]> = {
+const mockPackagesByRepository: Record<string, RepositoryPackageItem[]> = {
   '33333333-3333-4333-8333-333333333333': [
     {
       name: 'python-requests',
-      group_id: '',
+      group: '',
       versions: ['2.32.3', '2.32.4'],
-      latest_releases: ['rhlw-3001'],
-      last_updated: '2026-07-01',
+      latest_releases: [
+        { version: '2.32.3', release: 'rhlw-3001', created_at: '2026-07-01T00:00:00Z' },
+        { version: '2.32.4', release: 'rhlw-3002', created_at: '2026-07-01T00:00:00Z' },
+      ],
     },
     {
       name: 'python-urllib3',
+      group: '',
       versions: ['2.2.2'],
-      latest_releases: ['rhlw-3002'],
-      last_updated: '2026-07-01',
-      group_id: '',
+      latest_releases: [
+        { version: '2.2.2', release: 'rhlw-3002', created_at: '2026-07-01T00:00:00Z' },
+      ],
     },
   ],
   '11111111-1111-4111-8111-111111111111': [
     {
       name: 'commons-fileupload',
-      group_id: 'commons-fileupload',
+      group: 'commons-fileupload',
       versions: ['2.17.1'],
-      latest_releases: ['rhlw-3003'],
-      last_updated: '2026-07-01',
+      latest_releases: [
+        { version: '2.17.1', release: 'rhlw-3003', created_at: '2026-07-01T00:00:00Z' },
+      ],
     },
     {
       name: 'json',
-      group_id: 'org.json',
+      group: 'org.json',
       versions: ['3.14.0'],
-      latest_releases: ['rhlw-3004'],
-      last_updated: '2026-07-01',
+      latest_releases: [
+        { version: '3.14.0', release: 'rhlw-3004', created_at: '2026-07-01T00:00:00Z' },
+      ],
     },
     {
       name: 'httpclient',
-      group_id: 'org.apache.httpcomponents',
+      group: 'org.apache.httpcomponents',
       versions: ['32.1.3'],
-      latest_releases: ['rhlw-3005'],
-      last_updated: '2026-07-01',
+      latest_releases: [
+        { version: '32.1.3', release: 'rhlw-3005', created_at: '2026-07-01T00:00:00Z' },
+      ],
     },
   ],
   '22222222-2222-4222-8222-222222222222': [
     {
       name: 'json',
-      group_id: 'org.json',
+      group: 'org.json',
       versions: ['20220320.0.0'],
-      latest_releases: ['20220320.0.0.rhlw-00001'],
-      last_updated: '2026-07-01',
+      latest_releases: [
+        {
+          version: '20220320.0.0',
+          release: '20220320.0.0.rhlw-00001',
+          created_at: '2026-07-01T00:00:00Z',
+        },
+      ],
     },
     {
       name: 'json-path',
-      group_id: 'com.jayway.jsonpath',
+      group: 'com.jayway.jsonpath',
       versions: ['2.8.0', '2.7.0'],
-      latest_releases: ['2.8.0.rhlw-00001', '2.7.0.rhlw-00001'],
-      last_updated: '2026-07-01',
+      latest_releases: [
+        { version: '2.8.0', release: '2.8.0.rhlw-00001', created_at: '2026-07-01T00:00:00Z' },
+        { version: '2.7.0', release: '2.7.0.rhlw-00001', created_at: '2026-07-01T00:00:00Z' },
+      ],
     },
     {
       name: 'json-smart',
-      group_id: 'net.minidev',
+      group: 'net.minidev',
       versions: ['2.5.0', '2.4.8'],
-      latest_releases: ['2.5.0.rhlw-00001', '2.4.8.rhlw-00001'],
-      last_updated: '2026-07-01',
+      latest_releases: [
+        { version: '2.5.0', release: '2.5.0.rhlw-00001', created_at: '2026-07-01T00:00:00Z' },
+        { version: '2.4.8', release: '2.4.8.rhlw-00001', created_at: '2026-07-01T00:00:00Z' },
+      ],
     },
   ],
 };
 
-export const getMockLightwellPackages = (repoUUID: string, search = ''): LightwellPackage[] => {
+export const getMockLightwellPackages = (
+  repoUUID: string,
+  search = '',
+): RepositoryPackageItem[] => {
   const normalizedUuid = decodeURIComponent(repoUUID);
   const packages = mockPackagesByRepository[normalizedUuid] ?? [];
-  const query = search.trim().toLowerCase();
+  const normalizedSearch = search.trim().toLowerCase();
 
-  const filtered = query
-    ? packages.filter((pkg) => pkg.name.toLowerCase().includes(query))
-    : packages;
+  if (!normalizedSearch) {
+    return packages;
+  }
 
-  return filtered;
+  return packages.filter(
+    (pkg) =>
+      pkg.name.toLowerCase().includes(normalizedSearch) ||
+      pkg.group.toLowerCase().includes(normalizedSearch),
+  );
 };
+
+export const getMockLightwellRepositoryPackageCounts = (
+  repoUuids: string[],
+): Record<string, number> =>
+  Object.fromEntries(repoUuids.map((uuid) => [uuid, getMockLightwellPackages(uuid).length]));

--- a/src/Pages/Lightwell/mockRepositories.ts
+++ b/src/Pages/Lightwell/mockRepositories.ts
@@ -10,9 +10,8 @@ const mockRepositories = [
       'Maven artifacts with Red Hat backported fixes for known vulnerabilities in pinned versions.',
     security_level: 'validated',
     content_type: 'maven',
-    package_count: 1284,
-    last_introspection_status: 'Valid',
-    builds: 12,
+    package_count: 10,
+    build_count: 24,
   },
   {
     uuid: '22222222-2222-4222-8222-222222222222',
@@ -23,9 +22,8 @@ const mockRepositories = [
       'Maven artifacts with Red Hat backported fixes for known vulnerabilities in pinned versions.',
     security_level: 'remediated',
     content_type: 'maven',
-    package_count: 892,
-    last_introspection_status: 'Valid',
-    builds: 122,
+    package_count: 11,
+    build_count: 28,
   },
   {
     uuid: '33333333-3333-4333-8333-333333333333',
@@ -35,10 +33,9 @@ const mockRepositories = [
     description:
       'Python wheels with Red Hat backported fixes for known vulnerabilities in pinned versions.',
     security_level: 'remediated',
-    content_type: 'pypi',
-    package_count: 456,
-    last_introspection_status: 'Valid',
-    builds: 59,
+    content_type: 'python',
+    package_count: 13,
+    build_count: 31,
   },
   {
     uuid: '44444444-4444-4444-8444-444444444444',
@@ -48,10 +45,9 @@ const mockRepositories = [
     description:
       'Python wheels with Red Hat backported fixes for known vulnerabilities in pinned versions.',
     security_level: 'validated',
-    content_type: 'pypi',
-    package_count: 1045,
-    last_introspection_status: 'Valid',
-    builds: 234,
+    content_type: 'python',
+    package_count: 10,
+    build_count: 22,
   },
 ] as ContentItem[];
 

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -32,8 +32,8 @@ export interface ContentItem {
   description?: string;
   ecosystem?: string;
   security_level?: string;
-  builds?: number;
   published_distribution_url?: string;
+  build_count?: number;
 }
 
 export interface PopularRepository {
@@ -521,15 +521,17 @@ export const getPackages: (
   return data;
 };
 
-export const getRepositoryPackages: (
+export const getLightwellRepositoryPackages: (
   uuid: string,
   page: number,
   limit: number,
-) => Promise<RepositoryPackagesResponse> = async (uuid, page, limit) => {
+  search?: string,
+) => Promise<RepositoryPackagesResponse> = async (uuid, page, limit, search = '') => {
   const { data } = await axios.get(
     `/api/content-sources/v1/repositories/${uuid}/packages?${objectToUrlParams({
       offset: ((page - 1) * limit).toString(),
       limit: limit.toString(),
+      search,
     })}`,
   );
   return data;

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -22,7 +22,6 @@ import {
   EditContentListItem,
   getGpgKey,
   getPackages,
-  getRepositoryPackages,
   getPopularRepositories,
   PopularRepositoriesResponse,
   CreateContentRequestResponse,
@@ -49,6 +48,7 @@ import {
   getLatestRepoConfigFile,
   PopularRepository,
   bulkRemoveRepositoryRpms,
+  getLightwellRepositoryPackages,
 } from './ContentApi';
 import { ADMIN_TASK_LIST_KEY } from '../Admin/AdminTaskQueries';
 import useErrorNotification from 'Hooks/useErrorNotification';
@@ -66,7 +66,7 @@ export const POPULAR_REPOSITORIES_LIST_KEY = 'POPULAR_REPOSITORIES_LIST_KEY';
 export const REPOSITORY_PARAMS_KEY = 'REPOSITORY_PARAMS_KEY';
 export const CREATE_PARAMS_KEY = 'CREATE_PARAMS_KEY';
 export const PACKAGES_KEY = 'PACKAGES_KEY';
-export const REPOSITORY_PACKAGES_KEY = 'REPOSITORY_PACKAGES_KEY';
+export const LIGHTWELL_REPOSITORY_PACKAGES_KEY = 'LIGHTWELL_REPOSITORY_PACKAGES_KEY';
 export const SNAPSHOT_PACKAGES_KEY = 'SNAPSHOT_PACKAGES_KEY';
 export const SNAPSHOT_ERRATA_KEY = 'SNAPSHOT_ERRATA_KEY';
 export const LIST_SNAPSHOTS_KEY = 'LIST_SNAPSHOTS_KEY';
@@ -667,21 +667,22 @@ export const useGetPackagesQuery = (
     },
   });
 
-export const useRepositoryPackagesQuery = (
+export const useLightwellRepositoryPackagesQuery = (
   uuid: string,
   page: number,
   limit: number,
+  search = '',
   enabled = true,
 ) =>
   useQuery({
-    queryKey: [REPOSITORY_PACKAGES_KEY, uuid, page, limit],
-    queryFn: () => getRepositoryPackages(uuid, page, limit),
+    queryKey: [LIGHTWELL_REPOSITORY_PACKAGES_KEY, uuid, page, limit, search],
+    queryFn: () => getLightwellRepositoryPackages(uuid, page, limit, search),
     placeholderData: keepPreviousData,
     staleTime: 60000,
     enabled: enabled && !!uuid,
     meta: {
       title: 'Unable to find packages for the repository.',
-      id: 'repository-packages-list-error',
+      id: 'lightwell-repository-packages-list-error',
     },
   });
 

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -11,6 +11,8 @@ import {
   ValidationResponse,
   type ErrataItem,
   type Package,
+  type RepositoryPackageItem,
+  type RepositoryPackagesResponse,
   ContentOrigin,
 } from 'services/Content/ContentApi';
 import { AdminTask } from 'services/Admin/AdminTaskApi';
@@ -395,9 +397,11 @@ export const defaultLightwellContentItem: ContentItem = {
   distribution_versions: ['any'],
   name: 'lightwell/java/validated',
   org_id: '-3',
-  url: 'https://example.com/lightwell/java/validated',
+  url: '',
+  published_distribution_url: 'https://example.com/lightwell/java/validated',
   uuid: '3875c35b-a67a-4ac2-a989-21139433c177',
-  package_count: 1000,
+  package_count: 1,
+  build_count: 3,
   origin: ContentOrigin.CUSTOM,
   status: '',
   last_introspection_error: '',
@@ -408,9 +412,24 @@ export const defaultLightwellContentItem: ContentItem = {
   snapshot: false,
   module_hotfixes: false,
   last_introspection_status: '',
-  security_level: 'Validated',
+  security_level: 'validated',
   content_type: 'maven',
-  builds: 13,
+};
+
+export const defaultLightwellRepositoryPackageItem: RepositoryPackageItem = {
+  group: 'org.json.test',
+  name: 'json-test',
+  versions: ['3.14.0'],
+  latest_releases: [
+    { version: '3.14.0', release: 'rhlw-3004-test', created_at: '2026-07-01T00:00:00Z' },
+  ],
+};
+
+export const defaultLightwellRepositoryPackageResponse: RepositoryPackagesResponse = {
+  results: [defaultLightwellRepositoryPackageItem],
+  total: 1,
+  limit: 20,
+  offset: 0,
 };
 
 export const defaultTemplateItem: TemplateItem = {


### PR DESCRIPTION
## Summary

- Adds package filtering by name/group (depends on tang and backend PRs)
- Adds routing and empty state for package details
- Removed mock branches
- Other misc fixes: formatting of versions on remediated repos, version/latest release column names, added close button to popover, resized Java/Python icons, formatting of copied version/latest release, routing by repo/package name

## Testing steps
