### PR TITLE
Lightwell: add sensitive data warning to remediated pages

### DIFF
--- a/src/Pages/Lightwell/Packages/PackageDetails.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.tsx
@@ -1,5 +1,4 @@
 import {
-  Alert,
   Breadcrumb,
   BreadcrumbItem,
   Button,
@@ -48,6 +47,7 @@ import {
   stripLightwellVersionSuffix,
 } from '../helpers';
 import { getMockLightwellPackages } from '../mockPackages';
+import RemediatedDataWarning from '../RemediatedDataWarning';
 import useLightwellRepository from '../useLightwellRepository';
 import PackageOverviewTab from './components/PackageOverviewTab';
 import PackageReleasesTab, { buildVersionFromRelease } from './components/PackageReleasesTab';
@@ -437,7 +437,7 @@ const PackageDetails = () => {
           </StackItem>
           {repository.security_level === 'remediated' && (
             <StackItem className={spacing.ptMd}>
-              <Alert variant='warning' isInline title='This data is sensitive. Do not share or capture screenshots.' />
+              <RemediatedDataWarning />
             </StackItem>
           )}
         </Stack>

--- a/src/Pages/Lightwell/Packages/PackageDetails.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Breadcrumb,
   BreadcrumbItem,
   Button,
@@ -434,6 +435,11 @@ const PackageDetails = () => {
               ) : null}
             </Flex>
           </StackItem>
+          {repository.security_level === 'remediated' && (
+            <StackItem className={spacing.ptMd}>
+              <Alert variant='warning' isInline title='This data is sensitive. Do not share or capture screenshots.' />
+            </StackItem>
+          )}
         </Stack>
       </Grid>
 

--- a/src/Pages/Lightwell/Packages/PackagesTable.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesTable.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Breadcrumb,
   BreadcrumbItem,
   Button,
@@ -377,6 +378,11 @@ const PackagesTable = () => {
               {getRepositoryDescription(repository.content_type, repository.security_level)}
             </Content>
           </StackItem>
+          {isRemediated && (
+            <StackItem className={spacing.ptSm}>
+              <Alert variant='warning' isInline title='This data is sensitive. Do not share or capture screenshots.' />
+            </StackItem>
+          )}
         </Stack>
       </Grid>
 

--- a/src/Pages/Lightwell/Packages/PackagesTable.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesTable.tsx
@@ -1,5 +1,4 @@
 import {
-  Alert,
   Breadcrumb,
   BreadcrumbItem,
   Button,
@@ -55,6 +54,7 @@ import EmptyTableState from 'components/EmptyTableState/EmptyTableState';
 import Loader from 'components/Loader';
 import ConnectRepositoryPopover from '../Repositories/components/ConnectRepositoryPopover';
 import { buildVersionFromRelease } from './components/PackageReleasesTab';
+import RemediatedDataWarning from '../RemediatedDataWarning';
 import useLightwellRepository from '../useLightwellRepository';
 
 const useStyles = createUseStyles({
@@ -380,7 +380,7 @@ const PackagesTable = () => {
           </StackItem>
           {isRemediated && (
             <StackItem className={spacing.ptSm}>
-              <Alert variant='warning' isInline title='This data is sensitive. Do not share or capture screenshots.' />
+              <RemediatedDataWarning />
             </StackItem>
           )}
         </Stack>

--- a/src/Pages/Lightwell/RemediatedDataWarning.tsx
+++ b/src/Pages/Lightwell/RemediatedDataWarning.tsx
@@ -1,0 +1,11 @@
+import { Alert } from '@patternfly/react-core';
+
+const RemediatedDataWarning = () => (
+  <Alert
+    variant='warning'
+    isInline
+    title='This data is sensitive. Do not share or capture screenshots.'
+  />
+);
+
+export default RemediatedDataWarning;


### PR DESCRIPTION
## Summary
- Adds an inline warning alert to all remediated repository pages (packages list and package detail)
- Warning text: "This data is sensitive. Do not share or capture screenshots."
- Only appears on remediated repos, not validated
- Placed inside the page header (`topContainer`) for consistent positioning

Context: [Slack thread](https://redhat-external.slack.com/archives/C0BDRCHCECB/p1783348043026749) — BK requested a reminder on remediated pages that this data should not be shared or screenshotted.

**Open question for the team:** Final warning text. Alternatives to consider:
1. This data is sensitive. Do not share or capture screenshots. *(current)*
2. Confidential. Do not share or capture screenshots.
3. Confidential. This data reveals unpatched vulnerabilities. Do not share externally.

## Test plan
- [ ] Navigate to a remediated repo (e.g. Java Remediated) — warning banner visible
- [ ] Navigate to a validated repo — no warning banner
- [ ] Navigate to a package detail within a remediated repo — warning banner visible
- [ ] Navigate to a package detail within a validated repo — no warning banner

co-authored by Claude Code