### PR TITLE
fix: update Gradle connect snippet to match official docs

### DIFF
--- a/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
+++ b/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
@@ -88,21 +88,16 @@ const getMavenSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[]
           label: 'Add to your build.gradle:',
           code: `repositories {
     maven {
-        credentials {
-            username "$mavenUser"
-            password "$mavenPassword"
-        }
+        name = "${repoId}"
         url "${distributionUrl}"
+        credentials {
+            username = "<service_account_username>"
+            password = "<service_account_token>"
+        }
     }
     mavenCentral()
 }`,
-          description: 'Place above mavenCentral() to prioritize patched versions.',
-        },
-        {
-          label: 'Add credentials to ~/.gradle/gradle.properties:',
-          code: `mavenUser=<service_account_username>
-mavenPassword=<service_account_token>`,
-          description: 'Do not commit credentials. Store in ~/.gradle/gradle.properties.',
+          description: 'Username format: XXXXXXX|service-account-name',
         },
       ],
     },


### PR DESCRIPTION
## Summary
- Updates Gradle snippet in the Lightwell connect modal to match the official docs at docs.redhat.com
- Replaces `$mavenUser`/`$mavenPassword` variable pattern with inline `<service_account_username>`/`<service_account_token>` placeholders
- Removes the separate `~/.gradle/gradle.properties` step (docs don't include it)
- Adds `name` field to the maven block

## Test plan
- [ ] Open connect modal for a Java repository
- [ ] Verify Gradle tab shows single snippet with inline credentials matching docs
- [ ] Verify Maven, Artifactory, Nexus tabs are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)