### PR TITLE
HMS-10935: change "Namespace" to "Group ID"

### DIFF
--- a/src/Pages/Lightwell/Packages/PackageDetails.test.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.test.tsx
@@ -234,7 +234,7 @@ it('renders sidebar metadata', async () => {
 
   expect(await screen.findByText('Last updated')).toBeInTheDocument();
   expect(await screen.findAllByText('2026-07-01')).toHaveLength(2);
-  expect(await screen.findByText('Namespace')).toBeInTheDocument();
+  expect(await screen.findByText('Group ID')).toBeInTheDocument();
   expect(await screen.findByText(defaultLightwellRepositoryPackageItem.group)).toBeInTheDocument();
   expect(await screen.findByText('Rebuilt by')).toBeInTheDocument();
   expect(await screen.findByText('Red Hat')).toBeInTheDocument();

--- a/src/Pages/Lightwell/Packages/PackageDetails.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.tsx
@@ -459,7 +459,7 @@ const PackageDetails = () => {
               <GridItem md={4}>
                 <PackageSidebar
                   lastUpdated={lastUpdated}
-                  namespace={packageGroup}
+                  groupId={packageGroup}
                   upstreamVersion={upstreamVersion}
                   allVersions={
                     isMaven && !hasRelease

--- a/src/Pages/Lightwell/Packages/PackagesTable.test.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesTable.test.tsx
@@ -151,7 +151,7 @@ it('shows a loading skeleton while packages are fetching', () => {
 
   renderPackagesTable();
 
-  expect(screen.getByLabelText('Filter by name or namespace')).toBeInTheDocument();
+  expect(screen.getByLabelText('Filter by name or group ID')).toBeInTheDocument();
   expect(screen.queryByRole('table', { name: 'Lightwell packages table' })).not.toBeInTheDocument();
 });
 
@@ -166,7 +166,7 @@ it('shows loader while the repository is resolving', () => {
 
   renderPackagesTable();
 
-  expect(screen.queryByLabelText('Filter by name or namespace')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Filter by name or group ID')).not.toBeInTheDocument();
 });
 
 it('shows filtered empty state when search returns no packages', async () => {
@@ -178,7 +178,7 @@ it('shows filtered empty state when search returns no packages', async () => {
 
   renderPackagesTable();
 
-  await userEvent.type(screen.getByLabelText('Filter by name or namespace'), 'missing');
+  await userEvent.type(screen.getByLabelText('Filter by name or group ID'), 'missing');
 
   expect(await screen.findByText('No packages match the filter criteria')).toBeInTheDocument();
   expect(screen.getByText('Clear all filters to show more results.')).toBeInTheDocument();
@@ -243,7 +243,7 @@ it('renders remediated java packages with a Latest release column', async () => 
   expect(screen.queryByLabelText('Copy 3.14.0')).not.toBeInTheDocument();
 });
 
-it('renders python validated packages with pip copy labels and no namespace column', async () => {
+it('renders python validated packages with pip copy labels and no group ID column', async () => {
   mockUseParams.mockReturnValue({
     repoName: getRepositoryPathSlug('python', 'validated'),
   });
@@ -262,7 +262,7 @@ it('renders python validated packages with pip copy labels and no namespace colu
   renderPackagesTable();
 
   expect(await screen.findByRole('heading', { name: 'Python Validated' })).toBeInTheDocument();
-  expect(screen.queryByRole('columnheader', { name: 'Namespace' })).not.toBeInTheDocument();
+  expect(screen.queryByRole('columnheader', { name: 'Group ID' })).not.toBeInTheDocument();
   expect(screen.queryByRole('columnheader', { name: 'Latest release' })).not.toBeInTheDocument();
 
   await clickCopyLabel('Copy 2.21.2');
@@ -300,12 +300,12 @@ it('clears the search filter from the filtered empty state', async () => {
 
   renderPackagesTable();
 
-  await userEvent.type(screen.getByLabelText('Filter by name or namespace'), 'missing');
+  await userEvent.type(screen.getByLabelText('Filter by name or group ID'), 'missing');
   expect(await screen.findByText('No packages match the filter criteria')).toBeInTheDocument();
 
   fireEvent.click(screen.getByRole('button', { name: 'Clear all filters' }));
 
-  await waitFor(() => expect(screen.getByLabelText('Filter by name or namespace')).toHaveValue(''));
+  await waitFor(() => expect(screen.getByLabelText('Filter by name or group ID')).toHaveValue(''));
 });
 
 it('renders connect action and repository description', async () => {

--- a/src/Pages/Lightwell/Packages/PackagesTable.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesTable.tsx
@@ -298,7 +298,7 @@ const PackagesTable = () => {
     { title: 'Package', width: 25 },
     { title: 'Version', width: 15 },
     ...(isRemediated ? [{ title: 'Latest release', width: 20 as BaseCellProps['width'] }] : []),
-    ...(isMaven ? [{ title: 'Namespace', width: 20 as BaseCellProps['width'] }] : []),
+    ...(isMaven ? [{ title: 'Group ID', width: 20 as BaseCellProps['width'] }] : []),
     { title: 'Last updated', width: 15 },
   ];
 
@@ -375,8 +375,8 @@ const PackagesTable = () => {
             <ToolbarItem className={classes.filterToolbarItem}>
               <SearchInput
                 id='lightwell-package-filter'
-                aria-label='Filter by name or namespace'
-                placeholder='Filter by name or namespace'
+                aria-label={isMaven ? 'Filter by name or group ID' : 'Filter by name'}
+                placeholder={isMaven ? 'Filter by name or group ID' : 'Filter by name'}
                 value={searchQuery}
                 onChange={(_event, value) => {
                   setSearchQuery(value);

--- a/src/Pages/Lightwell/Packages/components/PackageSidebar.tsx
+++ b/src/Pages/Lightwell/Packages/components/PackageSidebar.tsx
@@ -10,7 +10,7 @@ import UrlWithExternalIcon from 'components/UrlWithLinkIcon/UrlWithLinkIcon';
 
 type PackageSidebarProps = {
   lastUpdated: string;
-  namespace?: string;
+  groupId?: string;
   upstreamVersion: string;
   allVersions?: string[];
   license?: string;
@@ -21,7 +21,7 @@ type PackageSidebarProps = {
 
 const PackageSidebar = ({
   lastUpdated,
-  namespace,
+  groupId,
   upstreamVersion,
   allVersions,
   license,
@@ -44,10 +44,10 @@ const PackageSidebar = ({
             <DescriptionListDescription>{license}</DescriptionListDescription>
           </DescriptionListGroup>
         ) : null}
-        {namespace ? (
+        {groupId ? (
           <DescriptionListGroup>
-            <DescriptionListTerm>Namespace</DescriptionListTerm>
-            <DescriptionListDescription>{namespace}</DescriptionListDescription>
+            <DescriptionListTerm>Group ID</DescriptionListTerm>
+            <DescriptionListDescription>{groupId}</DescriptionListDescription>
           </DescriptionListGroup>
         ) : null}
         {author ? (

--- a/src/Pages/Lightwell/Repositories/components/ConnectRepositoryPopover.tsx
+++ b/src/Pages/Lightwell/Repositories/components/ConnectRepositoryPopover.tsx
@@ -2,32 +2,20 @@ import {
   ClipboardCopy,
   ClipboardCopyVariant,
   Content,
+  Flex,
+  FlexItem,
   Popover,
-  Stack,
-  StackItem,
   Tab,
   TabContent,
   Tabs,
   TabTitleText,
 } from '@patternfly/react-core';
 import { createRef, ReactElement, useMemo, useState } from 'react';
-import { createUseStyles } from 'react-jss';
 
 import { ContentItem } from 'services/Content/ContentApi';
 
 import { ConnectSnippetTab, getConnectSnippetTabs } from './connectSnippets';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-
-const useStyles = createUseStyles({
-  popoverBody: {
-    minWidth: '32rem',
-    maxWidth: '40rem',
-    '& .pf-v6-c-clipboard-copy__expandable-content': {
-      '--pf-v6-c-clipboard-copy__expandable-content--BorderColor':
-        'var(--pf-t--global--border--color--control--default)',
-    },
-  },
-});
 
 type ConnectRepositoryPopoverProps = {
   repository: Pick<ContentItem, 'name' | 'published_distribution_url' | 'content_type' | 'uuid'>;
@@ -35,7 +23,6 @@ type ConnectRepositoryPopoverProps = {
 };
 
 const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPopoverProps) => {
-  const classes = useStyles();
   const tabs = useMemo(() => getConnectSnippetTabs(repository), [repository]);
   const [activeTabKey, setActiveTabKey] = useState(tabs[0]?.eventKey ?? '');
   const firstTabKey = tabs[0]?.eventKey ?? '';
@@ -53,9 +40,9 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
   );
 
   const renderTabPanel = (tab: ConnectSnippetTab) => (
-    <Stack hasGutter>
+    <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
       {tab.snippets.map((snippet) => (
-        <StackItem key={snippet.label}>
+        <FlexItem key={snippet.label}>
           <Content component='small' style={{ textAlign: 'left' }}>
             {snippet.label}
           </Content>
@@ -74,13 +61,13 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
               {snippet.description}
             </Content>
           )}
-        </StackItem>
+        </FlexItem>
       ))}
-    </Stack>
+    </Flex>
   );
 
   const bodyContent = (
-    <div className={classes.popoverBody}>
+    <div>
       <Tabs
         activeKey={activeTabKey}
         onSelect={(_, eventKey) => setActiveTabKey(eventKey as string)}
@@ -118,10 +105,10 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
       aria-label='Connect to this repository'
       headerContent='Connect to this repository'
       bodyContent={bodyContent}
-      position='right'
-      minWidth='32rem'
-      maxWidth='40rem'
-      onHide={() => setActiveTabKey(firstTabKey)}
+      position='right-start'
+      flipBehavior={['right-start', 'left-start']}
+      onShow={() => setActiveTabKey(firstTabKey)}
+      minWidth='600px'
     >
       {children}
     </Popover>


### PR DESCRIPTION
## Summary

- Changes "Namespace" UI copy/columns to "Group ID"
- Fixes inconsistent popover sizing on tab switch

## Testing steps
