### PR TITLE
HMS-10918: Fix repositories columns and template details formatting

### DIFF
--- a/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
+++ b/src/Pages/Repositories/ContentListTable/ContentListTable.tsx
@@ -89,7 +89,7 @@ const ContentListTable = () => {
     { name: 'Architecture', sortAttribute: 'distribution_arch' },
     { name: 'OS', sortAttribute: 'distribution_versions' },
     { name: 'Packages', sortAttribute: 'package_count' },
-    { name: 'Last Introspection', sortAttribute: 'last_introspection_time' },
+    { name: 'Last introspection', sortAttribute: 'last_introspection_time' },
     { name: 'Status', sortAttribute: null }, // Non-sortable column
   ];
 

--- a/src/Pages/Templates/TemplateDetails/TemplateDetails.tsx
+++ b/src/Pages/Templates/TemplateDetails/TemplateDetails.tsx
@@ -134,7 +134,7 @@ export default function TemplateDetails() {
             >
               <DetailItem title='Description:' value={template?.description} />
               <DetailItem
-                title='Snapshot date'
+                title='Snapshot date:'
                 value={
                   template?.use_latest
                     ? 'Using latest content from repositories'


### PR DESCRIPTION
## Summary
- Fixes text formatting issue on template details page changing `Snapshot date` to `Snapshot date:` as consistent with other template details on that page.
- Fixes text formatting in repositories list table column headers changing `Last Introspection` column header to `Last introspection` (sentence case).

## Testing steps

For snapshot date change
1. Run `yarn start:stage`
2. Navigate to template details page for any template `/insights/content/templates/:uuid/content/packages`
3. View change in template details

For last introspection column header change
1. Run `yarn start:stage`
2. Navigate to repositories lists table `/insights/content/repositories`
3. View change in the table column header

> [!CAUTION]
> My first ever PR 😆