### PR TITLE
Lightwell: Use copy button consistently

### DIFF
--- a/src/LightwellApp.tsx
+++ b/src/LightwellApp.tsx
@@ -1,4 +1,5 @@
 import '../styles/lightwell-chrome-overrides.scss';
+import '../styles/lightwell-clipboard-copy.scss';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useEffect } from 'react';

--- a/src/Pages/Lightwell/Packages/PackageDetails.test.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.test.tsx
@@ -366,7 +366,6 @@ it('shows install section for python package', async () => {
   expect(
     await screen.findByRole('button', { name: pythonRemediatedPipCommand }),
   ).toBeInTheDocument();
-  expect(document.body).toHaveTextContent(pythonRemediatedPipCommand);
 });
 
 const mockClipboard = () => {
@@ -430,7 +429,9 @@ it('copies pip command to clipboard for remediated python package', async () => 
   await assertClipboardCopy(
     writeText,
     async () => {
-      await userEvent.click(await screen.findByText('2.31.0.rhlw-0001'));
+      await userEvent.click(
+        await screen.findByRole('button', { name: `Copy ${otherPythonRemediatedPipCommand}` }),
+      );
     },
     otherPythonRemediatedPipCommand,
   );
@@ -475,7 +476,9 @@ it('copies maven coordinate to clipboard for remediated java package', async () 
     writeText,
     async () => {
       await userEvent.click(await screen.findByRole('tab', { name: 'Releases' }));
-      await userEvent.click(await screen.findByRole('button', { name: '3.14.0.rhlw-00001' }));
+      await userEvent.click(
+        await screen.findByRole('button', { name: `Copy ${javaRemediatedCopyCommand}` }),
+      );
     },
     javaRemediatedCopyCommand,
   );
@@ -484,7 +487,9 @@ it('copies maven coordinate to clipboard for remediated java package', async () 
   await assertClipboardCopy(
     writeText,
     async () => {
-      await userEvent.click(await screen.findByText('2.12.0.rhlw-00002'));
+      await userEvent.click(
+        await screen.findByRole('button', { name: `Copy ${otherJavaRemediatedCopyCommand}` }),
+      );
     },
     otherJavaRemediatedCopyCommand,
   );

--- a/src/Pages/Lightwell/Packages/PackageDetails.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.tsx
@@ -22,11 +22,12 @@ import {
   Tabs,
   TabTitleText,
   Title,
+  Tooltip,
 } from '@patternfly/react-core';
 import { CopyIcon, JavaIcon, PythonIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { createUseStyles } from 'react-jss';
-import { createRef, useEffect, useMemo, useState } from 'react';
+import { createRef, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import EmptyTableState from 'components/EmptyTableState/EmptyTableState';
@@ -80,6 +81,8 @@ const PackageDetails = () => {
   const [activeTabKey, setActiveTabKey] = useState(0);
   const [selectedVersion, setSelectedVersion] = useState<string>('');
   const [versionDropdownOpen, setVersionDropdownOpen] = useState(false);
+  const [isCopyTooltipVisible, setIsCopyTooltipVisible] = useState(false);
+  const copyTooltipTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
   const overviewTabRef = createRef<HTMLElement>();
   const releasesTabRef = createRef<HTMLElement>();
@@ -233,6 +236,28 @@ const PackageDetails = () => {
       setSelectedVersion(versionOptions[0]);
     }
   }, [versionOptions, selectedVersion]);
+
+  useEffect(
+    () => () => {
+      if (copyTooltipTimeoutRef.current) {
+        clearTimeout(copyTooltipTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  const handleCopyInstallCommand = (text: string) => {
+    void navigator.clipboard.writeText(text);
+
+    if (copyTooltipTimeoutRef.current) {
+      clearTimeout(copyTooltipTimeoutRef.current);
+    }
+
+    setIsCopyTooltipVisible(true);
+    copyTooltipTimeoutRef.current = setTimeout(() => {
+      setIsCopyTooltipVisible(false);
+    }, 2000);
+  };
 
   const isLoadingDetail = isMaven
     ? mavenVersionsListQuery.isLoading
@@ -391,14 +416,20 @@ const PackageDetails = () => {
               </Flex>
               {displayVersion ? (
                 <FlexItem>
-                  <Button
-                    variant='secondary'
-                    icon={<CopyIcon />}
-                    iconPosition='end'
-                    onClick={() => navigator.clipboard.writeText(installCommand)}
+                  <Tooltip
+                    content={isCopyTooltipVisible ? 'Copied' : 'Copy'}
+                    trigger='mouseenter focus'
+                    isVisible={isCopyTooltipVisible}
                   >
-                    {installCommand}
-                  </Button>
+                    <Button
+                      variant='secondary'
+                      icon={<CopyIcon />}
+                      iconPosition='end'
+                      onClick={() => handleCopyInstallCommand(installCommand)}
+                    >
+                      {installCommand}
+                    </Button>
+                  </Tooltip>
                 </FlexItem>
               ) : null}
             </Flex>

--- a/src/Pages/Lightwell/Packages/PackagesTable.test.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesTable.test.tsx
@@ -88,9 +88,8 @@ const mockClipboard = () => {
   return writeText;
 };
 
-const clickCopyLabel = async (label: string) => {
-  const copyLabel = await screen.findByLabelText(label);
-  await userEvent.click(copyLabel.querySelector('button')!);
+const clickCopyButton = async (label: string) => {
+  await userEvent.click(await screen.findByRole('button', { name: label }));
 };
 
 const javaValidatedTableCopyCommand = `${defaultLightwellRepositoryPackageItem.group}:${defaultLightwellRepositoryPackageItem.name}:3.14.0`;
@@ -135,12 +134,13 @@ it('renders with a single package', async () => {
   renderPackagesTable();
 
   expect(screen.queryAllByText('Java Validated')).toHaveLength(2);
-  expect(await screen.findByLabelText('Repository URL')).toHaveTextContent(
-    'https://example.com/lightwell/java/validated',
-  );
+  expect(
+    await screen.findByText('https://example.com/lightwell/java/validated'),
+  ).toBeInTheDocument();
   expect(await screen.findByText('org.json.test')).toBeInTheDocument();
   expect(screen.queryByText('rhlw-3004-test')).not.toBeInTheDocument();
-  expect(await screen.findByLabelText('Copy 3.14.0')).toHaveTextContent('3.14.0');
+  expect(await screen.findByRole('button', { name: 'Copy 3.14.0' })).toBeInTheDocument();
+  expect(screen.getByText('3.14.0')).toBeInTheDocument();
   expect(await screen.findByText('2026-07-01')).toBeInTheDocument();
 });
 
@@ -198,7 +198,7 @@ it('copies the maven coordinate when a validated version label is clicked', asyn
   const writeText = mockClipboard();
   renderPackagesTable();
 
-  await clickCopyLabel('Copy 3.14.0');
+  await clickCopyButton('Copy 3.14.0');
 
   expect(writeText).toHaveBeenCalledWith(javaValidatedTableCopyCommand);
 });
@@ -239,10 +239,9 @@ it('renders remediated java packages with a Latest release column', async () => 
 
   expect(await screen.findByRole('heading', { name: 'Java Remediated' })).toBeInTheDocument();
   expect(screen.getByRole('columnheader', { name: 'Latest release' })).toBeInTheDocument();
-  expect(await screen.findByLabelText('Copy 3.14.0.rhlw-0004')).toHaveTextContent(
-    '3.14.0.rhlw-0004',
-  );
-  expect(screen.queryByLabelText('Copy 3.14.0')).not.toBeInTheDocument();
+  expect(await screen.findByRole('button', { name: 'Copy 3.14.0.rhlw-0004' })).toBeInTheDocument();
+  expect(screen.getByText('3.14.0.rhlw-0004')).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Copy 3.14.0' })).not.toBeInTheDocument();
 });
 
 it('renders python validated packages with pip copy labels and no group ID column', async () => {
@@ -267,7 +266,7 @@ it('renders python validated packages with pip copy labels and no group ID colum
   expect(screen.queryByRole('columnheader', { name: 'Group ID' })).not.toBeInTheDocument();
   expect(screen.queryByRole('columnheader', { name: 'Latest release' })).not.toBeInTheDocument();
 
-  await clickCopyLabel('Copy 2.21.2');
+  await clickCopyButton('Copy 2.21.2');
   expect(writeText).toHaveBeenCalledWith(pythonValidatedPipCommand);
 });
 
@@ -290,7 +289,7 @@ it('renders python remediated packages with a Latest release column', async () =
 
   expect(await screen.findByRole('heading', { name: 'Python Remediated' })).toBeInTheDocument();
   expect(screen.getByRole('columnheader', { name: 'Latest release' })).toBeInTheDocument();
-  expect(await screen.findByLabelText('Copy 2.32.0.rhlw-0002')).toBeInTheDocument();
+  expect(await screen.findByRole('button', { name: 'Copy 2.32.0.rhlw-0002' })).toBeInTheDocument();
 });
 
 it('clears the search filter from the filtered empty state', async () => {

--- a/src/Pages/Lightwell/Packages/PackagesTable.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesTable.tsx
@@ -3,12 +3,13 @@ import {
   BreadcrumbItem,
   Button,
   Card,
+  ClipboardCopy,
+  ClipboardCopyVariant,
   Content,
   Flex,
   FlexItem,
   Grid,
   Icon,
-  Label,
   Pagination,
   PaginationVariant,
   SearchInput,
@@ -19,7 +20,7 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { CopyIcon, CodeIcon, JavaIcon, PythonIcon } from '@patternfly/react-icons';
+import { CodeIcon, JavaIcon, PythonIcon } from '@patternfly/react-icons';
 import { SkeletonTable } from '@patternfly/react-component-groups';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { createUseStyles } from 'react-jss';
@@ -141,14 +142,16 @@ const PackageCopyLabel = ({ name, groupId, version, isPython }: PackageCopyLabel
   const copyText = isPython ? `pip install ${name}==${version}` : `${groupId}:${name}:${version}`;
 
   return (
-    <Label
-      isCompact
-      icon={<CopyIcon />}
-      onClick={() => navigator.clipboard.writeText(copyText)}
-      aria-label={`Copy ${version}`}
+    <ClipboardCopy
+      isReadOnly
+      hoverTip='Copy'
+      clickTip='Copied'
+      variant={ClipboardCopyVariant.inlineCompact}
+      copyAriaLabel={`Copy ${version}`}
+      onCopy={() => navigator.clipboard.writeText(copyText)}
     >
       {version}
-    </Label>
+    </ClipboardCopy>
   );
 };
 
@@ -345,16 +348,14 @@ const PackagesTable = () => {
                   </Title>
                 </FlexItem>
                 <FlexItem>
-                  <Label
-                    aria-label='Repository URL'
-                    icon={<CopyIcon />}
-                    isCompact
-                    onClick={() =>
-                      navigator.clipboard.writeText(repository.published_distribution_url || '')
-                    }
+                  <ClipboardCopy
+                    isReadOnly
+                    hoverTip='Copy'
+                    clickTip='Copied'
+                    variant={ClipboardCopyVariant.inlineCompact}
                   >
-                    {repository.published_distribution_url}
-                  </Label>
+                    {repository.published_distribution_url || ''}
+                  </ClipboardCopy>
                 </FlexItem>
               </Flex>
               <FlexItem align={{ default: 'alignRight' }}>

--- a/src/Pages/Lightwell/Packages/components/PackageOverviewTab.tsx
+++ b/src/Pages/Lightwell/Packages/components/PackageOverviewTab.tsx
@@ -70,7 +70,7 @@ const PackageOverviewTab = ({
             isReadOnly
             isCode
             hoverTip='Copy'
-            clickTip=''
+            clickTip='Copied'
             variant={ClipboardCopyVariant.expansion}
             isExpanded
           >
@@ -146,7 +146,7 @@ const PackageOverviewTab = ({
             isReadOnly
             isCode
             hoverTip='Copy'
-            clickTip=''
+            clickTip='Copied'
             variant={ClipboardCopyVariant.inline}
           >
             {installCommand ?? `pip install ${name}==${latestRelease}`}

--- a/src/Pages/Lightwell/Packages/components/PackageReleasesTab.tsx
+++ b/src/Pages/Lightwell/Packages/components/PackageReleasesTab.tsx
@@ -1,5 +1,4 @@
-import { Button, Flex, Label, Title } from '@patternfly/react-core';
-import { CopyIcon } from '@patternfly/react-icons';
+import { Button, ClipboardCopy, ClipboardCopyVariant, Flex, Title } from '@patternfly/react-core';
 import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { useMemo } from 'react';
 
@@ -58,15 +57,16 @@ const PackageReleasesTab = ({
             return (
               <Tr key={build.version}>
                 <Td dataLabel='Release'>
-                  <Label
-                    isCompact
-                    isClickable
-                    icon={<CopyIcon />}
-                    onClick={() => navigator.clipboard.writeText(copyText)}
-                    aria-label={`Copy ${copyText}`}
+                  <ClipboardCopy
+                    isReadOnly
+                    hoverTip='Copy'
+                    clickTip='Copied'
+                    copyAriaLabel={`Copy ${copyText}`}
+                    variant={ClipboardCopyVariant.inlineCompact}
+                    onCopy={() => navigator.clipboard.writeText(copyText)}
                   >
                     {build.version}
-                  </Label>
+                  </ClipboardCopy>
                 </Td>
                 <Td dataLabel='Date'>{build.created_at?.split('T')[0] ?? '—'}</Td>
               </Tr>
@@ -103,15 +103,16 @@ const PackageReleasesTab = ({
                     </Td>
                     <Td dataLabel='Latest release'>
                       {release ? (
-                        <Label
-                          isCompact
-                          isClickable
-                          icon={<CopyIcon />}
-                          onClick={() => navigator.clipboard.writeText(copyText)}
-                          aria-label={`Copy ${copyText}`}
+                        <ClipboardCopy
+                          isReadOnly
+                          hoverTip='Copy'
+                          clickTip='Copied'
+                          copyAriaLabel={`Copy ${copyText}`}
+                          variant={ClipboardCopyVariant.inlineCompact}
+                          onCopy={() => navigator.clipboard.writeText(copyText)}
                         >
                           {releaseVersion}
-                        </Label>
+                        </ClipboardCopy>
                       ) : (
                         '—'
                       )}

--- a/src/Pages/Lightwell/Repositories/components/ConnectRepositoryPopover.tsx
+++ b/src/Pages/Lightwell/Repositories/components/ConnectRepositoryPopover.tsx
@@ -50,7 +50,7 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
             isReadOnly
             isCode
             hoverTip='Copy'
-            clickTip=''
+            clickTip='Copied'
             variant={snippet.urlOnly ? ClipboardCopyVariant.inline : ClipboardCopyVariant.expansion}
             isExpanded={!snippet.urlOnly}
           >

--- a/styles/lightwell-clipboard-copy.scss
+++ b/styles/lightwell-clipboard-copy.scss
@@ -1,0 +1,5 @@
+.pf-v6-c-clipboard-copy.pf-m-inline {
+  border-radius: var(--pf-t--global--border--radius--pill);
+  padding-inline-start: 0.5rem;
+  padding-inline-end: 0.5rem;
+}


### PR DESCRIPTION
Copy buttons do not provide any feedback when clicked. Also Labels were used and not the ClipboardCopy components.

This changes the visual slightly - the copy icon is on the right and not left and only the icon is clickable and not the whole label. I had to fake round edges with css - not thrilled about it but I feel that the feedback when clicked was worth it.

@xbhouse Please feel free to close if that was done on purpose.

Before:
<img width="1912" height="618" alt="Screenshot From 2026-07-07 10-36-57" src="https://github.com/user-attachments/assets/6602c939-8666-4880-ab6f-ead9e3d59997" />


After:

<img width="1912" height="618" alt="Screenshot From 2026-07-07 10-31-52" src="https://github.com/user-attachments/assets/cee60a1b-7e05-4581-aeb2-cc4ee49c7c81" />

