### PR TITLE
Lightwell: Fix position of cookie consent link

### DIFF
--- a/styles/lightwell-chrome-overrides.scss
+++ b/styles/lightwell-chrome-overrides.scss
@@ -10,3 +10,13 @@ li.pf-v6-c-menu__list-item:has(> a[href="/settings/notifications/user-preference
 .chr-c-menu-settings .pf-v6-c-divider {
     display: none !important;
 }
+
+// TrustArc "Cookie preferences" link is injected by Chrome and pushed off-screen,
+// causing an unwanted scrollbar. Fix it in the bottom-left corner instead.
+.truste_caIcon_display {
+    position: fixed !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    z-index: 1000 !important;
+    overflow: visible !important;
+}


### PR DESCRIPTION
## Summary

This override CSS fixes the position of the cookie consent link which is otherwise pushed off-screen, which results in a scrollbar. This secondary scrollbar really has a negative impact on the UX, so it warrants a hackaround.

## Testing steps

Load the `/lightwell` route and observe the pointless scrollbar.