### PR TITLE
HMS-10996: add version count support for lw repos

### DIFF
--- a/src/Pages/Lightwell/Repositories/RepositoriesTable.test.tsx
+++ b/src/Pages/Lightwell/Repositories/RepositoriesTable.test.tsx
@@ -44,6 +44,7 @@ const javaRemediatedContentItem: ContentItem = {
   security_level: 'remediated',
   package_count: 11,
   build_count: 28,
+  version_count: 28,
 };
 
 const renderRepositoriesTable = () =>
@@ -206,5 +207,5 @@ it('renders repository table column headers', async () => {
   expect(screen.getByRole('columnheader', { name: 'Ecosystem' })).toBeInTheDocument();
   expect(screen.getByRole('columnheader', { name: 'Security level' })).toBeInTheDocument();
   expect(screen.getByRole('columnheader', { name: 'Packages' })).toBeInTheDocument();
-  expect(screen.getByRole('columnheader', { name: 'Builds' })).toBeInTheDocument();
+  expect(screen.getByRole('columnheader', { name: 'Versions' })).toBeInTheDocument();
 });

--- a/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
+++ b/src/Pages/Lightwell/Repositories/RepositoriesTable.tsx
@@ -111,11 +111,10 @@ const RepositoriesTable = () => {
       info: { tooltip: 'Unique package names available in this repository.' },
     },
     {
-      title: 'Builds',
+      title: 'Versions',
       width: 10,
       info: {
-        tooltip:
-          'Total built artifacts across all versions. A single package may have multiple builds.',
+        tooltip: 'Total package versions available in this repository.',
       },
     },
   ];
@@ -199,7 +198,7 @@ const RepositoriesTable = () => {
                           published_distribution_url,
                           security_level,
                           package_count,
-                          build_count,
+                          version_count,
                         } = repo;
 
                         return (
@@ -265,7 +264,7 @@ const RepositoriesTable = () => {
                               )}
                             </Td>
                             <Td>{package_count.toLocaleString() ?? '0'}</Td>
-                            <Td>{build_count?.toLocaleString() ?? '0'}</Td>
+                            <Td>{version_count?.toLocaleString() ?? '0'}</Td>
                           </Tr>
                         );
                       })}

--- a/src/Pages/Lightwell/mockRepositories.ts
+++ b/src/Pages/Lightwell/mockRepositories.ts
@@ -13,6 +13,7 @@ const mockRepositories = [
     content_type: 'maven',
     package_count: 10,
     build_count: 24,
+    version_count: 24,
   },
   {
     uuid: '22222222-2222-4222-8222-222222222222',
@@ -24,6 +25,7 @@ const mockRepositories = [
     content_type: 'maven',
     package_count: 11,
     build_count: 28,
+    version_count: 28,
   },
   {
     uuid: '33333333-3333-4333-8333-333333333333',
@@ -35,6 +37,7 @@ const mockRepositories = [
     content_type: 'python',
     package_count: 13,
     build_count: 31,
+    version_count: 31,
   },
   {
     uuid: '44444444-4444-4444-8444-444444444444',
@@ -46,6 +49,7 @@ const mockRepositories = [
     content_type: 'python',
     package_count: 10,
     build_count: 22,
+    version_count: 22,
   },
 ] as ContentItem[];
 

--- a/src/services/Content/ContentApi.ts
+++ b/src/services/Content/ContentApi.ts
@@ -34,6 +34,7 @@ export interface ContentItem {
   security_level?: string;
   published_distribution_url?: string;
   build_count?: number;
+  version_count?: number;
 }
 
 export interface PopularRepository {

--- a/src/testingHelpers.tsx
+++ b/src/testingHelpers.tsx
@@ -404,6 +404,7 @@ export const defaultLightwellContentItem: ContentItem = {
   uuid: '3875c35b-a67a-4ac2-a989-21139433c177',
   package_count: 1,
   build_count: 3,
+  version_count: 3,
   origin: ContentOrigin.LIGHTWELL,
   status: '',
   last_introspection_error: '',


### PR DESCRIPTION
This PR:
- Shows `version_count` instead of `build_count` in the Lightwell repositories table
- Renames the column header from `Builds` to `Versions` and updates the tooltip
- Adds `version_count` to `ContentItem` while keeping `build_count` on the type
- Updates mocks, test fixtures, and table tests for the new field