### PR TITLE
Lightwell: update connect popover with auth and accurate snippets

### DIFF
--- a/src/Pages/Lightwell/Packages/PackagesTable.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesTable.tsx
@@ -50,7 +50,7 @@ import Hide from 'components/Hide/Hide';
 import { LIGHTWELL_USE_MOCK, lightwellPkgsPerPageKey } from '../constants';
 import EmptyTableState from 'components/EmptyTableState/EmptyTableState';
 import Loader from 'components/Loader';
-import ConnectRepositoryPopover from '../Repositories/components/ConnectRepositoryPopover';
+import ConnectRepositoryModal from '../Repositories/components/ConnectRepositoryModal';
 import { buildVersionFromRelease } from './components/PackageReleasesTab';
 import CopyLabel from './components/CopyLabel';
 import RemediatedDataWarning from '../RemediatedDataWarning';
@@ -342,7 +342,7 @@ const PackagesTable = () => {
                 </FlexItem>
               </Flex>
               <FlexItem align={{ default: 'alignRight' }}>
-                <ConnectRepositoryPopover
+                <ConnectRepositoryModal
                   repository={{
                     uuid: repository.uuid,
                     name: repository.name,
@@ -353,7 +353,7 @@ const PackagesTable = () => {
                   <Button size='sm' variant='secondary' icon={<CodeIcon />}>
                     Connect
                   </Button>
-                </ConnectRepositoryPopover>
+                </ConnectRepositoryModal>
               </FlexItem>
             </Flex>
             <Content className={spacing.pySm}>

--- a/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
+++ b/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
@@ -43,7 +43,7 @@ import {
   formatRepositoryName,
   getRepositoryPathSlug,
 } from '../helpers';
-import ConnectRepositoryPopover from './components/ConnectRepositoryPopover';
+import ConnectRepositoryModal from './components/ConnectRepositoryModal';
 import { capitalize } from 'lodash';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
@@ -231,7 +231,7 @@ const RepositoriesTable = () => {
                                   </Content>
                                 </FlexItem>
                                 <FlexItem>
-                                  <ConnectRepositoryPopover
+                                  <ConnectRepositoryModal
                                     repository={{
                                       uuid,
                                       name,
@@ -248,7 +248,7 @@ const RepositoriesTable = () => {
                                     >
                                       Connect to this repository
                                     </Label>
-                                  </ConnectRepositoryPopover>
+                                  </ConnectRepositoryModal>
                                 </FlexItem>
                               </Flex>
                             </Td>

--- a/src/Pages/Lightwell/Repositories/components/ConnectRepositoryContent.tsx
+++ b/src/Pages/Lightwell/Repositories/components/ConnectRepositoryContent.tsx
@@ -5,29 +5,70 @@ import {
   Content,
   Flex,
   FlexItem,
-  Popover,
   Tab,
   TabContent,
   Tabs,
   TabTitleText,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { createRef, ReactElement, useMemo, useState } from 'react';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import { createRef, useEffect, useMemo, useState } from 'react';
 
 import { ContentItem } from 'services/Content/ContentApi';
 
 import { ConnectSnippetTab, getConnectSnippetTabs } from './connectSnippets';
-import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
-type ConnectRepositoryPopoverProps = {
+type ConnectRepositoryContentProps = {
   repository: Pick<ContentItem, 'name' | 'published_distribution_url' | 'content_type' | 'uuid'>;
-  children: ReactElement;
 };
 
-const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPopoverProps) => {
+const renderTabPanel = (tab: ConnectSnippetTab) => (
+  <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
+    {tab.snippets.map((snippet) => (
+      <FlexItem key={snippet.label}>
+        <Content component='p' style={{ textAlign: 'left' }}>
+          {snippet.label}
+        </Content>
+        <ClipboardCopy
+          isReadOnly
+          isCode
+          hoverTip='Copy'
+          clickTip='Copied'
+          variant={snippet.urlOnly ? ClipboardCopyVariant.inline : ClipboardCopyVariant.expansion}
+          isExpanded={false}
+        >
+          {snippet.code}
+        </ClipboardCopy>
+        {snippet.description && (
+          <Content component='small' className={spacing.mtSm} style={{ textAlign: 'left' }}>
+            {snippet.description}
+          </Content>
+        )}
+      </FlexItem>
+    ))}
+    {tab.docsUrl && (
+      <FlexItem>
+        <Button
+          variant='link'
+          isInline
+          component='a'
+          href={tab.docsUrl}
+          target='_blank'
+          rel='noopener noreferrer'
+          icon={<ExternalLinkAltIcon />}
+          iconPosition='end'
+        >
+          Full documentation for {tab.title}
+        </Button>
+      </FlexItem>
+    )}
+  </Flex>
+);
+
+const ConnectRepositoryContent = ({ repository }: ConnectRepositoryContentProps) => {
   const tabs = useMemo(() => getConnectSnippetTabs(repository), [repository]);
-  const [activeTabKey, setActiveTabKey] = useState(tabs[0]?.eventKey ?? '');
   const firstTabKey = tabs[0]?.eventKey ?? '';
+  const [activeTabKey, setActiveTabKey] = useState(firstTabKey);
 
   const tabRefs = useMemo(
     () =>
@@ -41,51 +82,13 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
     [tabs],
   );
 
-  const renderTabPanel = (tab: ConnectSnippetTab) => (
-    <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
-      {tab.snippets.map((snippet) => (
-        <FlexItem key={snippet.label}>
-          <Content component='p' style={{ textAlign: 'left' }}>
-            {snippet.label}
-          </Content>
-          <ClipboardCopy
-            isReadOnly
-            isCode
-            hoverTip='Copy'
-            clickTip='Copied'
-            variant={snippet.urlOnly ? ClipboardCopyVariant.inline : ClipboardCopyVariant.expansion}
-            isExpanded={!snippet.urlOnly}
-          >
-            {snippet.code}
-          </ClipboardCopy>
-          {snippet.description && (
-            <Content component='small' className={spacing.mtSm} style={{ textAlign: 'left' }}>
-              {snippet.description}
-            </Content>
-          )}
-        </FlexItem>
-      ))}
-      {tab.docsUrl && (
-        <FlexItem>
-          <Button
-            variant='link'
-            isInline
-            component='a'
-            href={tab.docsUrl}
-            target='_blank'
-            icon={<ExternalLinkAltIcon />}
-            iconPosition='end'
-          >
-            Full documentation for {tab.title}
-          </Button>
-        </FlexItem>
-      )}
-    </Flex>
-  );
+  useEffect(() => {
+    setActiveTabKey(firstTabKey);
+  }, [firstTabKey, repository.uuid]);
 
-  const bodyContent = (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
-      <div>
+  return (
+    <Flex direction={{ default: 'column' }} gap={{ default: 'gapLg' }}>
+      <FlexItem>
         <Content component='h4' className={spacing.mbSm}>
           Authenticate build tools
         </Content>
@@ -97,6 +100,7 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
             component='a'
             href='https://access.redhat.com/terms-based-registry/'
             target='_blank'
+            rel='noopener noreferrer'
             icon={<ExternalLinkAltIcon />}
             iconPosition='end'
             style={{ fontWeight: 'bold' }}
@@ -112,6 +116,7 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
             component='a'
             href='https://docs.redhat.com/en/documentation/red_hat_lightwell_network/'
             target='_blank'
+            rel='noopener noreferrer'
             icon={<ExternalLinkAltIcon />}
             iconPosition='end'
           >
@@ -119,8 +124,8 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
           </Button>
           .
         </Content>
-      </div>
-      <div>
+      </FlexItem>
+      <FlexItem>
         <Content component='h4' className={spacing.mbSm}>
           Connect to your build tool
         </Content>
@@ -153,23 +158,9 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
             {renderTabPanel(tab)}
           </TabContent>
         ))}
-      </div>
-    </div>
-  );
-
-  return (
-    <Popover
-      aria-label='Connect to this repository'
-      headerContent='Connect to this repository'
-      bodyContent={bodyContent}
-      position='right-start'
-      flipBehavior={['right-start', 'left-start']}
-      onShow={() => setActiveTabKey(firstTabKey)}
-      minWidth='600px'
-    >
-      {children}
-    </Popover>
+      </FlexItem>
+    </Flex>
   );
 };
 
-export default ConnectRepositoryPopover;
+export default ConnectRepositoryContent;

--- a/src/Pages/Lightwell/Repositories/components/ConnectRepositoryModal.tsx
+++ b/src/Pages/Lightwell/Repositories/components/ConnectRepositoryModal.tsx
@@ -1,0 +1,51 @@
+import { Modal, ModalBody, ModalHeader, ModalVariant } from '@patternfly/react-core';
+import { cloneElement, ReactElement, useState } from 'react';
+
+import { ContentItem } from 'services/Content/ContentApi';
+
+import ConnectRepositoryContent from './ConnectRepositoryContent';
+
+type ConnectRepositoryModalProps = {
+  repository: Pick<ContentItem, 'name' | 'published_distribution_url' | 'content_type' | 'uuid'>;
+  children: ReactElement<{ onClick?: (event: React.MouseEvent) => void }>;
+};
+
+const ConnectRepositoryModal = ({ repository, children }: ConnectRepositoryModalProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openModal = () => setIsOpen(true);
+  const closeModal = () => setIsOpen(false);
+
+  const trigger = cloneElement(children, {
+    onClick: (event: React.MouseEvent) => {
+      children.props.onClick?.(event);
+      if (!event.defaultPrevented) {
+        openModal();
+      }
+    },
+  });
+
+  return (
+    <>
+      {trigger}
+      <Modal
+        variant={ModalVariant.large}
+        position='top'
+        isOpen={isOpen}
+        onClose={closeModal}
+        aria-labelledby='lightwell-connect-repository-modal-title'
+        ouiaId='lightwell-connect-repository-modal'
+      >
+        <ModalHeader
+          title='Connect to this repository'
+          labelId='lightwell-connect-repository-modal-title'
+        />
+        <ModalBody>
+          <ConnectRepositoryContent repository={repository} />
+        </ModalBody>
+      </Modal>
+    </>
+  );
+};
+
+export default ConnectRepositoryModal;

--- a/src/Pages/Lightwell/Repositories/components/ConnectRepositoryPopover.tsx
+++ b/src/Pages/Lightwell/Repositories/components/ConnectRepositoryPopover.tsx
@@ -1,4 +1,6 @@
 import {
+  Alert,
+  Button,
   ClipboardCopy,
   ClipboardCopyVariant,
   Content,
@@ -10,6 +12,7 @@ import {
   Tabs,
   TabTitleText,
 } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { createRef, ReactElement, useMemo, useState } from 'react';
 
 import { ContentItem } from 'services/Content/ContentApi';
@@ -68,6 +71,20 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
 
   const bodyContent = (
     <div>
+      <Alert variant='info' isInline isPlain title='Authentication required' className={spacing.mbMd}>
+        <Button
+          variant='link'
+          isInline
+          component='a'
+          href='https://access.redhat.com/terms-based-registry/'
+          target='_blank'
+          icon={<ExternalLinkAltIcon />}
+          iconPosition='end'
+        >
+          Create a service account
+        </Button>{' '}
+        to generate credentials.
+      </Alert>
       <Tabs
         activeKey={activeTabKey}
         onSelect={(_, eventKey) => setActiveTabKey(eventKey as string)}

--- a/src/Pages/Lightwell/Repositories/components/ConnectRepositoryPopover.tsx
+++ b/src/Pages/Lightwell/Repositories/components/ConnectRepositoryPopover.tsx
@@ -86,67 +86,73 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
   const bodyContent = (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
       <div>
-        <Content component='h4' className={spacing.mbSm}>Authenticate build tools</Content>
+        <Content component='h4' className={spacing.mbSm}>
+          Authenticate build tools
+        </Content>
         <Content component='p'>
-        {'First, '}
-        <Button
-          variant='link'
-          isInline
-          component='a'
-          href='https://access.redhat.com/terms-based-registry/'
-          target='_blank'
-          icon={<ExternalLinkAltIcon />}
-          iconPosition='end'
-          style={{ fontWeight: 'bold' }}
-        >
-          create a service account
-        </Button>
-        {' for Lightwell. Use the username and token in the snippets below. For further help, see '}
-        <Button
-          variant='link'
-          isInline
-          component='a'
-          href='https://docs.redhat.com/en/documentation/red_hat_lightwell_network/'
-          target='_blank'
-          icon={<ExternalLinkAltIcon />}
-          iconPosition='end'
-        >
-          Documentation
-        </Button>
-        .
-      </Content>
+          {'First, '}
+          <Button
+            variant='link'
+            isInline
+            component='a'
+            href='https://access.redhat.com/terms-based-registry/'
+            target='_blank'
+            icon={<ExternalLinkAltIcon />}
+            iconPosition='end'
+            style={{ fontWeight: 'bold' }}
+          >
+            create a service account
+          </Button>
+          {
+            ' for Lightwell. Use the username and token in the snippets below. For further help, see '
+          }
+          <Button
+            variant='link'
+            isInline
+            component='a'
+            href='https://docs.redhat.com/en/documentation/red_hat_lightwell_network/'
+            target='_blank'
+            icon={<ExternalLinkAltIcon />}
+            iconPosition='end'
+          >
+            Documentation
+          </Button>
+          .
+        </Content>
       </div>
       <div>
-        <Content component='h4' className={spacing.mbSm}>Connect to your build tool</Content>
+        <Content component='h4' className={spacing.mbSm}>
+          Connect to your build tool
+        </Content>
         <Tabs
-        activeKey={activeTabKey}
-        onSelect={(_, eventKey) => setActiveTabKey(eventKey as string)}
-        aria-label='Connect repository snippets'
-        ouiaId='lightwell-connect-snippets-tabs'
-      >
-        {tabs.map((tab) => (
-          <Tab
+          activeKey={activeTabKey}
+          onSelect={(_, eventKey) => setActiveTabKey(eventKey as string)}
+          aria-label='Connect repository snippets'
+          ouiaId='lightwell-connect-snippets-tabs'
+        >
+          {tabs.map((tab) => (
+            <Tab
+              key={tab.eventKey}
+              eventKey={tab.eventKey}
+              title={<TabTitleText>{tab.title}</TabTitleText>}
+              tabContentRef={tabRefs[tab.eventKey]}
+              ouiaId={`lightwell-connect-tab-${tab.eventKey}`}
+            />
+          ))}
+        </Tabs>
+        {tabs.map((tab, index) => (
+          <TabContent
             key={tab.eventKey}
             eventKey={tab.eventKey}
-            title={<TabTitleText>{tab.title}</TabTitleText>}
-            tabContentRef={tabRefs[tab.eventKey]}
-            ouiaId={`lightwell-connect-tab-${tab.eventKey}`}
-          />
+            id={`lightwell-connect-panel-${tab.eventKey}`}
+            aria-label={tab.title}
+            ref={tabRefs[tab.eventKey]}
+            hidden={index > 0}
+            className={spacing.ptMd}
+          >
+            {renderTabPanel(tab)}
+          </TabContent>
         ))}
-      </Tabs>
-      {tabs.map((tab, index) => (
-        <TabContent
-          key={tab.eventKey}
-          eventKey={tab.eventKey}
-          id={`lightwell-connect-panel-${tab.eventKey}`}
-          aria-label={tab.title}
-          ref={tabRefs[tab.eventKey]}
-          hidden={index > 0}
-          className={spacing.ptMd}
-        >
-          {renderTabPanel(tab)}
-        </TabContent>
-      ))}
       </div>
     </div>
   );

--- a/src/Pages/Lightwell/Repositories/components/ConnectRepositoryPopover.tsx
+++ b/src/Pages/Lightwell/Repositories/components/ConnectRepositoryPopover.tsx
@@ -1,5 +1,4 @@
 import {
-  Alert,
   Button,
   ClipboardCopy,
   ClipboardCopyVariant,
@@ -46,7 +45,7 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
     <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
       {tab.snippets.map((snippet) => (
         <FlexItem key={snippet.label}>
-          <Content component='small' style={{ textAlign: 'left' }}>
+          <Content component='p' style={{ textAlign: 'left' }}>
             {snippet.label}
           </Content>
           <ClipboardCopy
@@ -66,12 +65,30 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
           )}
         </FlexItem>
       ))}
+      {tab.docsUrl && (
+        <FlexItem>
+          <Button
+            variant='link'
+            isInline
+            component='a'
+            href={tab.docsUrl}
+            target='_blank'
+            icon={<ExternalLinkAltIcon />}
+            iconPosition='end'
+          >
+            Full documentation for {tab.title}
+          </Button>
+        </FlexItem>
+      )}
     </Flex>
   );
 
   const bodyContent = (
-    <div>
-      <Alert variant='info' isInline isPlain title='Authentication required' className={spacing.mbMd}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <div>
+        <Content component='h4' className={spacing.mbSm}>Authenticate build tools</Content>
+        <Content component='p'>
+        {'First, '}
         <Button
           variant='link'
           isInline
@@ -80,12 +97,28 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
           target='_blank'
           icon={<ExternalLinkAltIcon />}
           iconPosition='end'
+          style={{ fontWeight: 'bold' }}
         >
-          Create a service account
-        </Button>{' '}
-        to generate credentials.
-      </Alert>
-      <Tabs
+          create a service account
+        </Button>
+        {' for Lightwell. Use the username and token in the snippets below. For further help, see '}
+        <Button
+          variant='link'
+          isInline
+          component='a'
+          href='https://docs.redhat.com/en/documentation/red_hat_lightwell_network/'
+          target='_blank'
+          icon={<ExternalLinkAltIcon />}
+          iconPosition='end'
+        >
+          Documentation
+        </Button>
+        .
+      </Content>
+      </div>
+      <div>
+        <Content component='h4' className={spacing.mbSm}>Connect to your build tool</Content>
+        <Tabs
         activeKey={activeTabKey}
         onSelect={(_, eventKey) => setActiveTabKey(eventKey as string)}
         aria-label='Connect repository snippets'
@@ -114,6 +147,7 @@ const ConnectRepositoryPopover = ({ repository, children }: ConnectRepositoryPop
           {renderTabPanel(tab)}
         </TabContent>
       ))}
+      </div>
     </div>
   );
 

--- a/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
+++ b/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
@@ -15,8 +15,20 @@ export interface ConnectSnippetTab {
 
 type RepositoryContext = Pick<ContentItem, 'name' | 'published_distribution_url' | 'content_type'>;
 
+const getMavenRepoId = (repository: RepositoryContext): string => {
+  const securityLevel = repository.name.includes('remediated') ? 'remediated' : 'validated';
+  return `lightwell-${securityLevel}`;
+};
+
+const getMavenRepoName = (repository: RepositoryContext): string => {
+  const securityLevel = repository.name.includes('remediated') ? 'Remediated' : 'Validated';
+  return `Red Hat Lightwell Network - ${securityLevel}`;
+};
+
 const getMavenSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[] => {
-  const { name, published_distribution_url } = repository;
+  const { published_distribution_url } = repository;
+  const repoId = getMavenRepoId(repository);
+  const repoName = getMavenRepoName(repository);
 
   return [
     {
@@ -24,11 +36,41 @@ const getMavenSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[]
       title: 'Maven',
       snippets: [
         {
-          label: 'Add to your settings.xml or pom.xml:',
-          code: `<repository>
-  <id>${name}</id>
-  <url>${published_distribution_url}</url>
-</repository>`,
+          label: 'Add to your settings.xml:',
+          code: `<settings>
+  <profiles>
+    <profile>
+      <id>${repoId}</id>
+      <repositories>
+        <repository>
+          <id>${repoId}</id>
+          <name>${repoName}</name>
+          <url>${published_distribution_url}</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>${repoId}</activeProfile>
+  </activeProfiles>
+</settings>`,
+        },
+        {
+          label: 'Add server credentials to your settings.xml:',
+          code: `<servers>
+  <server>
+    <id>${repoId}</id>
+    <username><service_account_username></username>
+    <password><service_account_token></password>
+  </server>
+</servers>`,
+          description: 'Username format: XXXXXXX|service-account-name',
         },
       ],
     },
@@ -37,12 +79,24 @@ const getMavenSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[]
       title: 'Gradle',
       snippets: [
         {
-          label: 'Add to your build gradle:',
+          label: 'Add to your build.gradle:',
           code: `repositories {
     maven {
+        credentials {
+            username "$mavenUser"
+            password "$mavenPassword"
+        }
         url "${published_distribution_url}"
     }
+    mavenCentral()
 }`,
+          description: 'Place above mavenCentral() to prioritize patched versions.',
+        },
+        {
+          label: 'Add credentials to ~/.gradle/gradle.properties:',
+          code: `mavenUser=<service_account_username>
+mavenPassword=<service_account_token>`,
+          description: 'Do not commit credentials. Store in ~/.gradle/gradle.properties.',
         },
       ],
     },
@@ -51,11 +105,24 @@ const getMavenSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[]
       title: 'Artifactory',
       snippets: [
         {
-          label: 'Configure as a remote repository in Artifactory:',
-          code: published_distribution_url ? published_distribution_url : '',
+          label: 'Configure as a remote Maven repository:',
+          code: published_distribution_url || '',
           urlOnly: true,
           description:
-            'Set the remote URL to this endpoint. Artifactory will proxy and cache packages automatically.',
+            'Set as the remote URL in Artifactory. Configure basic authentication with your service account credentials.',
+        },
+      ],
+    },
+    {
+      eventKey: 'nexus',
+      title: 'Nexus',
+      snippets: [
+        {
+          label: 'Configure as a Maven proxy repository:',
+          code: published_distribution_url || '',
+          urlOnly: true,
+          description:
+            'Set as the remote URL in Nexus. Authentication uses mTLS client certificates.',
         },
       ],
     },

--- a/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
+++ b/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
@@ -11,6 +11,7 @@ export interface ConnectSnippetTab {
   eventKey: string;
   title: string;
   snippets: ConnectCodeSnippet[];
+  docsUrl?: string;
 }
 
 type RepositoryContext = Pick<ContentItem, 'name' | 'published_distribution_url' | 'content_type'>;
@@ -34,6 +35,7 @@ const getMavenSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[]
     {
       eventKey: 'maven',
       title: 'Maven',
+      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_java_build_tool',
       snippets: [
         {
           label: 'Add to your settings.xml:',
@@ -77,6 +79,7 @@ const getMavenSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[]
     {
       eventKey: 'gradle',
       title: 'Gradle',
+      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_java_build_tool',
       snippets: [
         {
           label: 'Add to your build.gradle:',
@@ -103,6 +106,7 @@ mavenPassword=<service_account_token>`,
     {
       eventKey: 'artifactory',
       title: 'Artifactory',
+      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_artifactory_to_use_rhln_repository',
       snippets: [
         {
           label: 'Configure as a remote Maven repository:',
@@ -116,6 +120,7 @@ mavenPassword=<service_account_token>`,
     {
       eventKey: 'nexus',
       title: 'Nexus',
+      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_nexus_to_use_rhln_repository',
       snippets: [
         {
           label: 'Configure as a Maven proxy repository:',
@@ -136,33 +141,76 @@ const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[
     {
       eventKey: 'pip',
       title: 'pip',
+      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_python_build_tool',
       snippets: [
         {
-          label: 'Install directly:',
-          code: `pip install --index-url ${published_distribution_url} <package>`,
+          label: 'Add credentials to ~/.netrc:',
+          code: `machine packages.redhat.com login <service_account_username> password <service_account_token>`,
+          description: 'Username format: XXXXXXX|service-account-name',
+        },
+        {
+          label: 'Set as default index:',
+          code: `pip config set global.index-url ${published_distribution_url}`,
         },
       ],
     },
     {
-      eventKey: 'pip.conf',
-      title: 'pip.conf',
+      eventKey: 'pipenv',
+      title: 'Pipenv',
+      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_python_build_tool',
       snippets: [
         {
-          label: 'Add to your pip.conf for permanent use:',
-          code: `[global] index-url = ${published_distribution_url}`,
+          label: 'Add credentials to ~/.netrc:',
+          code: `machine packages.redhat.com login <service_account_username> password <service_account_token>`,
+          description: 'Username format: XXXXXXX|service-account-name',
+        },
+        {
+          label: 'Install from the repository:',
+          code: `pipenv install --index ${published_distribution_url}`,
+        },
+      ],
+    },
+    {
+      eventKey: 'poetry',
+      title: 'Poetry',
+      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_python_build_tool',
+      snippets: [
+        {
+          label: 'Configure authentication:',
+          code: `poetry config http-basic.lightwell "<service_account_username>" "<service_account_token>"`,
+          description: 'Username format: XXXXXXX|service-account-name',
+        },
+        {
+          label: 'Add as default source:',
+          code: `poetry source add --priority=default lightwell ${published_distribution_url}`,
         },
       ],
     },
     {
       eventKey: 'artifactory',
       title: 'Artifactory',
+      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_artifactory_to_use_rhln_repository',
       snippets: [
         {
-          label: 'Configure as a remote repository in Artifactory:',
-          code: published_distribution_url ? published_distribution_url : '',
+          label: 'Configure as a remote PyPI repository:',
+          code: published_distribution_url || '',
           urlOnly: true,
           description:
-            'Set the remote URL to this endpoint. Artifactory will proxy and cache packages automatically.',
+            'Set as the remote URL in Artifactory. Configure basic authentication with your service account credentials.',
+        },
+      ],
+    },
+    {
+      eventKey: 'nexus',
+      title: 'Nexus',
+      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_nexus_to_use_rhln_repository',
+      snippets: [
+        {
+          label: 'Configure as a PyPI proxy repository:',
+          code: published_distribution_url || '',
+          urlOnly: true,
+          description:
+            'Set as the remote URL in Nexus. Authentication uses mTLS client certificates.',
         },
       ],
     },

--- a/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
+++ b/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
@@ -35,7 +35,8 @@ const getMavenSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[]
     {
       eventKey: 'maven',
       title: 'Maven',
-      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_java_build_tool',
+      docsUrl:
+        'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_java_build_tool',
       snippets: [
         {
           label: 'Add to your settings.xml:',
@@ -79,7 +80,8 @@ const getMavenSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[]
     {
       eventKey: 'gradle',
       title: 'Gradle',
-      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_java_build_tool',
+      docsUrl:
+        'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_java_build_tool',
       snippets: [
         {
           label: 'Add to your build.gradle:',
@@ -106,7 +108,8 @@ mavenPassword=<service_account_token>`,
     {
       eventKey: 'artifactory',
       title: 'Artifactory',
-      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_artifactory_to_use_rhln_repository',
+      docsUrl:
+        'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_artifactory_to_use_rhln_repository',
       snippets: [
         {
           label: 'Configure as a remote Maven repository:',
@@ -120,7 +123,8 @@ mavenPassword=<service_account_token>`,
     {
       eventKey: 'nexus',
       title: 'Nexus',
-      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_nexus_to_use_rhln_repository',
+      docsUrl:
+        'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_nexus_to_use_rhln_repository',
       snippets: [
         {
           label: 'Configure as a Maven proxy repository:',
@@ -141,7 +145,8 @@ const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[
     {
       eventKey: 'pip',
       title: 'pip',
-      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_python_build_tool',
+      docsUrl:
+        'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_python_build_tool',
       snippets: [
         {
           label: 'Add credentials to ~/.netrc:',
@@ -157,7 +162,8 @@ const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[
     {
       eventKey: 'pipenv',
       title: 'Pipenv',
-      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_python_build_tool',
+      docsUrl:
+        'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_python_build_tool',
       snippets: [
         {
           label: 'Add credentials to ~/.netrc:',
@@ -173,7 +179,8 @@ const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[
     {
       eventKey: 'poetry',
       title: 'Poetry',
-      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_python_build_tool',
+      docsUrl:
+        'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_python_build_tool',
       snippets: [
         {
           label: 'Configure authentication:',
@@ -189,7 +196,8 @@ const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[
     {
       eventKey: 'artifactory',
       title: 'Artifactory',
-      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_artifactory_to_use_rhln_repository',
+      docsUrl:
+        'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_artifactory_to_use_rhln_repository',
       snippets: [
         {
           label: 'Configure as a remote PyPI repository:',
@@ -203,7 +211,8 @@ const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[
     {
       eventKey: 'nexus',
       title: 'Nexus',
-      docsUrl: 'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_nexus_to_use_rhln_repository',
+      docsUrl:
+        'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_nexus_to_use_rhln_repository',
       snippets: [
         {
           label: 'Configure as a PyPI proxy repository:',


### PR DESCRIPTION
## Summary
- Adds auth section to connect popover with link to terms-based registry and documentation
- Updates Maven snippets with full settings.xml (profiles + server auth) from official docs
- Updates Gradle snippets with externalized credentials (gradle.properties, not in-repo)
- Updates pip snippets with .netrc auth
- Adds Pipenv, Poetry, and Nexus tabs
- Adds per-tab documentation links ("Full documentation for Maven", etc.)
- Restructures popover as two-section flow: "Authenticate build tools" then "Connect to your build tool"

Context: [Justin/Andy call Jul 6](https://docs.google.com/document/d/1mAsQuCBj7gNlmL9zc_MVNc7Ei1m1vBESKUvRURQ_6Ag/edit) — current snippets missing auth and Maven config was inaccurate. Snippets sourced from official Lightwell docs.

## Test plan
- [ ] Open connect popover on Java repo — auth section visible, Maven/Gradle/Artifactory/Nexus tabs with docs links
- [ ] Open connect popover on Python repo — auth section visible, pip/Pipenv/Poetry/Artifactory/Nexus tabs with docs links
- [ ] Verify auth link opens terms-based registry in new tab
- [ ] Verify docs links open correct pages in new tab

co-authored by Claude Code