### PR TITLE
Lightwell: repositories page UI improvements

### DIFF
--- a/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
+++ b/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
@@ -97,7 +97,11 @@ const RepositoriesTable = () => {
 
   if (isError) throw error;
 
-  const columnHeaders: { title: string; width?: BaseCellProps['width']; info?: ComponentProps<typeof Th>['info'] }[] = [
+  const columnHeaders: {
+    title: string;
+    width?: BaseCellProps['width'];
+    info?: ComponentProps<typeof Th>['info'];
+  }[] = [
     { title: 'Repository' },
     { title: 'Ecosystem', width: 15 },
     { title: 'Security level', width: 15 },

--- a/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
+++ b/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
@@ -23,6 +23,7 @@ import {
   Thead,
   Tr,
   type BaseCellProps,
+  type ThInfoType,
 } from '@patternfly/react-table';
 import { useState } from 'react';
 import { createUseStyles } from 'react-jss';
@@ -96,12 +97,23 @@ const RepositoriesTable = () => {
 
   if (isError) throw error;
 
-  const columnHeaders: { title: string; width?: BaseCellProps['width'] }[] = [
+  const columnHeaders: { title: string; width?: BaseCellProps['width']; info?: ThInfoType }[] = [
     { title: 'Repository' },
     { title: 'Ecosystem', width: 15 },
     { title: 'Security level', width: 15 },
-    { title: 'Packages', width: 10 },
-    { title: 'Builds', width: 10 },
+    {
+      title: 'Packages',
+      width: 10,
+      info: { tooltip: 'Unique package names available in this repository.' },
+    },
+    {
+      title: 'Builds',
+      width: 10,
+      info: {
+        tooltip:
+          'Total built artifacts across all versions. A single package may have multiple builds.',
+      },
+    },
   ];
 
   const onSetPage = (_, newPage: number) => setPage(newPage);
@@ -167,9 +179,9 @@ const RepositoriesTable = () => {
                   >
                     <Thead>
                       <Tr>
-                        {columnHeaders.map(({ title, width }) => (
-                          <Th key={title + 'column'} width={width} modifier='wrap'>
-                            {title}
+                        {columnHeaders.map(({ title, width, info }) => (
+                          <Th key={title + 'column'} width={width} modifier='wrap' info={info}>
+                            {info ? <span>{title}</span> : title}
                           </Th>
                         ))}
                       </Tr>

--- a/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
+++ b/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
@@ -23,9 +23,8 @@ import {
   Thead,
   Tr,
   type BaseCellProps,
-  type ThInfoType,
 } from '@patternfly/react-table';
-import { useState } from 'react';
+import { type ComponentProps, useState } from 'react';
 import { createUseStyles } from 'react-jss';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import text from '@patternfly/react-styles/css/utilities/Text/text';
@@ -98,7 +97,7 @@ const RepositoriesTable = () => {
 
   if (isError) throw error;
 
-  const columnHeaders: { title: string; width?: BaseCellProps['width']; info?: ThInfoType }[] = [
+  const columnHeaders: { title: string; width?: BaseCellProps['width']; info?: ComponentProps<typeof Th>['info'] }[] = [
     { title: 'Repository' },
     { title: 'Ecosystem', width: 15 },
     { title: 'Security level', width: 15 },

--- a/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
+++ b/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
@@ -171,7 +171,7 @@ const RepositoriesTable = () => {
           </Hide>
           <Hide hide={countIsZero || isLoading}>
             <Stack>
-              <Card className={`${spacing.ptLg} ${spacing.pbXl} ${spacing.pxLg}`}>
+              <Card className={`${spacing.ptLg} ${spacing.pb_2xl} ${spacing.pxLg}`}>
                 <Stack>
                   <Table
                     aria-label='Lightwell repositories table'

--- a/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
+++ b/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
@@ -144,7 +144,7 @@ const RepositoriesTable = () => {
         paragraph='Browse Lightwell repositories by ecosystem and security level.'
         showOpenSourceBadge={false}
       />
-      <PageSection hasBodyWrapper={false} className={spacing.pb_2xl}>
+      <PageSection hasBodyWrapper={false} className={`${spacing.pt_0} ${spacing.pb_2xl}`}>
         <Grid data-ouia-component-id='lightwell-repositories-page'>
           <Hide hide={countIsZero || count < 10}>
             <Flex

--- a/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
+++ b/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
@@ -28,6 +28,7 @@ import {
 import { useState } from 'react';
 import { createUseStyles } from 'react-jss';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import text from '@patternfly/react-styles/css/utilities/Text/text';
 
 import EmptyTableState from './components/EmptyTableState';
 import Header from 'components/Header/Header';
@@ -213,6 +214,7 @@ const RepositoriesTable = () => {
                                     variant='link'
                                     isInline
                                     ouiaId={`lightwell-repo-${uuid}`}
+                                    className={text.fontWeightBold}
                                     onClick={() =>
                                       navigate(getRepositoryPathSlug(content_type, security_level))
                                     }


### PR DESCRIPTION
## Summary
- Add info tooltips to Packages and Builds column headers explaining the distinction
- Bold repo name links for visual hierarchy
- Reduce gap between page header and table
- Balance table card top/bottom padding

## Test plan
- [ ] Navigate to `/lightwell`
- [ ] Hover over Packages/Builds column headers to see info tooltips (no duplicate tooltip on header text)
- [ ] Repo names should be bold
- [ ] Spacing between header and table should be tight
- [ ] Table card should have visually balanced top/bottom padding

co-authored by Claude Code