### PR TITLE
fix: show correct Artifactory URLs for Python repositories

### DIFF
--- a/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
+++ b/src/Pages/Lightwell/Repositories/components/connectSnippets.ts
@@ -140,7 +140,8 @@ mavenPassword=<service_account_token>`,
 };
 
 const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[] => {
-  const distributionUrl = formatDistributionUrl(repository.published_distribution_url || '');
+  const rawUrl = repository.published_distribution_url || '';
+  const distributionUrl = formatDistributionUrl(rawUrl);
 
   return [
     {
@@ -198,14 +199,24 @@ const getPythonSnippetTabs = (repository: RepositoryContext): ConnectSnippetTab[
       eventKey: 'artifactory',
       title: 'Artifactory',
       docsUrl:
-        'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_artifactory_to_use_rhln_repository',
+        'https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_artifactory_to_use_rhln_repository_python',
       snippets: [
         {
-          label: 'Configure as a remote PyPI repository:',
+          label: 'URL:',
+          code: rawUrl,
+          urlOnly: true,
+        },
+        {
+          label: 'Registry URL:',
           code: distributionUrl || '',
           urlOnly: true,
+        },
+        {
+          label: 'Registry Index Location URL Suffix:',
+          code: 'simple',
+          urlOnly: true,
           description:
-            'Set as the remote URL in Artifactory. Configure basic authentication with your service account credentials.',
+            'Leave at the default value. Configure basic authentication with your service account credentials.',
         },
       ],
     },


### PR DESCRIPTION
## Summary
- Python Artifactory setup requires the full `/api/pulp-content/` URL path, not the shortened `/lightwell/` path
- The connect modal now shows three fields matching the [official docs](https://docs.redhat.com/en/documentation/red_hat_lightwell_network/current/configure-configure_artifactory_to_use_rhln_repository_python): URL, Registry URL, and Registry Index Location URL Suffix
- Java Artifactory tab is unchanged (shortened URL works for Maven)
- Fixes customer-reported issue where Artifactory proxy fails with the shortened URL

## Test plan
- [ ] Open connect modal for a **Python** repository
- [ ] Verify Artifactory tab shows three fields: URL (with `/api/pulp-content/`), Registry URL (shortened), suffix (`simple`)
- [ ] Open connect modal for a **Java** repository
- [ ] Verify Java Artifactory tab is unchanged (single URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)