### PR TITLE
Lightwell: Use only latest release in package list

### DIFF
--- a/src/Pages/Lightwell/Packages/PackagesTable.test.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesTable.test.tsx
@@ -15,7 +15,7 @@ import {
   pythonValidatedPipCommand,
   ReactQueryTestWrapper,
 } from 'testingHelpers';
-import { ContentItem } from 'services/Content/ContentApi';
+import { ContentItem, RepositoryPackageItem } from 'services/Content/ContentApi';
 import { getRepositoryPathSlug } from '../helpers';
 import useLightwellRepository from '../useLightwellRepository';
 
@@ -240,6 +240,51 @@ it('renders remediated java packages with a Latest release column', async () => 
   expect(await screen.findByRole('heading', { name: 'Java Remediated' })).toBeInTheDocument();
   expect(screen.getByRole('columnheader', { name: 'Latest release' })).toBeInTheDocument();
   expect(await screen.findByRole('button', { name: '3.14.0.rhlw-0004' })).toBeInTheDocument();
+});
+
+it('shows one version row per upstream version with its latest release only', async () => {
+  const multiReleasePackage: RepositoryPackageItem = {
+    group: 'org.example',
+    name: 'my-lib',
+    versions: ['2.0.0', '1.0.0'],
+    latest_releases: [
+      { version: '2.0.0.rhlw-2', release: 'rhlw-2', created_at: '2026-07-02T00:00:00Z' },
+      { version: '2.0.0.rhlw-1', release: 'rhlw-1', created_at: '2026-07-01T00:00:00Z' },
+      { version: '1.0.0.rhlw-3', release: 'rhlw-3', created_at: '2026-06-15T00:00:00Z' },
+      { version: '1.0.0.rhlw-1', release: 'rhlw-1', created_at: '2026-06-13T00:00:00Z' },
+    ],
+  };
+
+  mockUseParams.mockReturnValue({
+    repoName: getRepositoryPathSlug('maven', 'remediated'),
+  });
+  mockRepository(javaRemediatedContentItem);
+  (useLightwellRepositoryPackagesQuery as jest.Mock).mockImplementation(() =>
+    mockPackagesQuery({
+      data: {
+        ...defaultLightwellRepositoryPackageResponse,
+        results: [multiReleasePackage],
+        total: 1,
+      },
+    }),
+  );
+
+  renderPackagesTable();
+
+  // Version column: 2.0.0 shown once (not duplicated for each release), 1.0.0 collapsed
+  expect(await screen.findByText('2.0.0')).toBeInTheDocument();
+  expect(screen.queryAllByText('2.0.0')).toHaveLength(1);
+  expect(screen.queryByText('1.0.0')).not.toBeInTheDocument();
+
+  // Latest release column: shows the latest release for 2.0.0, not the older one
+  expect(screen.getByRole('button', { name: '2.0.0.rhlw-2' })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: '2.0.0.rhlw-1' })).not.toBeInTheDocument();
+
+  // Expand to reveal 1.0.0 with its latest release (rhlw-3, not rhlw-1)
+  await userEvent.click(screen.getByRole('button', { name: '1 more' }));
+  expect(screen.getByText('1.0.0')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: '1.0.0.rhlw-3' })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: '1.0.0.rhlw-1' })).not.toBeInTheDocument();
 });
 
 it('renders python validated packages with pip copy labels and no group ID column', async () => {

--- a/src/Pages/Lightwell/Packages/PackagesTable.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesTable.tsx
@@ -98,16 +98,25 @@ const mapRepositoryPackage = (pkg: RepositoryPackageItem): MappedPackage => {
 
   const sortedReleases = [...pkg.latest_releases].sort(compareReleasesDesc);
 
+  // Deduplicate: keep only the latest release per upstream version
+  const seenVersions = new Set<string>();
+  const latestReleasePerVersion = sortedReleases.filter((release) => {
+    const v = stripLightwellVersionSuffix(release.version);
+    if (seenVersions.has(v)) return false;
+    seenVersions.add(v);
+    return true;
+  });
+
   const sortedVersions =
-    sortedReleases.length > 0
-      ? sortedReleases.map((release) => stripLightwellVersionSuffix(release.version))
+    latestReleasePerVersion.length > 0
+      ? latestReleasePerVersion.map((release) => stripLightwellVersionSuffix(release.version))
       : sortVersionsDesc(pkg.versions.map(stripLightwellVersionSuffix));
 
   return {
     group_id: pkg.group,
     name: pkg.name,
     versions: sortedVersions,
-    latest_releases: sortedReleases.map((release) => ({
+    latest_releases: latestReleasePerVersion.map((release) => ({
       version: stripLightwellVersionSuffix(release.version),
       release: release.release,
     })),


### PR DESCRIPTION
## Summary
This is a workaround to remove multiple latest releases showing up for different versions. The API will be changed in the future to better address this.

## Testing steps
