### PR TITLE
feat: add Lightwell search entries to global search index

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -117,26 +117,22 @@ objects:
           href: /lightwell
           description: Remediated and validated open source libraries for Java and Python.
           alt_title:
-            - lightwell
-            - light well
-            - lightwell network
-            - lightwell clearinghouse
-            - remediated packages
-            - remediated libraries
-            - validated packages
-            - validated libraries
-            - trusted content
-            - supply chain security
-            - open source supply chain
-            - secured repositories
-            - signed libraries
-            - patched artifacts
-            - CVE remediation
-            - vulnerability remediation
             - backported patches
-            - remediated java
-            - remediated python
+            - CVE remediation
+            - light well
+            - lightwell
+            - lightwell clearinghouse
+            - lightwell network
             - lightwell repositories
+            - remediated java
+            - remediated libraries
+            - remediated packages
+            - remediated python
+            - supply chain security
+            - trusted content
+            - validated libraries
+            - validated packages
+            - vulnerability remediation
 
 parameters:
   - name: ENV_NAME

--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -112,6 +112,31 @@ objects:
             - Red Hat repositories
             - snapshot
             - insights
+        - id: lightwell
+          title: Lightwell
+          href: /lightwell
+          description: Remediated and validated open source libraries for Java and Python.
+          alt_title:
+            - lightwell
+            - light well
+            - lightwell network
+            - lightwell clearinghouse
+            - remediated packages
+            - remediated libraries
+            - validated packages
+            - validated libraries
+            - trusted content
+            - supply chain security
+            - open source supply chain
+            - secured repositories
+            - signed libraries
+            - patched artifacts
+            - CVE remediation
+            - vulnerability remediation
+            - backported patches
+            - remediated java
+            - remediated python
+            - lightwell repositories
 
 parameters:
   - name: ENV_NAME


### PR DESCRIPTION
## Summary
- Adds search entry for Lightwell to `deploy/frontend.yaml` so console users can discover the service through global search
- Includes alt_title terms covering product name variations, security terminology, and ecosystem-specific terms (remediated packages, CVE remediation, trusted content, etc.)
- Currently there is no way for a console user to find Lightwell through search

## Test plan
- [ ] Verify search entry appears in global search results when searching "lightwell"
- [ ] Verify alt_title terms surface the entry (e.g. "remediated packages", "CVE remediation")
- [ ] Verify href `/lightwell` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)