### PR TITLE
HMS-11009: set origins in ContentListTable if none specified

### DIFF
--- a/src/Pages/Repositories/ContentListTable/ContentListTable.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.test.tsx
@@ -220,6 +220,31 @@ it('disables delete kebab when Red Hat and/or EPEL tabs are active and shows rea
   ).toBeInTheDocument();
 });
 
+it('queries with ContentOrigin.ALL when no origin filter is selected', () => {
+  (useAppContext as jest.Mock).mockReturnValue({
+    features: { snapshots: { accessible: true } },
+    rbac: { repoWrite: true, repoRead: true },
+    contentOrigin: [],
+    setContentOrigin: () => {},
+  });
+  (useContentListQuery as jest.Mock).mockImplementation(() => ({
+    isLoading: false,
+    data: { data: [], meta: { count: 0, limit: 20, offset: 0 } },
+  }));
+
+  renderContentListTable();
+
+  expect(useContentListQuery).toHaveBeenCalledWith(
+    1,
+    expect.any(Number),
+    expect.any(Object),
+    expect.any(String),
+    [ContentOrigin.ALL],
+    true,
+    false,
+  );
+});
+
 it('hides bulk select when Red Hat and/or EPEL tabs are active', async () => {
   (useContentListQuery as jest.Mock).mockImplementation(() => ({
     isLoading: false,

--- a/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
@@ -207,13 +207,16 @@ const ContentListTable = () => {
     setUrlSearchParams,
   ]);
 
+  // Set content origins for the repository list query explicitly if no origin filters are selected
+  const originsForQuery = contentOrigin.length ? contentOrigin : [ContentOrigin.ALL];
+
   const {
     isLoading,
     isFetching,
     error,
     isError,
     data = { data: [], meta: { count: 0, limit: 20, offset: 0 } },
-  } = useContentListQuery(page, perPage, filters, sortString, contentOrigin, true, polling);
+  } = useContentListQuery(page, perPage, filters, sortString, originsForQuery, true, polling);
 
   useEffect(() => {
     if (isError) {


### PR DESCRIPTION
## Summary

Content origins should be set explicitly if no origin filters are selected

## Testing steps

Tests pass