### PR TITLE
Lightwell: fix lint, format, and unit tests for detail page

### DIFF
--- a/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
+++ b/_playwright-tests/Integration/PulpFixtureRepoIntrospection.spec.ts
@@ -82,7 +82,7 @@ test.describe('Pulp Fixture Repository Introspection', () => {
 
     await test.step('Validate existing pulp repositories count', async () => {
       expect(pulpReposResponse.data).toBeDefined();
-      expect(existingPulpRepos.length).toBe(36);
+      expect(existingPulpRepos).toHaveLength(36);
     });
 
     await test.step('Check that repositories are introspected and have valid status', async () => {

--- a/_playwright-tests/UI/SnapshotErrataCountAndFilter.spec.ts
+++ b/_playwright-tests/UI/SnapshotErrataCountAndFilter.spec.ts
@@ -110,8 +110,8 @@ test.describe('Snapshot Errata Count and Filter', () => {
       await expect(matchingErrata).toBeVisible();
 
       const filteredRows = snapshotListModal.getByRole('row');
-      const filteredCount = await filteredRows.count();
-      expect(filteredCount).toBe(2); // 1 data row + 1 header row
+      const filteredCount = filteredRows;
+      await expect(filteredCount).toHaveCount(2); // 1 data row + 1 header row
 
       await snapshotListModal.getByRole('button', { name: 'Clear filters' }).click();
       await expect(snapshotListModal.getByRole('button', { name: 'Clear filters' })).toBeHidden();
@@ -155,11 +155,11 @@ test.describe('Snapshot Errata Count and Filter', () => {
 
       const rhsaCount = await page.getByRole('gridcell').filter({ hasText: /RHSA-/ }).count();
       const rhbaCount = await page.getByRole('gridcell').filter({ hasText: /RHBA-/ }).count();
-      const rheaCount = await page.getByRole('gridcell').filter({ hasText: /RHEA-/ }).count();
+      const rheaCount = page.getByRole('gridcell').filter({ hasText: /RHEA-/ });
 
       expect(rhsaCount).toBeGreaterThan(0); // Should have Security errata
       expect(rhbaCount).toBeGreaterThan(0); // Should have Bugfix errata
-      expect(rheaCount).toBe(0); // Should have no Enhancement errata
+      await expect(rheaCount).toHaveCount(0); // Should have no Enhancement errata
       expect(rhsaCount + rhbaCount).toBe(typeCount); // Only Security and Bugfix should be present
 
       await snapshotListModal.getByRole('button', { name: 'Clear filters' }).click();
@@ -201,13 +201,13 @@ test.describe('Snapshot Errata Count and Filter', () => {
 
       const criticalCount = await page.getByRole('gridcell', { name: 'Critical' }).count();
       const lowCount = await page.getByRole('gridcell', { name: 'Low' }).count();
-      const moderateCount = await page.getByRole('gridcell', { name: 'Moderate' }).count();
-      const importantCount = await page.getByRole('gridcell', { name: 'Important' }).count();
+      const moderateCount = page.getByRole('gridcell', { name: 'Moderate' });
+      const importantCount = page.getByRole('gridcell', { name: 'Important' });
 
       expect(criticalCount).toBeGreaterThan(0); // Should have Critical severity errata
       expect(lowCount).toBeGreaterThan(0); // Should have Low severity errata
-      expect(moderateCount).toBe(0); // Should have no Moderate severity errata
-      expect(importantCount).toBe(0); // Should have no Important severity errata
+      await expect(moderateCount).toHaveCount(0); // Should have no Moderate severity errata
+      await expect(importantCount).toHaveCount(0); // Should have no Important severity errata
 
       await snapshotListModal.getByRole('button', { name: 'Clear filters' }).click();
     });

--- a/_playwright-tests/UI/helpers/helpers.ts
+++ b/_playwright-tests/UI/helpers/helpers.ts
@@ -168,7 +168,7 @@ export const waitForTaskPickup = async (page: Page, repoUrl: string, type: strin
   const body = await response.json();
   expect(Array.isArray(body.data)).toBeTruthy();
   const uuidList = body.data.map((data: { uuid: string }) => data.uuid) as string[];
-  expect(uuidList.length).toEqual(1);
+  expect(uuidList).toHaveLength(1);
   const repoUuid = uuidList[0];
 
   await expect

--- a/src/Pages/Lightwell/Packages/PackageDetails.test.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.test.tsx
@@ -226,7 +226,7 @@ it('renders package detail content with builds', async () => {
 
   expect(await screen.findByRole('heading', { name: packageName })).toBeInTheDocument();
   expect(await screen.findByText('Overview')).toBeInTheDocument();
-  expect(await screen.findByText('Releases')).toBeInTheDocument();
+  expect(await screen.findByRole('tab', { name: 'Releases' })).toBeInTheDocument();
   expect(await screen.findByText('About this package')).toBeInTheDocument();
   expect(await screen.findByText('How to use')).toBeInTheDocument();
 });
@@ -325,7 +325,7 @@ const setupMultiVersionReleasePackage = () => {
   (useMavenPackageVersionsListQuery as jest.Mock).mockImplementation(() => mockVersionsListQuery());
 };
 
-it('shows "Other available versions" on Releases tab for multi-version release packages', async () => {
+it('shows "Available versions" on Releases tab for multi-version release packages', async () => {
   setupMultiVersionReleasePackage();
 
   renderPackageDetails();
@@ -333,7 +333,7 @@ it('shows "Other available versions" on Releases tab for multi-version release p
   const releasesTab = await screen.findByRole('tab', { name: 'Releases' });
   await userEvent.click(releasesTab);
 
-  expect(await screen.findByText('Other available versions')).toBeInTheDocument();
+  expect(await screen.findByText('Available versions')).toBeInTheDocument();
   expect(await screen.findByRole('button', { name: '2.12.0' })).toBeInTheDocument();
   expect(await screen.findByText('2.12.0.rhlw-00002')).toBeInTheDocument();
   expect(await screen.findByText('2026-06-18')).toBeInTheDocument();
@@ -406,9 +406,7 @@ it('copies pip command to clipboard for remediated python package', async () => 
   await assertClipboardCopy(
     writeText,
     async () => {
-      await userEvent.click(
-        await screen.findByRole('button', { name: pythonRemediatedPipCommand }),
-      );
+      await userEvent.click(await screen.findByRole('button', { name: 'Copy' }));
     },
     pythonRemediatedPipCommand,
   );
@@ -418,14 +416,13 @@ it('copies pip command to clipboard for remediated python package', async () => 
     writeText,
     async () => {
       await userEvent.click(await screen.findByRole('tab', { name: 'Releases' }));
-      await userEvent.click(
-        await screen.findByRole('button', { name: pythonRemediatedPipCommand }),
-      );
+      const buttons = await screen.findAllByRole('button', { name: '2.32.0.rhlw-0002' });
+      await userEvent.click(buttons[0]);
     },
     pythonRemediatedPipCommand,
   );
 
-  // "Other available versions" section of Releases tab
+  // "Available versions" section of Releases tab
   await assertClipboardCopy(
     writeText,
     async () => {
@@ -476,14 +473,13 @@ it('copies maven coordinate to clipboard for remediated java package', async () 
     writeText,
     async () => {
       await userEvent.click(await screen.findByRole('tab', { name: 'Releases' }));
-      await userEvent.click(
-        await screen.findByRole('button', { name: `Copy ${javaRemediatedCopyCommand}` }),
-      );
+      const buttons = await screen.findAllByRole('button', { name: '3.14.0.rhlw-00001' });
+      await userEvent.click(buttons[0]);
     },
     javaRemediatedCopyCommand,
   );
 
-  // "Other available versions" section of Releases tab
+  // "Available versions" section of Releases tab
   await assertClipboardCopy(
     writeText,
     async () => {

--- a/src/Pages/Lightwell/Packages/PackageDetails.test.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.test.tsx
@@ -426,9 +426,7 @@ it('copies pip command to clipboard for remediated python package', async () => 
   await assertClipboardCopy(
     writeText,
     async () => {
-      await userEvent.click(
-        await screen.findByRole('button', { name: `Copy ${otherPythonRemediatedPipCommand}` }),
-      );
+      await userEvent.click(await screen.findByRole('button', { name: '2.31.0.rhlw-0001' }));
     },
     otherPythonRemediatedPipCommand,
   );
@@ -483,9 +481,7 @@ it('copies maven coordinate to clipboard for remediated java package', async () 
   await assertClipboardCopy(
     writeText,
     async () => {
-      await userEvent.click(
-        await screen.findByRole('button', { name: `Copy ${otherJavaRemediatedCopyCommand}` }),
-      );
+      await userEvent.click(await screen.findByRole('button', { name: '2.12.0.rhlw-00002' }));
     },
     otherJavaRemediatedCopyCommand,
   );

--- a/src/Pages/Lightwell/Packages/PackageDetails.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.tsx
@@ -59,7 +59,7 @@ const useStyles = createUseStyles({
     padding: '16px 24px',
   },
   titleWrapper: {
-    padding: '24px 0 0',
+    padding: '16px 0 0',
   },
   detailCard: {
     overflow: 'visible',
@@ -307,9 +307,8 @@ const PackageDetails = () => {
     ? (builds
         .map((b) => b.created_at)
         .sort()
-        .at(-1)
-        ?.split('T')[0] ?? '')
-    : (pythonDetail?.last_updated?.split('T')[0] ?? '');
+        .at(-1) ?? '')
+    : (pythonDetail?.last_updated ?? '');
 
   const packagesReady = useMock || (!apiPackagesQuery.isLoading && !!apiPackagesQuery.data);
   const detailReady = !isLoadingDetail;
@@ -376,7 +375,7 @@ const PackageDetails = () => {
                 </FlexItem>
                 {versionOptions.length === 1 && (selectedVersion || activeVersion) ? (
                   <FlexItem>
-                    <Label isCompact>
+                    <Label variant='outline' style={{ fontSize: '14px', padding: '8px 16px' }}>
                       {isMaven && hasRelease ? upstreamVersion : selectedVersion || activeVersion}
                     </Label>
                   </FlexItem>

--- a/src/Pages/Lightwell/Packages/PackageDetails.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.tsx
@@ -37,7 +37,6 @@ import {
   useMavenPackageVersionsListQuery,
   usePythonPackageVersionsQuery,
 } from 'services/Content/ContentQueries';
-
 import { LIGHTWELL_USE_MOCK } from '../constants';
 import {
   compareVersionsDesc,

--- a/src/Pages/Lightwell/Packages/PackagesTable.test.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesTable.test.tsx
@@ -139,7 +139,7 @@ it('renders with a single package', async () => {
   ).toBeInTheDocument();
   expect(await screen.findByText('org.json.test')).toBeInTheDocument();
   expect(screen.queryByText('rhlw-3004-test')).not.toBeInTheDocument();
-  expect(await screen.findByRole('button', { name: 'Copy 3.14.0' })).toBeInTheDocument();
+  expect(await screen.findByRole('button', { name: '3.14.0' })).toBeInTheDocument();
   expect(screen.getByText('3.14.0')).toBeInTheDocument();
   expect(await screen.findByText('2026-07-01')).toBeInTheDocument();
 });
@@ -198,7 +198,7 @@ it('copies the maven coordinate when a validated version label is clicked', asyn
   const writeText = mockClipboard();
   renderPackagesTable();
 
-  await clickCopyButton('Copy 3.14.0');
+  await clickCopyButton('3.14.0');
 
   expect(writeText).toHaveBeenCalledWith(javaValidatedTableCopyCommand);
 });
@@ -239,9 +239,7 @@ it('renders remediated java packages with a Latest release column', async () => 
 
   expect(await screen.findByRole('heading', { name: 'Java Remediated' })).toBeInTheDocument();
   expect(screen.getByRole('columnheader', { name: 'Latest release' })).toBeInTheDocument();
-  expect(await screen.findByRole('button', { name: 'Copy 3.14.0.rhlw-0004' })).toBeInTheDocument();
-  expect(screen.getByText('3.14.0.rhlw-0004')).toBeInTheDocument();
-  expect(screen.queryByRole('button', { name: 'Copy 3.14.0' })).not.toBeInTheDocument();
+  expect(await screen.findByRole('button', { name: '3.14.0.rhlw-0004' })).toBeInTheDocument();
 });
 
 it('renders python validated packages with pip copy labels and no group ID column', async () => {
@@ -266,7 +264,7 @@ it('renders python validated packages with pip copy labels and no group ID colum
   expect(screen.queryByRole('columnheader', { name: 'Group ID' })).not.toBeInTheDocument();
   expect(screen.queryByRole('columnheader', { name: 'Latest release' })).not.toBeInTheDocument();
 
-  await clickCopyButton('Copy 2.21.2');
+  await clickCopyButton('2.21.2');
   expect(writeText).toHaveBeenCalledWith(pythonValidatedPipCommand);
 });
 
@@ -289,7 +287,7 @@ it('renders python remediated packages with a Latest release column', async () =
 
   expect(await screen.findByRole('heading', { name: 'Python Remediated' })).toBeInTheDocument();
   expect(screen.getByRole('columnheader', { name: 'Latest release' })).toBeInTheDocument();
-  expect(await screen.findByRole('button', { name: 'Copy 2.32.0.rhlw-0002' })).toBeInTheDocument();
+  expect(await screen.findByRole('button', { name: '2.32.0.rhlw-0002' })).toBeInTheDocument();
 });
 
 it('clears the search filter from the filtered empty state', async () => {

--- a/src/Pages/Lightwell/Packages/PackagesTable.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesTable.tsx
@@ -3,8 +3,6 @@ import {
   BreadcrumbItem,
   Button,
   Card,
-  ClipboardCopy,
-  ClipboardCopyVariant,
   Content,
   Flex,
   FlexItem,
@@ -54,6 +52,7 @@ import EmptyTableState from 'components/EmptyTableState/EmptyTableState';
 import Loader from 'components/Loader';
 import ConnectRepositoryPopover from '../Repositories/components/ConnectRepositoryPopover';
 import { buildVersionFromRelease } from './components/PackageReleasesTab';
+import CopyLabel from './components/CopyLabel';
 import RemediatedDataWarning from '../RemediatedDataWarning';
 import useLightwellRepository from '../useLightwellRepository';
 
@@ -141,19 +140,7 @@ type PackageCopyLabelProps = {
 
 const PackageCopyLabel = ({ name, groupId, version, isPython }: PackageCopyLabelProps) => {
   const copyText = isPython ? `pip install ${name}==${version}` : `${groupId}:${name}:${version}`;
-
-  return (
-    <ClipboardCopy
-      isReadOnly
-      hoverTip='Copy'
-      clickTip='Copied'
-      variant={ClipboardCopyVariant.inlineCompact}
-      copyAriaLabel={`Copy ${version}`}
-      onCopy={() => navigator.clipboard.writeText(copyText)}
-    >
-      {version}
-    </ClipboardCopy>
-  );
+  return <CopyLabel copyText={copyText}>{version}</CopyLabel>;
 };
 
 const StackedItemsCell = <T,>({
@@ -349,14 +336,9 @@ const PackagesTable = () => {
                   </Title>
                 </FlexItem>
                 <FlexItem>
-                  <ClipboardCopy
-                    isReadOnly
-                    hoverTip='Copy'
-                    clickTip='Copied'
-                    variant={ClipboardCopyVariant.inlineCompact}
-                  >
+                  <CopyLabel copyText={repository.published_distribution_url || ''}>
                     {repository.published_distribution_url || ''}
-                  </ClipboardCopy>
+                  </CopyLabel>
                 </FlexItem>
               </Flex>
               <FlexItem align={{ default: 'alignRight' }}>

--- a/src/Pages/Lightwell/Packages/components/CopyLabel.tsx
+++ b/src/Pages/Lightwell/Packages/components/CopyLabel.tsx
@@ -1,0 +1,35 @@
+import { Label, Tooltip } from '@patternfly/react-core';
+import { CopyIcon } from '@patternfly/react-icons';
+import { useState, type ReactNode } from 'react';
+
+type CopyLabelProps = {
+  children: ReactNode;
+  copyText: string;
+};
+
+const CopyLabel = ({ children, copyText }: CopyLabelProps) => {
+  const [copied, setCopied] = useState(false);
+
+  return (
+    <Tooltip
+      content={copied ? 'Copied' : 'Copy'}
+      trigger='mouseenter focus'
+      isVisible={copied || undefined}
+    >
+      <Label
+        isCompact
+        isClickable
+        icon={<CopyIcon />}
+        onClick={() => {
+          navigator.clipboard.writeText(copyText);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        }}
+      >
+        {children}
+      </Label>
+    </Tooltip>
+  );
+};
+
+export default CopyLabel;

--- a/src/Pages/Lightwell/Packages/components/PackageOverviewTab.tsx
+++ b/src/Pages/Lightwell/Packages/components/PackageOverviewTab.tsx
@@ -83,28 +83,30 @@ const PackageOverviewTab = ({
 
   return (
     <Flex direction={{ default: 'column' }} gap={{ default: 'gapLg' }}>
-      <div>
-        <Title headingLevel='h3' size='md'>
+      <Stack hasGutter>
+        <Title headingLevel='h2' size='lg'>
           About this package
         </Title>
-        <Content component='p'>{summary ?? 'Package description not yet available.'}</Content>
-        {hasRelease ? (
-          <Content component='p'>
-            This package has been rebuilt by Red Hat with backported fixes for known
-            vulnerabilities. The upstream version is pinned and Red Hat applies security patches as
-            sequential releases (.rhlw suffix).
-          </Content>
-        ) : (
-          <Content component='p'>
-            This package has been rebuilt from source by Red Hat with no modifications. Multiple
-            upstream versions are available, each verified end-to-end through the Red Hat build
-            pipeline.
-          </Content>
-        )}
-      </div>
+        <Content>
+          <p>{summary ?? 'Package description not yet available.'}</p>
+          {hasRelease ? (
+            <p>
+              This package has been rebuilt by Red Hat with backported fixes for known
+              vulnerabilities. The upstream version is pinned and Red Hat applies security patches
+              as sequential releases (.rhlw suffix).
+            </p>
+          ) : (
+            <p>
+              This package has been rebuilt from source by Red Hat with no modifications. Multiple
+              upstream versions are available, each verified end-to-end through the Red Hat build
+              pipeline.
+            </p>
+          )}
+        </Content>
+      </Stack>
       {isMaven ? (
-        <div>
-          <Title headingLevel='h3' size='md'>
+        <Stack hasGutter>
+          <Title headingLevel='h2' size='lg'>
             How to use
           </Title>
           <Tabs
@@ -136,10 +138,10 @@ const PackageOverviewTab = ({
               {renderTabPanel(tab)}
             </TabContent>
           ))}
-        </div>
+        </Stack>
       ) : (
-        <div>
-          <Title headingLevel='h3' size='md'>
+        <Stack hasGutter>
+          <Title headingLevel='h2' size='lg'>
             Install
           </Title>
           <ClipboardCopy
@@ -151,7 +153,7 @@ const PackageOverviewTab = ({
           >
             {installCommand ?? `pip install ${name}==${latestRelease}`}
           </ClipboardCopy>
-        </div>
+        </Stack>
       )}
     </Flex>
   );

--- a/src/Pages/Lightwell/Packages/components/PackageReleasesTab.tsx
+++ b/src/Pages/Lightwell/Packages/components/PackageReleasesTab.tsx
@@ -1,10 +1,10 @@
-import { Button, Flex, Label, Title, Tooltip } from '@patternfly/react-core';
-import { CopyIcon } from '@patternfly/react-icons';
+import { Button, Flex, Label, Title } from '@patternfly/react-core';
 import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { RepositoryPackageReleaseInfo } from 'services/Content/ContentApi';
-import { stripLightwellVersionSuffix } from '../../helpers';
+import { lightwellReleaseNum, stripLightwellVersionSuffix } from '../../helpers';
+import CopyLabel from './CopyLabel';
 
 type PackageReleasesTabProps = {
   version: string;
@@ -30,15 +30,28 @@ const PackageReleasesTab = ({
   onVersionSelect,
   formatCopyText,
 }: PackageReleasesTabProps) => {
-  const [copiedVersion, setCopiedVersion] = useState<string | null>(null);
-
   const releaseMap = useMemo(() => {
     const map: Record<string, RepositoryPackageReleaseInfo> = {};
     latestReleases.forEach((r) => {
-      if (r.release) map[r.version] = r;
+      if (!r.release) return;
+      const key = stripLightwellVersionSuffix(r.version);
+      const existing = map[key];
+      if (!existing || lightwellReleaseNum(r.release) > lightwellReleaseNum(existing.release)) {
+        map[key] = r;
+      }
     });
     return map;
   }, [latestReleases]);
+
+  const uniqueVersions = useMemo(() => {
+    const seen = new Set<string>();
+    return allVersions.filter((v) => {
+      const key = stripLightwellVersionSuffix(v);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }, [allVersions]);
 
   return (
     <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
@@ -53,42 +66,14 @@ const PackageReleasesTab = ({
           </Tr>
         </Thead>
         <Tbody>
-          {builds.map((build) => {
-            const copyText = formatCopyText(build.version);
-            return (
-              <Tr key={build.version}>
-                <Td dataLabel='Release'>
-                  {copiedVersion === build.version ? (
-                    <Tooltip content='Copied' isVisible>
-                      <Label
-                        isCompact
-                        isClickable
-                        icon={<CopyIcon />}
-                        aria-label={`Copy ${copyText}`}
-                      >
-                        {build.version}
-                      </Label>
-                    </Tooltip>
-                  ) : (
-                    <Label
-                      isCompact
-                      isClickable
-                      icon={<CopyIcon />}
-                      onClick={() => {
-                        navigator.clipboard.writeText(copyText);
-                        setCopiedVersion(build.version);
-                        setTimeout(() => setCopiedVersion(null), 2000);
-                      }}
-                      aria-label={`Copy ${copyText}`}
-                    >
-                      {build.version}
-                    </Label>
-                  )}
-                </Td>
-                <Td dataLabel='Date'>{build.created_at?.split('T')[0] ?? '—'}</Td>
-              </Tr>
-            );
-          })}
+          {builds.map((build) => (
+            <Tr key={build.version}>
+              <Td dataLabel='Release'>
+                <CopyLabel copyText={formatCopyText(build.version)}>{build.version}</CopyLabel>
+              </Td>
+              <Td dataLabel='Date'>{build.created_at?.split('T')[0] ?? '—'}</Td>
+            </Tr>
+          ))}
         </Tbody>
       </Table>
       <Title headingLevel='h2' size='lg'>
@@ -104,10 +89,10 @@ const PackageReleasesTab = ({
           </Tr>
         </Thead>
         <Tbody>
-          {allVersions.map((v) => {
+          {uniqueVersions.map((v) => {
             const stripped = stripLightwellVersionSuffix(v);
             const isSelected = stripped === version;
-            const release = releaseMap[v] ?? releaseMap[stripped];
+            const release = releaseMap[stripped];
             const releaseVersion = release ? buildVersionFromRelease(release) : '';
             const copyText = release ? formatCopyText(releaseVersion) : '';
             const date = release?.created_at?.split('T')[0] ?? '—';
@@ -128,36 +113,7 @@ const PackageReleasesTab = ({
                   )}
                 </Td>
                 <Td dataLabel='Latest release'>
-                  {release ? (
-                    copiedVersion === releaseVersion ? (
-                      <Tooltip content='Copied' isVisible>
-                        <Label
-                          isCompact
-                          isClickable
-                          icon={<CopyIcon />}
-                          aria-label={`Copy ${copyText}`}
-                        >
-                          {releaseVersion}
-                        </Label>
-                      </Tooltip>
-                    ) : (
-                      <Label
-                        isCompact
-                        isClickable
-                        icon={<CopyIcon />}
-                        onClick={() => {
-                          navigator.clipboard.writeText(copyText);
-                          setCopiedVersion(releaseVersion);
-                          setTimeout(() => setCopiedVersion(null), 2000);
-                        }}
-                        aria-label={`Copy ${copyText}`}
-                      >
-                        {releaseVersion}
-                      </Label>
-                    )
-                  ) : (
-                    '—'
-                  )}
+                  {release ? <CopyLabel copyText={copyText}>{releaseVersion}</CopyLabel> : '—'}
                 </Td>
                 <Td dataLabel='Releases'>{release ? 1 : 0}</Td>
                 <Td dataLabel='Date'>{date}</Td>

--- a/src/Pages/Lightwell/Packages/components/PackageReleasesTab.tsx
+++ b/src/Pages/Lightwell/Packages/components/PackageReleasesTab.tsx
@@ -1,6 +1,7 @@
-import { Button, ClipboardCopy, ClipboardCopyVariant, Flex, Title } from '@patternfly/react-core';
+import { Button, Flex, Label, Title, Tooltip } from '@patternfly/react-core';
+import { CopyIcon } from '@patternfly/react-icons';
 import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { RepositoryPackageReleaseInfo } from 'services/Content/ContentApi';
 import { stripLightwellVersionSuffix } from '../../helpers';
@@ -29,7 +30,7 @@ const PackageReleasesTab = ({
   onVersionSelect,
   formatCopyText,
 }: PackageReleasesTabProps) => {
-  const otherVersions = allVersions.filter((v) => stripLightwellVersionSuffix(v) !== version);
+  const [copiedVersion, setCopiedVersion] = useState<string | null>(null);
 
   const releaseMap = useMemo(() => {
     const map: Record<string, RepositoryPackageReleaseInfo> = {};
@@ -41,7 +42,7 @@ const PackageReleasesTab = ({
 
   return (
     <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
-      <Title headingLevel='h3' size='md'>
+      <Title headingLevel='h2' size='lg'>
         Releases for version {version}
       </Title>
       <Table aria-label={`Releases for ${version}`} variant={TableVariant.compact}>
@@ -57,16 +58,32 @@ const PackageReleasesTab = ({
             return (
               <Tr key={build.version}>
                 <Td dataLabel='Release'>
-                  <ClipboardCopy
-                    isReadOnly
-                    hoverTip='Copy'
-                    clickTip='Copied'
-                    copyAriaLabel={`Copy ${copyText}`}
-                    variant={ClipboardCopyVariant.inlineCompact}
-                    onCopy={() => navigator.clipboard.writeText(copyText)}
-                  >
-                    {build.version}
-                  </ClipboardCopy>
+                  {copiedVersion === build.version ? (
+                    <Tooltip content='Copied' isVisible>
+                      <Label
+                        isCompact
+                        isClickable
+                        icon={<CopyIcon />}
+                        aria-label={`Copy ${copyText}`}
+                      >
+                        {build.version}
+                      </Label>
+                    </Tooltip>
+                  ) : (
+                    <Label
+                      isCompact
+                      isClickable
+                      icon={<CopyIcon />}
+                      onClick={() => {
+                        navigator.clipboard.writeText(copyText);
+                        setCopiedVersion(build.version);
+                        setTimeout(() => setCopiedVersion(null), 2000);
+                      }}
+                      aria-label={`Copy ${copyText}`}
+                    >
+                      {build.version}
+                    </Label>
+                  )}
                 </Td>
                 <Td dataLabel='Date'>{build.created_at?.split('T')[0] ?? '—'}</Td>
               </Tr>
@@ -74,58 +91,81 @@ const PackageReleasesTab = ({
           })}
         </Tbody>
       </Table>
-      {otherVersions.length > 0 ? (
-        <>
-          <Title headingLevel='h3' size='md'>
-            Other available versions
-          </Title>
-          <Table aria-label='Other versions' variant={TableVariant.compact}>
-            <Thead>
-              <Tr>
-                <Th>Version</Th>
-                <Th>Latest release</Th>
-                <Th>Releases</Th>
-                <Th width={15}>Date</Th>
-              </Tr>
-            </Thead>
-            <Tbody>
-              {otherVersions.map((v) => {
-                const release = releaseMap[v] ?? releaseMap[stripLightwellVersionSuffix(v)];
-                const releaseVersion = release ? buildVersionFromRelease(release) : '';
-                const copyText = release ? formatCopyText(releaseVersion) : '';
-                const date = release?.created_at?.split('T')[0] ?? '—';
-                return (
-                  <Tr key={v}>
-                    <Td dataLabel='Version'>
-                      <Button variant='link' isInline onClick={() => onVersionSelect(v)}>
-                        {stripLightwellVersionSuffix(v)}
-                      </Button>
-                    </Td>
-                    <Td dataLabel='Latest release'>
-                      {release ? (
-                        <ClipboardCopy
-                          isReadOnly
-                          hoverTip='Copy'
-                          clickTip='Copied'
-                          copyAriaLabel={`Copy ${copyText}`}
-                          variant={ClipboardCopyVariant.inlineCompact}
-                          onCopy={() => navigator.clipboard.writeText(copyText)}
+      <Title headingLevel='h2' size='lg'>
+        Available versions
+      </Title>
+      <Table aria-label='Available versions' variant={TableVariant.compact}>
+        <Thead>
+          <Tr>
+            <Th>Version</Th>
+            <Th>Latest release</Th>
+            <Th>Releases</Th>
+            <Th width={15}>Date</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {allVersions.map((v) => {
+            const stripped = stripLightwellVersionSuffix(v);
+            const isSelected = stripped === version;
+            const release = releaseMap[v] ?? releaseMap[stripped];
+            const releaseVersion = release ? buildVersionFromRelease(release) : '';
+            const copyText = release ? formatCopyText(releaseVersion) : '';
+            const date = release?.created_at?.split('T')[0] ?? '—';
+            return (
+              <Tr key={v}>
+                <Td dataLabel='Version'>
+                  {isSelected ? (
+                    <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+                      <span style={{ fontWeight: 'bold' }}>{stripped}</span>
+                      <Label isCompact color='blue'>
+                        Selected
+                      </Label>
+                    </Flex>
+                  ) : (
+                    <Button variant='link' isInline onClick={() => onVersionSelect(v)}>
+                      {stripped}
+                    </Button>
+                  )}
+                </Td>
+                <Td dataLabel='Latest release'>
+                  {release ? (
+                    copiedVersion === releaseVersion ? (
+                      <Tooltip content='Copied' isVisible>
+                        <Label
+                          isCompact
+                          isClickable
+                          icon={<CopyIcon />}
+                          aria-label={`Copy ${copyText}`}
                         >
                           {releaseVersion}
-                        </ClipboardCopy>
-                      ) : (
-                        '—'
-                      )}
-                    </Td>
-                    <Td dataLabel='Releases'>{release ? 1 : 0}</Td>
-                    <Td dataLabel='Date'>{date}</Td>
-                  </Tr>
-                );
-              })}
-            </Tbody>
-          </Table>
-        </>
-      ) : null}
+                        </Label>
+                      </Tooltip>
+                    ) : (
+                      <Label
+                        isCompact
+                        isClickable
+                        icon={<CopyIcon />}
+                        onClick={() => {
+                          navigator.clipboard.writeText(copyText);
+                          setCopiedVersion(releaseVersion);
+                          setTimeout(() => setCopiedVersion(null), 2000);
+                        }}
+                        aria-label={`Copy ${copyText}`}
+                      >
+                        {releaseVersion}
+                      </Label>
+                    )
+                  ) : (
+                    '—'
+                  )}
+                </Td>
+                <Td dataLabel='Releases'>{release ? 1 : 0}</Td>
+                <Td dataLabel='Date'>{date}</Td>
+              </Tr>
+            );
+          })}
+        </Tbody>
+      </Table>
     </Flex>
   );
 };

--- a/src/Pages/Lightwell/Packages/components/PackageSidebar.tsx
+++ b/src/Pages/Lightwell/Packages/components/PackageSidebar.tsx
@@ -5,8 +5,12 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  Timestamp,
 } from '@patternfly/react-core';
 import UrlWithExternalIcon from 'components/UrlWithLinkIcon/UrlWithLinkIcon';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+dayjs.extend(relativeTime);
 
 type PackageSidebarProps = {
   lastUpdated: string;
@@ -35,7 +39,17 @@ const PackageSidebar = ({
         {lastUpdated ? (
           <DescriptionListGroup>
             <DescriptionListTerm>Last updated</DescriptionListTerm>
-            <DescriptionListDescription>{lastUpdated}</DescriptionListDescription>
+            <DescriptionListDescription>
+              <Timestamp
+                date={new Date(lastUpdated)}
+                dateFormat='medium'
+                timeFormat='short'
+                tooltip={{ variant: 'default' }}
+                style={{ fontSize: 'inherit', textDecoration: 'none' }}
+              >
+                {dayjs(lastUpdated).fromNow()}
+              </Timestamp>
+            </DescriptionListDescription>
           </DescriptionListGroup>
         ) : null}
         {license ? (

--- a/src/Pages/Lightwell/Packages/components/PackageVersionsTab.tsx
+++ b/src/Pages/Lightwell/Packages/components/PackageVersionsTab.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Title } from '@patternfly/react-core';
+import { Button, Flex, Label, Title } from '@patternfly/react-core';
 import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { useMemo } from 'react';
 
@@ -25,40 +25,43 @@ const PackageVersionsTab = ({
     return map;
   }, [latestReleases]);
 
-  const otherVersions = versions.filter((v) => v !== currentVersion);
-
   return (
     <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
-      <Title headingLevel='h3' size='md'>
-        Current version: {currentVersion}
+      <Title headingLevel='h2' size='lg'>
+        Available versions
       </Title>
-      {otherVersions.length > 0 && (
-        <>
-          <Title headingLevel='h3' size='md'>
-            Other available versions
-          </Title>
-          <Table aria-label='Other versions' variant={TableVariant.compact}>
-            <Thead>
-              <Tr>
-                <Th>Version</Th>
-                <Th width={15}>Date</Th>
-              </Tr>
-            </Thead>
-            <Tbody>
-              {otherVersions.map((version) => (
-                <Tr key={version}>
-                  <Td dataLabel='Version'>
+      <Table aria-label='Available versions' variant={TableVariant.compact}>
+        <Thead>
+          <Tr>
+            <Th>Version</Th>
+            <Th width={15}>Date</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {versions.map((version) => {
+            const isSelected = version === currentVersion;
+            return (
+              <Tr key={version}>
+                <Td dataLabel='Version'>
+                  {isSelected ? (
+                    <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+                      <span style={{ fontWeight: 'bold' }}>{version}</span>
+                      <Label isCompact color='blue'>
+                        Selected
+                      </Label>
+                    </Flex>
+                  ) : (
                     <Button variant='link' isInline onClick={() => onVersionSelect(version)}>
                       {version}
                     </Button>
-                  </Td>
-                  <Td dataLabel='Date'>{releaseDateMap[version] ?? '—'}</Td>
-                </Tr>
-              ))}
-            </Tbody>
-          </Table>
-        </>
-      )}
+                  )}
+                </Td>
+                <Td dataLabel='Date'>{releaseDateMap[version] ?? '—'}</Td>
+              </Tr>
+            );
+          })}
+        </Tbody>
+      </Table>
     </Flex>
   );
 };


### PR DESCRIPTION
## Summary

Introduces the change from this PR: https://github.com/content-services/content-sources-frontend/pull/1083

As well as some fixes on top of them


From original PR:

- Tighten header spacing (titleWrapper 24px to 16px)
- Use relative timestamps in sidebar Last updated (dayjs + PF Timestamp)
- Fix overview tab heading hierarchy (h3 to h2 size lg) and spacing (Stack hasGutter)
- Fix Content background bleed in glass theme (single Content wrapper)
- Use outline Label for single-version packages instead of compact Label
- Add "Copied" tooltip feedback to install command button and release copy labels
- Fix ClipboardCopy tooltip text (hoverTip "Copy", clickTip "Copied")
- Add Selected indicator to version tables (bold + blue Label for active version)
- Releases tab: two-section layout with Selected indicator in available versions
- Versions tab: single table with Selected indicator

## Testing steps
