### PR TITLE
Lightwell: render routes during RBAC fetch (RHCLOUD-49049)

### DIFF
--- a/src/LightwellApp.tsx
+++ b/src/LightwellApp.tsx
@@ -1,6 +1,5 @@
 import '../styles/lightwell-chrome-overrides.scss';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
-import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
@@ -9,25 +8,14 @@ import usePageSafe from 'Hooks/usePageSafe';
 import PackagesTable from 'Pages/Lightwell/Packages/PackagesTable';
 import PackageDetails from 'Pages/Lightwell/Packages/PackageDetails';
 import RepositoriesTable from 'Pages/Lightwell/Repositories/RepositoriesTable';
-import { useAppContext } from './middleware/AppContext';
 
 export default function LightwellApp() {
-  const { rbac, isFetchingPermissions } = useAppContext();
   const pageSafe = usePageSafe();
   const { hideGlobalFilter } = useChrome();
 
   useEffect(() => {
     hideGlobalFilter(true);
   }, [hideGlobalFilter]);
-
-  if (!rbac || isFetchingPermissions) {
-    return (
-      <Bullseye>
-        <div data-ouia-safe={false} />
-        <Spinner size='xl' />
-      </Bullseye>
-    );
-  }
 
   return (
     <ErrorPage>


### PR DESCRIPTION
## Summary

Remove the app-level spinner gate so RepositoriesTable can show its skeleton while permissions load, avoiding a duplicate loading step after the chrome shell mounts.

## Screencast


## Testing steps

Run insights-chrome from this branch/pull-request in combination with this pull-request to see the final effect of the screencast: https://github.com/RedHatInsights/insights-chrome/pull/3592