### PR TITLE
Lightwell: format distribution urls to use /lightwell

### DIFF
--- a/src/Pages/Lightwell/Packages/PackageDetails.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.tsx
@@ -40,6 +40,7 @@ import {
 import { LIGHTWELL_USE_MOCK } from '../constants';
 import {
   compareVersionsDesc,
+  formatDistributionUrl,
   formatRepositoryName,
   lightwellReleaseNum,
   sortVersionsDesc,
@@ -500,7 +501,7 @@ const PackageDetails = () => {
                       latestRelease={displayVersion}
                       hasRelease={hasRelease}
                       summary={isMaven ? mavenDetail?.summary : pythonDetail?.summary}
-                      sourceUrl={repository.published_distribution_url ?? ''}
+                      sourceUrl={formatDistributionUrl(repository.published_distribution_url ?? '')}
                     />
                   </TabContentBody>
                 </TabContent>

--- a/src/Pages/Lightwell/Packages/PackagesTable.tsx
+++ b/src/Pages/Lightwell/Packages/PackagesTable.tsx
@@ -41,6 +41,7 @@ import useDebounce from 'Hooks/useDebounce';
 import { getMockLightwellPackages } from '../mockPackages';
 import {
   compareReleasesDesc,
+  formatDistributionUrl,
   formatRepositoryName,
   getRepositoryDescription,
   sortVersionsDesc,
@@ -345,8 +346,10 @@ const PackagesTable = () => {
                   </Title>
                 </FlexItem>
                 <FlexItem>
-                  <CopyLabel copyText={repository.published_distribution_url || ''}>
-                    {repository.published_distribution_url || ''}
+                  <CopyLabel
+                    copyText={formatDistributionUrl(repository.published_distribution_url || '')}
+                  >
+                    {formatDistributionUrl(repository.published_distribution_url || '')}
                   </CopyLabel>
                 </FlexItem>
               </Flex>
@@ -355,7 +358,9 @@ const PackagesTable = () => {
                   repository={{
                     uuid: repository.uuid,
                     name: repository.name,
-                    published_distribution_url: repository.published_distribution_url,
+                    published_distribution_url: formatDistributionUrl(
+                      repository.published_distribution_url || '',
+                    ),
                     content_type: repository.content_type,
                   }}
                 >

--- a/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
+++ b/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
@@ -1,4 +1,5 @@
 import { ContentItem } from 'services/Content/ContentApi';
+import { formatDistributionUrl } from '../../helpers';
 
 export interface ConnectCodeSnippet {
   label: string;
@@ -27,7 +28,7 @@ const getMavenRepoName = (repository: RepositoryContext): string => {
 };
 
 const getMavenSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[] => {
-  const { published_distribution_url } = repository;
+  const distributionUrl = formatDistributionUrl(repository.published_distribution_url || '');
   const repoId = getMavenRepoId(repository);
   const repoName = getMavenRepoName(repository);
 
@@ -48,7 +49,7 @@ const getMavenSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[]
         <repository>
           <id>${repoId}</id>
           <name>${repoName}</name>
-          <url>${published_distribution_url}</url>
+          <url>${distributionUrl}</url>
           <releases>
             <enabled>true</enabled>
           </releases>
@@ -91,7 +92,7 @@ const getMavenSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[]
             username "$mavenUser"
             password "$mavenPassword"
         }
-        url "${published_distribution_url}"
+        url "${distributionUrl}"
     }
     mavenCentral()
 }`,
@@ -113,7 +114,7 @@ mavenPassword=<service_account_token>`,
       snippets: [
         {
           label: 'Configure as a remote Maven repository:',
-          code: published_distribution_url || '',
+          code: distributionUrl || '',
           urlOnly: true,
           description:
             'Set as the remote URL in Artifactory. Configure basic authentication with your service account credentials.',
@@ -128,7 +129,7 @@ mavenPassword=<service_account_token>`,
       snippets: [
         {
           label: 'Configure as a Maven proxy repository:',
-          code: published_distribution_url || '',
+          code: distributionUrl || '',
           urlOnly: true,
           description:
             'Set as the remote URL in Nexus. Authentication uses mTLS client certificates.',
@@ -139,7 +140,7 @@ mavenPassword=<service_account_token>`,
 };
 
 const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[] => {
-  const { published_distribution_url } = repository;
+  const distributionUrl = formatDistributionUrl(repository.published_distribution_url || '');
 
   return [
     {
@@ -155,7 +156,7 @@ const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[
         },
         {
           label: 'Set as default index:',
-          code: `pip config set global.index-url ${published_distribution_url}`,
+          code: `pip config set global.index-url ${distributionUrl}`,
         },
       ],
     },
@@ -172,7 +173,7 @@ const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[
         },
         {
           label: 'Install from the repository:',
-          code: `pipenv install --index ${published_distribution_url}`,
+          code: `pipenv install --index ${distributionUrl}`,
         },
       ],
     },
@@ -189,7 +190,7 @@ const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[
         },
         {
           label: 'Add as default source:',
-          code: `poetry source add --priority=default lightwell ${published_distribution_url}`,
+          code: `poetry source add --priority=default lightwell ${distributionUrl}`,
         },
       ],
     },
@@ -201,7 +202,7 @@ const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[
       snippets: [
         {
           label: 'Configure as a remote PyPI repository:',
-          code: published_distribution_url || '',
+          code: distributionUrl || '',
           urlOnly: true,
           description:
             'Set as the remote URL in Artifactory. Configure basic authentication with your service account credentials.',
@@ -216,7 +217,7 @@ const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[
       snippets: [
         {
           label: 'Configure as a PyPI proxy repository:',
-          code: published_distribution_url || '',
+          code: distributionUrl || '',
           urlOnly: true,
           description:
             'Set as the remote URL in Nexus. Authentication uses mTLS client certificates.',

--- a/src/Pages/Lightwell/helpers.test.ts
+++ b/src/Pages/Lightwell/helpers.test.ts
@@ -1,6 +1,7 @@
 import {
   compareReleasesDesc,
   compareVersionsDesc,
+  formatDistributionUrl,
   formatEcosystemDisplay,
   formatRepositoryName,
   getEcosystemFromContentType,
@@ -181,5 +182,41 @@ describe('compareReleasesDesc', () => {
       release('1.2.2.rhlw-00008', 'rhlw-00008'),
       release('1.2.2.rhlw-00003', 'rhlw-00003'),
     ]);
+  });
+});
+
+describe('formatDistributionUrl', () => {
+  it('transforms Pulp API URL to Lightwell URL for production', () => {
+    expect(
+      formatDistributionUrl(
+        'https://packages.redhat.com/api/pulp-content/lightwell/java/validated',
+      ),
+    ).toBe('https://packages.redhat.com/lightwell/java/validated');
+  });
+
+  it('transforms Pulp API URL to Lightwell URL for stage', () => {
+    expect(
+      formatDistributionUrl(
+        'https://packages.stage.redhat.com/api/pulp-content/lightwell/python/remediated/',
+      ),
+    ).toBe('https://packages.stage.redhat.com/lightwell/python/remediated/');
+  });
+
+  it('handles URLs without trailing slash', () => {
+    expect(
+      formatDistributionUrl(
+        'https://packages.redhat.com/api/pulp-content/lightwell/python/validated',
+      ),
+    ).toBe('https://packages.redhat.com/lightwell/python/validated');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(formatDistributionUrl('')).toBe('');
+  });
+
+  it('returns URL unchanged if it does not contain the expected path', () => {
+    expect(formatDistributionUrl('https://example.com/some/other/path')).toBe(
+      'https://example.com/some/other/path',
+    );
   });
 });

--- a/src/Pages/Lightwell/helpers.ts
+++ b/src/Pages/Lightwell/helpers.ts
@@ -135,3 +135,13 @@ export const compareReleasesDesc = (
 
   return lightwellReleaseNum(b.release) - lightwellReleaseNum(a.release);
 };
+
+/**
+ * Transforms published distribution URL by replacing /api/pulp-content/lightwell with /lightwell
+ *
+ * Example:
+ * https://packages.redhat.com/api/pulp-content/lightwell/java/validated
+ * -> https://packages.redhat.com/lightwell/java/validated
+ */
+export const formatDistributionUrl = (url: string): string =>
+  url.replace('/api/pulp-content/lightwell', '/lightwell');


### PR DESCRIPTION
## Summary

Format the urls to look like:  packages.redhat.com/lightwell/$PATH

## Testing steps
