### PR TITLE
HMS-11001: Fix blank URL rendering for upload repos

### DIFF
--- a/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContent.test.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContent.test.tsx
@@ -101,3 +101,25 @@ it('Render delete modal where repo is included in 1 template', () => {
   expect(queryByText(defaultContentItem.url)).toBeInTheDocument();
   expect(queryByText(defaultTemplateItem.name)).toBeInTheDocument();
 });
+
+it('Render delete modal URL column with N/A when repo url is blank', () => {
+  (useContentListQuery as jest.Mock).mockImplementation(() => ({
+    data: {
+      isLoading: false,
+      data: [{ ...defaultContentItem, url: '' }],
+    },
+  }));
+  (useTemplateList as jest.Mock).mockImplementation(() => ({
+    data: {
+      isLoading: false,
+      data: [defaultTemplateItem2],
+    },
+  }));
+  const { queryByText } = render(
+    <ReactQueryTestWrapper>
+      <DeleteContentModal />
+    </ReactQueryTestWrapper>,
+  );
+  expect(queryByText(defaultContentItem.name)).toBeInTheDocument();
+  expect(queryByText('N/A')).toBeInTheDocument();
+});

--- a/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
+++ b/src/Pages/Repositories/ContentListTable/components/DeleteContentModal/DeleteContentModal.tsx
@@ -210,7 +210,7 @@ export default function DeleteContentModal() {
                 return (
                   <Tr key={repo.uuid + index}>
                     <Td>{repo.name}</Td>
-                    <Td>{repo.url}</Td>
+                    <Td>{repo.url?.trim() || 'N/A'}</Td>
                     <Td className={classes.templateColumnMinWidth}>
                       {templatesWithRepos.length > 0 ? (
                         <List isPlain>


### PR DESCRIPTION
## Summary
Upload repos don’t have a URL. Currently, in the DeleteContentModal the repo URL just renders as blank. This PR fixes the case for upload repo's URLs to render as "N/A" instead of blank to be more descriptive to the user.

## Testing steps
1. Run `yarn start:stage`
2. Navigate to the repositories list page `/insights/content/repositories`
3. Select any upload repo and click "delete" under the kebab menu to open the DeleteContentModal
4. View the blank URL rendered as "N/A"
