### PR TITLE
HMS-10991: add expandable for long license text

### DIFF
--- a/src/Pages/Lightwell/Packages/PackageDetails.test.tsx
+++ b/src/Pages/Lightwell/Packages/PackageDetails.test.tsx
@@ -287,6 +287,7 @@ it('renders sidebar metadata', async () => {
   expect(await screen.findByText('JSON library for Java')).toBeInTheDocument();
   expect(await screen.findByText('License')).toBeInTheDocument();
   expect(await screen.findByText('MIT')).toBeInTheDocument();
+  expect(screen.queryByText('show more')).not.toBeInTheDocument();
   expect(await screen.findByText('Original author')).toBeInTheDocument();
   expect(await screen.findByText('JSON.org')).toBeInTheDocument();
   expect(await screen.findByText('Project')).toBeInTheDocument();

--- a/src/Pages/Lightwell/Packages/components/PackageSidebar.tsx
+++ b/src/Pages/Lightwell/Packages/components/PackageSidebar.tsx
@@ -5,11 +5,13 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  ExpandableSection,
   Timestamp,
 } from '@patternfly/react-core';
 import UrlWithExternalIcon from 'components/UrlWithLinkIcon/UrlWithLinkIcon';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import { useState } from 'react';
 dayjs.extend(relativeTime);
 
 type PackageSidebarProps = {
@@ -32,72 +34,89 @@ const PackageSidebar = ({
   author,
   projectUrl,
   hasRelease,
-}: PackageSidebarProps) => (
-  <Card isPlain>
-    <CardBody>
-      <DescriptionList>
-        {lastUpdated ? (
-          <DescriptionListGroup>
-            <DescriptionListTerm>Last updated</DescriptionListTerm>
-            <DescriptionListDescription>
-              <Timestamp
-                date={new Date(lastUpdated)}
-                dateFormat='medium'
-                timeFormat='short'
-                tooltip={{ variant: 'default' }}
-                style={{ fontSize: 'inherit', textDecoration: 'none' }}
-              >
-                {dayjs(lastUpdated).fromNow()}
-              </Timestamp>
-            </DescriptionListDescription>
-          </DescriptionListGroup>
-        ) : null}
-        {license ? (
-          <DescriptionListGroup>
-            <DescriptionListTerm>License</DescriptionListTerm>
-            <DescriptionListDescription>{license}</DescriptionListDescription>
-          </DescriptionListGroup>
-        ) : null}
-        {groupId ? (
-          <DescriptionListGroup>
-            <DescriptionListTerm>Group ID</DescriptionListTerm>
-            <DescriptionListDescription>{groupId}</DescriptionListDescription>
-          </DescriptionListGroup>
-        ) : null}
-        {author ? (
-          <DescriptionListGroup>
-            <DescriptionListTerm>{hasRelease ? 'Original author' : 'Author'}</DescriptionListTerm>
-            <DescriptionListDescription>{author}</DescriptionListDescription>
-          </DescriptionListGroup>
-        ) : null}
-        {hasRelease ? (
-          <DescriptionListGroup>
-            <DescriptionListTerm>Rebuilt by</DescriptionListTerm>
-            <DescriptionListDescription>Red Hat</DescriptionListDescription>
-          </DescriptionListGroup>
-        ) : null}
-        {allVersions && allVersions.length > 1 ? (
-          <DescriptionListGroup>
-            <DescriptionListTerm>Upstream versions</DescriptionListTerm>
-            <DescriptionListDescription>{allVersions.join(', ')}</DescriptionListDescription>
-          </DescriptionListGroup>
-        ) : upstreamVersion ? (
-          <DescriptionListGroup>
-            <DescriptionListTerm>Upstream version</DescriptionListTerm>
-            <DescriptionListDescription>{upstreamVersion}</DescriptionListDescription>
-          </DescriptionListGroup>
-        ) : null}
-        {projectUrl ? (
-          <DescriptionListGroup>
-            <DescriptionListTerm>Project</DescriptionListTerm>
-            <DescriptionListDescription>
-              <UrlWithExternalIcon href={projectUrl} customText='Source' />
-            </DescriptionListDescription>
-          </DescriptionListGroup>
-        ) : null}
-      </DescriptionList>
-    </CardBody>
-  </Card>
-);
+}: PackageSidebarProps) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const onToggle = (_event, expanded: boolean) => {
+    setIsExpanded(expanded);
+  };
+
+  return (
+    <Card isPlain>
+      <CardBody>
+        <DescriptionList>
+          {lastUpdated ? (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Last updated</DescriptionListTerm>
+              <DescriptionListDescription>
+                <Timestamp
+                  date={new Date(lastUpdated)}
+                  dateFormat='medium'
+                  timeFormat='short'
+                  tooltip={{ variant: 'default' }}
+                  style={{ fontSize: 'inherit', textDecoration: 'none' }}
+                >
+                  {dayjs(lastUpdated).fromNow()}
+                </Timestamp>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          ) : null}
+          {license ? (
+            <DescriptionListGroup>
+              <DescriptionListTerm>License</DescriptionListTerm>
+              <DescriptionListDescription>
+                <ExpandableSection
+                  variant='truncate'
+                  toggleText={isExpanded ? 'hide' : 'show more'}
+                  onToggle={onToggle}
+                  isExpanded={isExpanded}
+                >
+                  {license}
+                </ExpandableSection>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          ) : null}
+          {groupId ? (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Group ID</DescriptionListTerm>
+              <DescriptionListDescription>{groupId}</DescriptionListDescription>
+            </DescriptionListGroup>
+          ) : null}
+          {author ? (
+            <DescriptionListGroup>
+              <DescriptionListTerm>{hasRelease ? 'Original author' : 'Author'}</DescriptionListTerm>
+              <DescriptionListDescription>{author}</DescriptionListDescription>
+            </DescriptionListGroup>
+          ) : null}
+          {hasRelease ? (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Rebuilt by</DescriptionListTerm>
+              <DescriptionListDescription>Red Hat</DescriptionListDescription>
+            </DescriptionListGroup>
+          ) : null}
+          {allVersions && allVersions.length > 1 ? (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Upstream versions</DescriptionListTerm>
+              <DescriptionListDescription>{allVersions.join(', ')}</DescriptionListDescription>
+            </DescriptionListGroup>
+          ) : upstreamVersion ? (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Upstream version</DescriptionListTerm>
+              <DescriptionListDescription>{upstreamVersion}</DescriptionListDescription>
+            </DescriptionListGroup>
+          ) : null}
+          {projectUrl ? (
+            <DescriptionListGroup>
+              <DescriptionListTerm>Project</DescriptionListTerm>
+              <DescriptionListDescription>
+                <UrlWithExternalIcon href={projectUrl} customText='Source' />
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          ) : null}
+        </DescriptionList>
+      </CardBody>
+    </Card>
+  );
+};
 
 export default PackageSidebar;


### PR DESCRIPTION
## Summary

Uses an ExpandableSection for the package license field and truncates if it's too long (default max is 3 lines)

## Testing steps

1. Run `yarn start:stage` and go to `stage.foo.redhat.com:1337/lightwell`
2. View the json5 package details in the Python Validated repo
3. License should be truncated by default with a "show more" toggle
4. The "show more" toggle should display the rest of the contents
5. The "hide" toggle should hide them again
6. Package licenses that are less than 3 lines should not be affected