### PR TITLE
Lightwell: remove package details copy link

### DIFF
--- a/src/Pages/Lightwell/Packages/PackageDetails.test.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.test.tsx
@@ -20,7 +20,6 @@ import {
   gradleRemediatedDependencySnippet,
   gradleValidatedDependencySnippet,
   javaRemediatedCopyCommand,
-  javaValidatedCopyCommand,
   mavenRemediatedDependencySnippet,
   mavenValidatedDependencySnippet,
   pipConfRemediatedInstallSnippet,
@@ -28,7 +27,6 @@ import {
   pipRemediatedInstallSnippet,
   pipValidatedInstallSnippet,
   pythonRemediatedPipCommand,
-  pythonValidatedPipCommand,
   ReactQueryTestWrapper,
   requirementsRemediatedInstallSnippet,
   requirementsValidatedInstallSnippet,
@@ -407,9 +405,6 @@ it('shows how to use section for python package', async () => {
   expect(await screen.findByRole('tab', { name: 'pip' })).toBeInTheDocument();
   expect(await screen.findByRole('tab', { name: 'requirements.txt' })).toBeInTheDocument();
   expect(await screen.findByRole('tab', { name: 'pip.conf' })).toBeInTheDocument();
-  expect(
-    await screen.findByRole('button', { name: pythonRemediatedPipCommand }),
-  ).toBeInTheDocument();
 });
 
 const mockClipboard = () => {
@@ -434,17 +429,6 @@ it('copies pip command to clipboard for remediated python package', async () => 
 
   setupPythonRemediatedPackage();
   renderPackageDetails();
-
-  // PackageDetails header
-  await assertClipboardCopy(
-    writeText,
-    async () => {
-      await userEvent.click(
-        await screen.findByRole('button', { name: pythonRemediatedPipCommand }),
-      );
-    },
-    pythonRemediatedPipCommand,
-  );
 
   // pip tab in "How to use" section of Overview tab
   await assertClipboardCopy(
@@ -501,15 +485,6 @@ it('copies maven coordinate to clipboard for remediated java package', async () 
 
   setupMultiVersionReleasePackage();
   renderPackageDetails();
-
-  // PackageDetails header
-  await assertClipboardCopy(
-    writeText,
-    async () => {
-      await userEvent.click(await screen.findByRole('button', { name: javaRemediatedCopyCommand }));
-    },
-    javaRemediatedCopyCommand,
-  );
 
   // Maven tab in "How to use" section of Overview tab
   await assertClipboardCopy(
@@ -585,15 +560,6 @@ it('copies pip command to clipboard for validated python package', async () => {
   setupPythonValidatedPackage();
   renderPackageDetails();
 
-  // PackageDetails header
-  await assertClipboardCopy(
-    writeText,
-    async () => {
-      await userEvent.click(await screen.findByRole('button', { name: pythonValidatedPipCommand }));
-    },
-    pythonValidatedPipCommand,
-  );
-
   // pip tab in "How to use" section of Overview tab
   await assertClipboardCopy(
     writeText,
@@ -629,15 +595,6 @@ it('copies maven coordinate to clipboard for validated java package', async () =
 
   setupNoReleasePackage();
   renderPackageDetails();
-
-  // PackageDetails header
-  await assertClipboardCopy(
-    writeText,
-    async () => {
-      await userEvent.click(await screen.findByRole('button', { name: javaValidatedCopyCommand }));
-    },
-    javaValidatedCopyCommand,
-  );
 
   // Maven tab in "How to use" section of Overview tab
   await assertClipboardCopy(

--- a/src/Pages/Lightwell/Packages/PackageDetails.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.tsx
@@ -1,7 +1,6 @@
 import {
   Breadcrumb,
   BreadcrumbItem,
-  Button,
   Card,
   CardBody,
   Dropdown,
@@ -22,9 +21,8 @@ import {
   Tabs,
   TabTitleText,
   Title,
-  Tooltip,
 } from '@patternfly/react-core';
-import { CopyIcon, JavaIcon, PythonIcon } from '@patternfly/react-icons';
+import { JavaIcon, PythonIcon } from '@patternfly/react-icons';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { createUseStyles } from 'react-jss';
 import { createRef, useEffect, useMemo, useRef, useState } from 'react';
@@ -81,7 +79,6 @@ const PackageDetails = () => {
   const [activeTabKey, setActiveTabKey] = useState(0);
   const [selectedVersion, setSelectedVersion] = useState<string>('');
   const [versionDropdownOpen, setVersionDropdownOpen] = useState(false);
-  const [isCopyTooltipVisible, setIsCopyTooltipVisible] = useState(false);
   const copyTooltipTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
   const overviewTabRef = createRef<HTMLElement>();
@@ -246,19 +243,6 @@ const PackageDetails = () => {
     [],
   );
 
-  const handleCopyInstallCommand = (text: string) => {
-    void navigator.clipboard.writeText(text);
-
-    if (copyTooltipTimeoutRef.current) {
-      clearTimeout(copyTooltipTimeoutRef.current);
-    }
-
-    setIsCopyTooltipVisible(true);
-    copyTooltipTimeoutRef.current = setTimeout(() => {
-      setIsCopyTooltipVisible(false);
-    }, 2000);
-  };
-
   const isLoadingDetail = isMaven
     ? mavenVersionsListQuery.isLoading
     : pythonPackageVersionsQuery.isLoading && !pythonPackageVersionsQuery.data;
@@ -290,12 +274,6 @@ const PackageDetails = () => {
     : hasRelease && pythonBuildVersion
       ? pythonBuildVersion
       : activeVersion;
-
-  const installCommand = isMaven
-    ? `${packageGroup}:${packageName}:${displayVersion}`
-    : hasRelease && pythonBuildVersion
-      ? `pip install ${packageName}==${pythonBuildVersion}`
-      : `pip install ${packageName}==${upstreamVersion}`;
 
   const formatReleaseCopyText = (version: string) =>
     isMaven
@@ -413,24 +391,6 @@ const PackageDetails = () => {
                   </FlexItem>
                 ) : null}
               </Flex>
-              {displayVersion ? (
-                <FlexItem>
-                  <Tooltip
-                    content={isCopyTooltipVisible ? 'Copied' : 'Copy'}
-                    trigger='mouseenter focus'
-                    isVisible={isCopyTooltipVisible}
-                  >
-                    <Button
-                      variant='secondary'
-                      icon={<CopyIcon />}
-                      iconPosition='end'
-                      onClick={() => handleCopyInstallCommand(installCommand)}
-                    >
-                      {installCommand}
-                    </Button>
-                  </Tooltip>
-                </FlexItem>
-              ) : null}
             </Flex>
           </StackItem>
           {repository.security_level === 'remediated' && (


### PR DESCRIPTION
## Summary

removes the install details button with copy for the lightwell package details pages


## Testing steps
