### PR TITLE
HMS-10964: Fix version switching and add group to route

### DIFF
--- a/src/LightwellApp.tsx
+++ b/src/LightwellApp.tsx
@@ -33,6 +33,7 @@ export default function LightwellApp() {
       <div data-ouia-safe={pageSafe} />
       <Routes>
         <Route index element={<RepositoriesTable />} />
+        <Route path=':repoName/:group/:packageName' element={<PackageDetails />} />
         <Route path=':repoName/:packageName' element={<PackageDetails />} />
         <Route path=':repoName' element={<PackagesTable />} />
       </Routes>

--- a/src/Pages/Lightwell/Packages/PackageDetails.test.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import PackageDetails from './PackageDetails';
 import {
   useLightwellRepositoryPackagesQuery,
-  useMavenPackageDetailQuery,
+  useMavenPackageVersionsListQuery,
   usePythonPackageVersionsQuery,
 } from 'services/Content/ContentQueries';
 import {
@@ -35,8 +35,7 @@ import useLightwellRepository from '../useLightwellRepository';
 
 jest.mock('services/Content/ContentQueries', () => ({
   useLightwellRepositoryPackagesQuery: jest.fn(),
-  useMavenPackageDetailQuery: jest.fn(),
-  useMavenPackageVersionsPreload: jest.fn(() => []),
+  useMavenPackageVersionsListQuery: jest.fn(),
   usePythonPackageVersionsQuery: jest.fn(),
 }));
 
@@ -49,10 +48,10 @@ const defaultRepoSlug = getRepositoryPathSlug(
 
 const packageName = defaultLightwellRepositoryPackageItem.name;
 
-const mockUseParams = jest.fn(() => ({
-  repoUUID: defaultLightwellContentItem.uuid,
-  packageName: 'missing-package',
-}));
+const mockUseParams = jest.fn<
+  Partial<{ repoName: string; group: string; packageName: string }>,
+  []
+>();
 
 jest.mock('react-router-dom', () => ({
   useNavigate: jest.fn(),
@@ -100,15 +99,24 @@ type PackageMetadata = {
   project_url?: string;
 };
 
-const mockPackageDetailQuery = (builds = defaultBuilds, metadata: PackageMetadata = {}) => ({
+const mockVersionsListQuery = (
+  builds = defaultBuilds,
+  metadata: PackageMetadata = {},
+  version = '3.14.0',
+) => ({
   isLoading: false,
-  isFetching: false,
   data: {
     group: defaultLightwellRepositoryPackageItem.group,
     name: defaultLightwellRepositoryPackageItem.name,
-    version: '3.14.0',
-    builds,
-    ...metadata,
+    versions: [
+      {
+        group: defaultLightwellRepositoryPackageItem.group,
+        name: defaultLightwellRepositoryPackageItem.name,
+        version,
+        builds,
+        ...metadata,
+      },
+    ],
   },
 });
 
@@ -131,7 +139,8 @@ const renderPackageDetails = () =>
 
 beforeEach(() => {
   mockUseParams.mockReturnValue({
-    repoUUID: defaultRepoSlug,
+    repoName: defaultRepoSlug,
+    group: defaultLightwellRepositoryPackageItem.group,
     packageName,
   });
   (useLightwellRepository as jest.Mock).mockReturnValue({
@@ -142,7 +151,7 @@ beforeEach(() => {
     error: undefined,
   });
   (useLightwellRepositoryPackagesQuery as jest.Mock).mockImplementation(mockPackagesQuery);
-  (useMavenPackageDetailQuery as jest.Mock).mockImplementation(() => mockPackageDetailQuery());
+  (useMavenPackageVersionsListQuery as jest.Mock).mockImplementation(() => mockVersionsListQuery());
   (usePythonPackageVersionsQuery as jest.Mock).mockImplementation(() => ({
     isLoading: false,
     isFetching: false,
@@ -151,7 +160,9 @@ beforeEach(() => {
 });
 
 it('shows empty state when the package has no builds', async () => {
-  (useMavenPackageDetailQuery as jest.Mock).mockImplementation(() => mockPackageDetailQuery([]));
+  (useMavenPackageVersionsListQuery as jest.Mock).mockImplementation(() =>
+    mockVersionsListQuery([]),
+  );
 
   renderPackageDetails();
 
@@ -168,14 +179,14 @@ const setupNoReleasePackage = () => {
       total: 1,
     },
   }));
-  (useMavenPackageDetailQuery as jest.Mock).mockImplementation(() =>
-    mockPackageDetailQuery(noReleaseBuilds),
+  (useMavenPackageVersionsListQuery as jest.Mock).mockImplementation(() =>
+    mockVersionsListQuery(noReleaseBuilds, {}, '2.21.2'),
   );
 };
 
 const setupPythonRemediatedPackage = () => {
   mockUseParams.mockReturnValue({
-    repoUUID: getRepositoryPathSlug('python', 'remediated'),
+    repoName: getRepositoryPathSlug('python', 'remediated'),
     packageName: defaultPythonRemediatedRepositoryPackageItem.name,
   });
   (useLightwellRepository as jest.Mock).mockReturnValue({
@@ -221,8 +232,8 @@ it('renders package detail content with builds', async () => {
 });
 
 it('renders sidebar metadata', async () => {
-  (useMavenPackageDetailQuery as jest.Mock).mockImplementation(() =>
-    mockPackageDetailQuery(defaultBuilds, {
+  (useMavenPackageVersionsListQuery as jest.Mock).mockImplementation(() =>
+    mockVersionsListQuery(defaultBuilds, {
       summary: 'JSON library for Java',
       license: 'MIT',
       author: 'JSON.org',
@@ -311,7 +322,7 @@ const setupMultiVersionReleasePackage = () => {
       total: 1,
     },
   }));
-  (useMavenPackageDetailQuery as jest.Mock).mockImplementation(() => mockPackageDetailQuery());
+  (useMavenPackageVersionsListQuery as jest.Mock).mockImplementation(() => mockVersionsListQuery());
 };
 
 it('shows "Other available versions" on Releases tab for multi-version release packages', async () => {
@@ -477,7 +488,7 @@ it('copies maven coordinate to clipboard for remediated java package', async () 
 
 const setupPythonValidatedPackage = () => {
   mockUseParams.mockReturnValue({
-    repoUUID: getRepositoryPathSlug('python', 'validated'),
+    repoName: getRepositoryPathSlug('python', 'validated'),
     packageName: defaultPythonValidatedPackageItem.name,
   });
   (useLightwellRepository as jest.Mock).mockReturnValue({

--- a/src/Pages/Lightwell/Packages/PackageDetails.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.tsx
@@ -33,13 +33,12 @@ import EmptyTableState from 'components/EmptyTableState/EmptyTableState';
 import Loader from 'components/Loader';
 import {
   useLightwellRepositoryPackagesQuery,
-  useMavenPackageDetailQuery,
-  useMavenPackageVersionsPreload,
+  useMavenPackageVersionsListQuery,
   usePythonPackageVersionsQuery,
 } from 'services/Content/ContentQueries';
 
 import { LIGHTWELL_USE_MOCK } from '../constants';
-import { formatRepositoryName, stripLightwellVersionSuffix } from '../helpers';
+import { formatRepositoryName, lightwellReleaseNum, stripLightwellVersionSuffix } from '../helpers';
 import { getMockLightwellPackages } from '../mockPackages';
 import useLightwellRepository from '../useLightwellRepository';
 import PackageOverviewTab from './components/PackageOverviewTab';
@@ -62,7 +61,11 @@ const useStyles = createUseStyles({
 const PackageDetails = () => {
   const classes = useStyles();
   const navigate = useNavigate();
-  const { repoName: repoSlug = '', packageName: packageNameParam = '' } = useParams();
+  const {
+    repoName: repoSlug = '',
+    group: groupParam = '',
+    packageName: packageNameParam = '',
+  } = useParams();
   const packageName = packageNameParam ? decodeURIComponent(packageNameParam) : '';
   const [activeTabKey, setActiveTabKey] = useState(0);
   const [selectedVersion, setSelectedVersion] = useState<string>('');
@@ -98,19 +101,17 @@ const PackageDetails = () => {
     return (apiPackagesQuery.data?.results ?? []).find((pkg) => pkg.name === packageName);
   }, [useMock, repoUUID, packageName, apiPackagesQuery.data?.results]);
 
-  const packageGroup = packageItem?.group ?? '';
+  const packageGroup = decodeURIComponent(groupParam);
   const packageVersion = packageItem?.versions[0] ?? '';
   const hasRelease = (packageItem?.latest_releases ?? []).some((r) => !!r.release);
   const isMaven = repository?.content_type === 'maven';
   const isPython = repository?.content_type === 'python';
   const activeVersion = selectedVersion || packageVersion;
 
-  const mavenPackageDetailQuery = useMavenPackageDetailQuery(
+  const mavenVersionsListQuery = useMavenPackageVersionsListQuery(
     repoUUID,
     packageGroup,
     packageName,
-    activeVersion,
-    isMaven && !!repoUUID && !!packageGroup && !!activeVersion && !useMock,
   );
 
   const pythonPackageVersionsQuery = usePythonPackageVersionsQuery(
@@ -119,15 +120,17 @@ const PackageDetails = () => {
     isPython && !!repoUUID && !!packageName && !useMock,
   );
 
-  useMavenPackageVersionsPreload(
-    repoUUID,
-    packageGroup,
-    packageName,
-    packageItem?.versions ?? [],
-    isMaven && !hasRelease && !!repoUUID && !!packageGroup && !useMock,
+  const mavenDetail = mavenVersionsListQuery.data?.versions.find(
+    (v) => v.version === activeVersion,
   );
-
-  const mavenDetail = mavenPackageDetailQuery.data;
+  const mavenBuilds = useMemo(() => {
+    if (!isMaven || !hasRelease || !mavenVersionsListQuery.data?.versions) return [];
+    const upstream = stripLightwellVersionSuffix(activeVersion);
+    return mavenVersionsListQuery.data.versions
+      .filter((v) => stripLightwellVersionSuffix(v.version) === upstream)
+      .flatMap((v) => v.builds)
+      .sort((a, b) => lightwellReleaseNum(b.release) - lightwellReleaseNum(a.release));
+  }, [isMaven, hasRelease, mavenVersionsListQuery.data?.versions, activeVersion]);
   const pythonVersionsFromApi = useMemo(
     () => pythonPackageVersionsQuery.data?.versions?.map((version) => version.version) ?? [],
     [pythonPackageVersionsQuery.data?.versions],
@@ -172,6 +175,19 @@ const PackageDetails = () => {
       }));
   }, [isPython, packageItem, activeVersion]);
 
+  const mavenDeduplicatedVersions = useMemo(() => {
+    if (!isMaven || !hasRelease) return packageItem?.versions ?? [];
+    const seen = new Set<string>();
+    return [...(packageItem?.versions ?? [])]
+      .sort((a, b) => lightwellReleaseNum(b) - lightwellReleaseNum(a))
+      .filter((v) => {
+        const upstream = stripLightwellVersionSuffix(v);
+        if (seen.has(upstream)) return false;
+        seen.add(upstream);
+        return true;
+      });
+  }, [isMaven, hasRelease, packageItem?.versions]);
+
   useEffect(() => {
     if (isPython && pythonVersions.length) {
       if (!selectedVersion || !pythonVersions.includes(selectedVersion)) {
@@ -186,7 +202,7 @@ const PackageDetails = () => {
   }, [isPython, pythonVersions, packageItem?.versions, selectedVersion]);
 
   const isLoadingDetail = isMaven
-    ? mavenPackageDetailQuery.isLoading || (hasRelease && mavenPackageDetailQuery.isFetching)
+    ? mavenVersionsListQuery.isLoading
     : pythonPackageVersionsQuery.isLoading && !pythonPackageVersionsQuery.data;
 
   if (isResolvingRepository || !repository) {
@@ -202,8 +218,8 @@ const PackageDetails = () => {
     repository.name,
   );
 
-  const versionOptions = isPython ? pythonVersions : (packageItem?.versions ?? []);
-  const builds = mavenDetail?.builds ?? [];
+  const versionOptions = isPython ? pythonVersions : mavenDeduplicatedVersions;
+  const builds = isMaven && hasRelease ? mavenBuilds : (mavenDetail?.builds ?? []);
   const latestBuild = builds[0];
   const latestVersion = isMaven ? (latestBuild?.version ?? activeVersion) : activeVersion;
   const upstreamVersion = stripLightwellVersionSuffix(isMaven ? latestVersion : activeVersion);
@@ -263,13 +279,13 @@ const PackageDetails = () => {
             <Breadcrumb ouiaId='lightwell-package-details-breadcrumb'>
               <BreadcrumbItem
                 component='button'
-                onClick={() => navigate('../..', { relative: 'path' })}
+                onClick={() => navigate(groupParam ? '../../..' : '../..', { relative: 'path' })}
               >
                 Lightwell
               </BreadcrumbItem>
               <BreadcrumbItem
                 component='button'
-                onClick={() => navigate('..', { relative: 'path' })}
+                onClick={() => navigate(groupParam ? '../..' : '..', { relative: 'path' })}
               >
                 {repositoryName}
               </BreadcrumbItem>
@@ -293,7 +309,7 @@ const PackageDetails = () => {
                     {packageName || 'Package details'}
                   </Title>
                 </FlexItem>
-                {versionOptions.length <= 1 && (selectedVersion || activeVersion) ? (
+                {versionOptions.length === 1 && (selectedVersion || activeVersion) ? (
                   <FlexItem>
                     <Label isCompact>
                       {isMaven && hasRelease ? upstreamVersion : selectedVersion || activeVersion}
@@ -426,7 +442,7 @@ const PackageDetails = () => {
                     <TabContentBody hasPadding>
                       <PackageReleasesTab
                         version={upstreamVersion}
-                        builds={isMaven ? builds : pythonBuilds}
+                        builds={isMaven ? mavenBuilds : pythonBuilds}
                         allVersions={packageItem?.versions ?? []}
                         latestReleases={packageItem?.latest_releases ?? []}
                         onVersionSelect={setSelectedVersion}

--- a/src/Pages/Lightwell/Packages/PackagesTable.test.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesTable.test.tsx
@@ -189,7 +189,9 @@ it('navigates to package details when a package name is clicked', async () => {
 
   await userEvent.click(await screen.findByRole('button', { name: 'json-test' }));
 
-  expect(mockNavigate).toHaveBeenCalledWith(encodeURIComponent('json-test'));
+  expect(mockNavigate).toHaveBeenCalledWith(
+    `${encodeURIComponent(defaultLightwellRepositoryPackageItem.group)}/${encodeURIComponent('json-test')}`,
+  );
 });
 
 it('copies the maven coordinate when a validated version label is clicked', async () => {

--- a/src/Pages/Lightwell/Packages/PackagesTable.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesTable.tsx
@@ -449,7 +449,13 @@ const PackagesTable = () => {
                                 variant='link'
                                 isInline
                                 ouiaId={`lightwell-package-${name}`}
-                                onClick={() => navigate(encodeURIComponent(name))}
+                                onClick={() =>
+                                  navigate(
+                                    isMaven
+                                      ? `${encodeURIComponent(group_id)}/${encodeURIComponent(name)}`
+                                      : encodeURIComponent(name),
+                                  )
+                                }
                               >
                                 {name}
                               </Button>

--- a/src/Pages/Lightwell/helpers.ts
+++ b/src/Pages/Lightwell/helpers.ts
@@ -67,3 +67,6 @@ export const getRepositoryNameFromPathSlug = (slug: string): string => {
 
 export const stripLightwellVersionSuffix = (version: string): string =>
   version.replace(/\.rhlw-.*$/, '');
+
+export const lightwellReleaseNum = (versionOrRelease: string): number =>
+  parseInt(versionOrRelease.match(/(\d+)$/)?.[1] ?? '0', 10);

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -262,6 +262,12 @@ export interface PackageDetailResponse {
   author?: string;
 }
 
+export interface MavenPackageVersionsListResponse {
+  group: string;
+  name: string;
+  versions: PackageDetailResponse[];
+}
+
 export interface PythonPackageAuthor {
   name: string;
   email?: string;
@@ -772,6 +778,17 @@ export const getPythonPackageVersions: (
 ) => Promise<PythonPackageVersionsResponse> = async (uuid, name) => {
   const { data } = await axios.get(
     `/api/content-sources/v1/repositories/${uuid}/python_packages/${name}`,
+  );
+  return data;
+};
+
+export const getMavenPackageVersionsList: (
+  uuid: string,
+  group: string,
+  name: string,
+) => Promise<MavenPackageVersionsListResponse> = async (uuid, group, name) => {
+  const { data } = await axios.get(
+    `/api/content-sources/v1/repositories/${uuid}/maven_packages/${group}/${name}`,
   );
   return data;
 };

--- a/src/services/Content/ContentQueries.ts
+++ b/src/services/Content/ContentQueries.ts
@@ -53,6 +53,7 @@ import {
   getPythonPackageDetail,
   getPythonPackageVersions,
   getMavenPackageDetail,
+  getMavenPackageVersionsList,
 } from './ContentApi';
 import { ADMIN_TASK_LIST_KEY } from '../Admin/AdminTaskQueries';
 import useErrorNotification from 'Hooks/useErrorNotification';
@@ -72,6 +73,7 @@ export const CREATE_PARAMS_KEY = 'CREATE_PARAMS_KEY';
 export const PACKAGES_KEY = 'PACKAGES_KEY';
 export const LIGHTWELL_REPOSITORY_PACKAGES_KEY = 'LIGHTWELL_REPOSITORY_PACKAGES_KEY';
 export const MAVEN_PACKAGE_DETAIL_KEY = 'MAVEN_PACKAGE_DETAIL_KEY';
+export const MAVEN_PACKAGE_VERSIONS_LIST_KEY = 'MAVEN_PACKAGE_VERSIONS_LIST_KEY';
 export const PYTHON_PACKAGE_DETAIL_KEY = 'PYTHON_PACKAGE_DETAIL_KEY';
 export const PYTHON_PACKAGE_VERSIONS_KEY = 'PYTHON_PACKAGE_VERSIONS_KEY';
 export const SNAPSHOT_PACKAGES_KEY = 'SNAPSHOT_PACKAGES_KEY';
@@ -729,6 +731,18 @@ export const useMavenPackageVersionsPreload = (
         id: 'maven-package-detail-error',
       },
     })),
+  });
+
+export const useMavenPackageVersionsListQuery = (uuid: string, group: string, name: string) =>
+  useQuery({
+    queryKey: [MAVEN_PACKAGE_VERSIONS_LIST_KEY, uuid, group, name],
+    queryFn: () => getMavenPackageVersionsList(uuid, group, name),
+    staleTime: 60000,
+    enabled: !!uuid && !!group && !!name,
+    meta: {
+      title: 'Unable to load package versions.',
+      id: 'maven-package-versions-list-error',
+    },
   });
 
 export const usePythonPackageDetailQuery = (


### PR DESCRIPTION
## Summary
Fixes the version switching on the details page to remove the preloading / be instant by adding support for API change. Also updates the URL route to include the group name.

Depends on: https://github.com/content-services/content-sources-backend/pull/1576

## Testing steps
